### PR TITLE
Implement state tracking.

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -62,7 +62,8 @@ func New(args ...interface{}) (s *Session, err error) {
 
 	// Create an empty Session interface.
 	s = &Session{
-		State: NewState(),
+		State:        NewState(),
+		StateEnabled: true,
 	}
 
 	// If no arguments are passed return the empty Session interface.

--- a/discord.go
+++ b/discord.go
@@ -61,7 +61,9 @@ type voiceUDP struct {
 func New(args ...interface{}) (s *Session, err error) {
 
 	// Create an empty Session interface.
-	s = &Session{}
+	s = &Session{
+		State: NewState(),
+	}
 
 	// If no arguments are passed return the empty Session interface.
 	// Later I will add default values, if appropriate.

--- a/state.go
+++ b/state.go
@@ -1,0 +1,195 @@
+package discordgo
+
+import "errors"
+
+// NewState creates an empty state.
+func NewState() *State {
+	return &State{
+		Ready: Ready{
+			PrivateChannels: []Channel{},
+			Guilds:          []Guild{},
+		},
+	}
+}
+
+// OnReady takes a Ready event and updates all internal state.
+func (s *State) OnReady(r *Ready) {
+	s.Ready = *r
+}
+
+// AddGuild adds a guild to the current world state, or
+// updates it if it already exists.
+func (s *State) AddGuild(guild *Guild) {
+	for _, g := range s.Guilds {
+		if g.ID == guild.ID {
+			// This could be a little faster ;)
+			for _, m := range guild.Members {
+				s.AddMember(&m)
+			}
+			for _, c := range guild.Channels {
+				s.AddChannel(&c)
+			}
+			return
+		}
+	}
+	s.Guilds = append(s.Guilds, *guild)
+}
+
+// RemoveGuild removes a guild from current world state.
+func (s *State) RemoveGuild(guild *Guild) error {
+	for i, g := range s.Guilds {
+		if g.ID == guild.ID {
+			s.Guilds = append(s.Guilds[:i], s.Guilds[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("Guild not found.")
+}
+
+// GetGuildByID gets a guild by ID.
+// Useful for querying if @me is in a guild:
+//     _, err := discordgo.Session.State.GetGuildById(guildID)
+//     isInGuild := err == nil
+func (s *State) GetGuildByID(guildID string) (*Guild, error) {
+	for _, g := range s.Guilds {
+		if g.ID == guildID {
+			return &g, nil
+		}
+	}
+	return nil, errors.New("Guild not found.")
+}
+
+// TODO: Consider moving Guild state update methods onto *Guild.
+
+// AddMember adds a member to the current world state, or
+// updates it if it already exists.
+func (s *State) AddMember(member *Member) error {
+	guild, err := s.GetGuildByID(member.GuildID)
+	if err != nil {
+		return err
+	}
+
+	for i, m := range guild.Members {
+		if m.User.ID == member.User.ID {
+			guild.Members[i] = *member
+			return nil
+		}
+	}
+
+	guild.Members = append(guild.Members, *member)
+	return nil
+}
+
+// RemoveMember removes a member from current world state.
+func (s *State) RemoveMember(member *Member) error {
+	guild, err := s.GetGuildByID(member.GuildID)
+	if err != nil {
+		return err
+	}
+
+	for i, m := range guild.Members {
+		if m.User.ID == member.User.ID {
+			guild.Members = append(guild.Members[:i], guild.Members[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("Member not found.")
+}
+
+// GetMemberByID gets a member by ID from a guild.
+func (s *State) GetMemberByID(guildID string, userID string) (*Member, error) {
+	guild, err := s.GetGuildByID(guildID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range guild.Members {
+		if m.User.ID == userID {
+			return &m, nil
+		}
+	}
+	return nil, errors.New("Member not found.")
+}
+
+// AddChannel adds a guild to the current world state, or
+// updates it if it already exists.
+// Channels may exist either as PrivateChannels or inside
+// a guild.
+func (s *State) AddChannel(channel *Channel) error {
+	if channel.IsPrivate {
+		for i, c := range s.PrivateChannels {
+			if c.ID == channel.ID {
+				s.PrivateChannels[i] = *channel
+				return nil
+			}
+		}
+
+		s.PrivateChannels = append(s.PrivateChannels, *channel)
+	} else {
+		guild, err := s.GetGuildByID(channel.GuildID)
+		if err != nil {
+			return err
+		}
+
+		for i, c := range guild.Channels {
+			if c.ID == channel.ID {
+				guild.Channels[i] = *channel
+				return nil
+			}
+		}
+
+		guild.Channels = append(guild.Channels, *channel)
+	}
+	return nil
+}
+
+// RemoveChannel removes a channel from current world state.
+func (s *State) RemoveChannel(channel *Channel) error {
+	if channel.IsPrivate {
+		for i, c := range s.PrivateChannels {
+			if c.ID == channel.ID {
+				s.PrivateChannels = append(s.PrivateChannels[:i], s.PrivateChannels[i+1:]...)
+				return nil
+			}
+		}
+	} else {
+		guild, err := s.GetGuildByID(channel.GuildID)
+		if err != nil {
+			return err
+		}
+
+		for i, c := range guild.Channels {
+			if c.ID == channel.ID {
+				guild.Channels = append(guild.Channels[:i], guild.Channels[i+1:]...)
+				return nil
+			}
+		}
+	}
+
+	return errors.New("Channel not found.")
+}
+
+// GetGuildChannelById gets a channel by ID from a guild.
+func (s *State) GetGuildChannelByID(guildID string, channelID string) (*Channel, error) {
+	guild, err := s.GetGuildByID(guildID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range guild.Channels {
+		if c.ID == channelID {
+			return &c, nil
+		}
+	}
+	return nil, errors.New("Channel not found.")
+}
+
+// GetPrivateChannelByID gets a private channel by ID.
+func (s *State) GetPrivateChannelByID(channelID string) (*Channel, error) {
+	for _, c := range s.PrivateChannels {
+		if c.ID == channelID {
+			return &c, nil
+		}
+	}
+	return nil, errors.New("Channel not found.")
+}

--- a/state.go
+++ b/state.go
@@ -245,3 +245,24 @@ func (s *State) PrivateChannel(channelID string) (*Channel, error) {
 
 	return nil, errors.New("Channel not found.")
 }
+
+// Channel gets a channel by ID, it will look in all guilds an private channels.
+func (s *State) Channel(channelID string) (*Channel, error) {
+	if s == nil {
+		return nil, nilError
+	}
+
+	c, err := s.PrivateChannel(channelID)
+	if err == nil {
+		return c, nil
+	}
+
+	for _, g := range s.Guilds {
+		c, err := s.GuildChannel(g.ID, channelID)
+		if err == nil {
+			return c, nil
+		}
+	}
+
+	return nil, errors.New("Channel not found.")
+}

--- a/state.go
+++ b/state.go
@@ -24,9 +24,9 @@ func (s *State) OnReady(r *Ready) error {
 	return nil
 }
 
-// AddGuild adds a guild to the current world state, or
+// GuildAdd adds a guild to the current world state, or
 // updates it if it already exists.
-func (s *State) AddGuild(guild *Guild) error {
+func (s *State) GuildAdd(guild *Guild) error {
 	if s == nil {
 		return nilError
 	}
@@ -35,10 +35,10 @@ func (s *State) AddGuild(guild *Guild) error {
 		if g.ID == guild.ID {
 			// This could be a little faster ;)
 			for _, m := range guild.Members {
-				s.AddMember(&m)
+				s.MemberAdd(&m)
 			}
 			for _, c := range guild.Channels {
-				s.AddChannel(&c)
+				s.ChannelAdd(&c)
 			}
 			return nil
 		}
@@ -47,8 +47,8 @@ func (s *State) AddGuild(guild *Guild) error {
 	return nil
 }
 
-// RemoveGuild removes a guild from current world state.
-func (s *State) RemoveGuild(guild *Guild) error {
+// GuildRemove removes a guild from current world state.
+func (s *State) GuildRemove(guild *Guild) error {
 	if s == nil {
 		return nilError
 	}
@@ -81,9 +81,9 @@ func (s *State) Guild(guildID string) (*Guild, error) {
 
 // TODO: Consider moving Guild state update methods onto *Guild.
 
-// AddMember adds a member to the current world state, or
+// MemberAdd adds a member to the current world state, or
 // updates it if it already exists.
-func (s *State) AddMember(member *Member) error {
+func (s *State) MemberAdd(member *Member) error {
 	if s == nil {
 		return nilError
 	}
@@ -104,8 +104,8 @@ func (s *State) AddMember(member *Member) error {
 	return nil
 }
 
-// RemoveMember removes a member from current world state.
-func (s *State) RemoveMember(member *Member) error {
+// MemberRemove removes a member from current world state.
+func (s *State) MemberRemove(member *Member) error {
 	if s == nil {
 		return nilError
 	}
@@ -145,11 +145,11 @@ func (s *State) Member(guildID string, userID string) (*Member, error) {
 	return nil, errors.New("Member not found.")
 }
 
-// AddChannel adds a guild to the current world state, or
+// ChannelAdd adds a guild to the current world state, or
 // updates it if it already exists.
 // Channels may exist either as PrivateChannels or inside
 // a guild.
-func (s *State) AddChannel(channel *Channel) error {
+func (s *State) ChannelAdd(channel *Channel) error {
 	if s == nil {
 		return nilError
 	}
@@ -181,8 +181,8 @@ func (s *State) AddChannel(channel *Channel) error {
 	return nil
 }
 
-// RemoveChannel removes a channel from current world state.
-func (s *State) RemoveChannel(channel *Channel) error {
+// ChannelRemove removes a channel from current world state.
+func (s *State) ChannelRemove(channel *Channel) error {
 	if s == nil {
 		return nilError
 	}

--- a/structs.go
+++ b/structs.go
@@ -84,6 +84,9 @@ type Session struct {
 	VChannelID string
 	Vop2       VoiceOP2
 	UDPConn    *net.UDPConn
+
+	// Managed state object, updated with events.
+	State *State
 }
 
 // A Message stores all data related to a specific Discord message.
@@ -262,14 +265,6 @@ type User struct {
 // it just doesn't seem able to handle this one
 // field correctly.  Need to research this more.
 
-// A PrivateChannel stores all data for a specific user private channel.
-type PrivateChannel struct {
-	ID            string `json:"id"`
-	IsPrivate     bool   `json:"is_private"`
-	LastMessageID string `json:"last_message_id"`
-	Recipient     User   `json:"recipient"`
-} // merge with channel?
-
 // A Settings stores data for a specific users Discord client settings.
 type Settings struct {
 	RenderEmbeds          bool     `json:"render_embeds"`
@@ -298,8 +293,8 @@ type Ready struct {
 	HeartbeatInterval time.Duration `json:"heartbeat_interval"`
 	User              User          `json:"user"`
 	ReadState         []ReadState
-	PrivateChannels   []PrivateChannel
-	Guilds            []Guild
+	PrivateChannels   []Channel `json:"private_channels"`
+	Guilds            []Guild   `json:"guilds"`
 }
 
 // A ReadState stores data on the read state of channels.
@@ -359,4 +354,11 @@ type GuildRoleDelete struct {
 type GuildBan struct {
 	User    User   `json:"user"`
 	GuildID string `json:"guild_id"`
+}
+
+// A State contains the current known state, as discord sends this in a
+// READY blob, it seems reasonable to simply use that message type as the
+// data store.
+type State struct {
+	Ready
 }

--- a/structs.go
+++ b/structs.go
@@ -356,9 +356,9 @@ type GuildBan struct {
 	GuildID string `json:"guild_id"`
 }
 
-// A State contains the current known state, as discord sends this in a
-// READY blob, it seems reasonable to simply use that message type as the
-// data store.
+// A State contains the current known state.
+// As discord sends this in a READY blob, it seems reasonable to simply
+// use that struct as the data store.
 type State struct {
 	Ready
 }

--- a/structs.go
+++ b/structs.go
@@ -86,7 +86,8 @@ type Session struct {
 	UDPConn    *net.UDPConn
 
 	// Managed state object, updated with events.
-	State *State
+	State        *State
+	StateEnabled bool
 }
 
 // A Message stores all data related to a specific Discord message.

--- a/wsapi.go
+++ b/wsapi.go
@@ -153,7 +153,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "READY":
 		var st Ready
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.OnReady(&st)
+			if s.StateEnabled {
+				s.State.OnReady(&st)
+			}
 			if s.OnReady != nil {
 				s.OnReady(s, st)
 			}
@@ -238,7 +240,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "CHANNEL_CREATE":
 		var st Channel
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.AddChannel(&st)
+			if s.StateEnabled {
+				s.State.AddChannel(&st)
+			}
 			if s.OnChannelCreate != nil {
 				s.OnChannelCreate(s, st)
 			}
@@ -247,7 +251,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "CHANNEL_UPDATE":
 		var st Channel
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.AddChannel(&st)
+			if s.StateEnabled {
+				s.State.AddChannel(&st)
+			}
 			if s.OnChannelUpdate != nil {
 				s.OnChannelUpdate(s, st)
 			}
@@ -256,7 +262,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "CHANNEL_DELETE":
 		var st Channel
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.RemoveChannel(&st)
+			if s.StateEnabled {
+				s.State.RemoveChannel(&st)
+			}
 			if s.OnChannelDelete != nil {
 				s.OnChannelDelete(s, st)
 			}
@@ -265,7 +273,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "GUILD_CREATE":
 		var st Guild
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.AddGuild(&st)
+			if s.StateEnabled {
+				s.State.AddGuild(&st)
+			}
 			if s.OnGuildCreate != nil {
 				s.OnGuildCreate(s, st)
 			}
@@ -274,7 +284,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "GUILD_UPDATE":
 		var st Guild
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.AddGuild(&st)
+			if s.StateEnabled {
+				s.State.AddGuild(&st)
+			}
 			if s.OnGuildCreate != nil {
 				s.OnGuildUpdate(s, st)
 			}
@@ -283,7 +295,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "GUILD_DELETE":
 		var st Guild
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.RemoveGuild(&st)
+			if s.StateEnabled {
+				s.State.RemoveGuild(&st)
+			}
 			if s.OnGuildDelete != nil {
 				s.OnGuildDelete(s, st)
 			}
@@ -292,7 +306,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "GUILD_MEMBER_ADD":
 		var st Member
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.AddMember(&st)
+			if s.StateEnabled {
+				s.State.AddMember(&st)
+			}
 			if s.OnGuildMemberAdd != nil {
 				s.OnGuildMemberAdd(s, st)
 			}
@@ -301,7 +317,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "GUILD_MEMBER_REMOVE":
 		var st Member
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.RemoveMember(&st)
+			if s.StateEnabled {
+				s.State.RemoveMember(&st)
+			}
 			if s.OnGuildMemberRemove != nil {
 				s.OnGuildMemberRemove(s, st)
 			}
@@ -310,7 +328,9 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "GUILD_MEMBER_UPDATE":
 		var st Member
 		if err = unmarshalEvent(e, &st); err == nil {
-			s.State.AddMember(&st)
+			if s.StateEnabled {
+				s.State.AddMember(&st)
+			}
 			if s.OnGuildMemberUpdate != nil {
 				s.OnGuildMemberUpdate(s, st)
 			}

--- a/wsapi.go
+++ b/wsapi.go
@@ -238,7 +238,6 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "CHANNEL_CREATE":
 		var st Channel
 		if err = unmarshalEvent(e, &st); err == nil {
-			fmt.Println("channel create", st)
 			s.State.AddChannel(&st)
 			if s.OnChannelCreate != nil {
 				s.OnChannelCreate(s, st)

--- a/wsapi.go
+++ b/wsapi.go
@@ -153,6 +153,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 	case "READY":
 		var st Ready
 		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.OnReady(&st)
 			if s.OnReady != nil {
 				s.OnReady(s, st)
 			}
@@ -235,77 +236,87 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 			return
 		}
 	case "CHANNEL_CREATE":
-		if s.OnChannelCreate != nil {
-			var st Channel
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Channel
+		if err = unmarshalEvent(e, &st); err == nil {
+			fmt.Println("channel create", st)
+			s.State.AddChannel(&st)
+			if s.OnChannelCreate != nil {
 				s.OnChannelCreate(s, st)
 			}
-			return
 		}
+		return
 	case "CHANNEL_UPDATE":
-		if s.OnChannelUpdate != nil {
-			var st Channel
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Channel
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.AddChannel(&st)
+			if s.OnChannelUpdate != nil {
 				s.OnChannelUpdate(s, st)
 			}
-			return
 		}
+		return
 	case "CHANNEL_DELETE":
-		if s.OnChannelDelete != nil {
-			var st Channel
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Channel
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.RemoveChannel(&st)
+			if s.OnChannelDelete != nil {
 				s.OnChannelDelete(s, st)
 			}
-			return
 		}
+		return
 	case "GUILD_CREATE":
-		if s.OnGuildCreate != nil {
-			var st Guild
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Guild
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.AddGuild(&st)
+			if s.OnGuildCreate != nil {
 				s.OnGuildCreate(s, st)
 			}
-			return
 		}
+		return
 	case "GUILD_UPDATE":
-		if s.OnGuildCreate != nil {
-			var st Guild
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Guild
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.AddGuild(&st)
+			if s.OnGuildCreate != nil {
 				s.OnGuildUpdate(s, st)
 			}
-			return
 		}
+		return
 	case "GUILD_DELETE":
-		if s.OnGuildDelete != nil {
-			var st Guild
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Guild
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.RemoveGuild(&st)
+			if s.OnGuildDelete != nil {
 				s.OnGuildDelete(s, st)
 			}
-			return
 		}
+		return
 	case "GUILD_MEMBER_ADD":
-		if s.OnGuildMemberAdd != nil {
-			var st Member
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Member
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.AddMember(&st)
+			if s.OnGuildMemberAdd != nil {
 				s.OnGuildMemberAdd(s, st)
 			}
-			return
 		}
+		return
 	case "GUILD_MEMBER_REMOVE":
-		if s.OnGuildMemberRemove != nil {
-			var st Member
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Member
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.RemoveMember(&st)
+			if s.OnGuildMemberRemove != nil {
 				s.OnGuildMemberRemove(s, st)
 			}
-			return
 		}
+		return
 	case "GUILD_MEMBER_UPDATE":
-		if s.OnGuildMemberUpdate != nil {
-			var st Member
-			if err = unmarshalEvent(e, &st); err == nil {
+		var st Member
+		if err = unmarshalEvent(e, &st); err == nil {
+			s.State.AddMember(&st)
+			if s.OnGuildMemberUpdate != nil {
 				s.OnGuildMemberUpdate(s, st)
 			}
-			return
 		}
+		return
 	case "GUILD_ROLE_CREATE":
 		if s.OnGuildRoleCreate != nil {
 			var st GuildRole

--- a/wsapi.go
+++ b/wsapi.go
@@ -241,7 +241,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Channel
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.AddChannel(&st)
+				s.State.ChannelAdd(&st)
 			}
 			if s.OnChannelCreate != nil {
 				s.OnChannelCreate(s, st)
@@ -252,7 +252,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Channel
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.AddChannel(&st)
+				s.State.ChannelAdd(&st)
 			}
 			if s.OnChannelUpdate != nil {
 				s.OnChannelUpdate(s, st)
@@ -263,7 +263,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Channel
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.RemoveChannel(&st)
+				s.State.ChannelRemove(&st)
 			}
 			if s.OnChannelDelete != nil {
 				s.OnChannelDelete(s, st)
@@ -274,7 +274,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Guild
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.AddGuild(&st)
+				s.State.GuildAdd(&st)
 			}
 			if s.OnGuildCreate != nil {
 				s.OnGuildCreate(s, st)
@@ -285,7 +285,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Guild
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.AddGuild(&st)
+				s.State.GuildAdd(&st)
 			}
 			if s.OnGuildCreate != nil {
 				s.OnGuildUpdate(s, st)
@@ -296,7 +296,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Guild
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.RemoveGuild(&st)
+				s.State.GuildRemove(&st)
 			}
 			if s.OnGuildDelete != nil {
 				s.OnGuildDelete(s, st)
@@ -307,7 +307,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Member
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.AddMember(&st)
+				s.State.MemberAdd(&st)
 			}
 			if s.OnGuildMemberAdd != nil {
 				s.OnGuildMemberAdd(s, st)
@@ -318,7 +318,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Member
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.RemoveMember(&st)
+				s.State.MemberRemove(&st)
 			}
 			if s.OnGuildMemberRemove != nil {
 				s.OnGuildMemberRemove(s, st)
@@ -329,7 +329,7 @@ func (s *Session) event(messageType int, message []byte) (err error) {
 		var st Member
 		if err = unmarshalEvent(e, &st); err == nil {
 			if s.StateEnabled {
-				s.State.AddMember(&st)
+				s.State.MemberAdd(&st)
 			}
 			if s.OnGuildMemberUpdate != nil {
 				s.OnGuildMemberUpdate(s, st)


### PR DESCRIPTION
Currently maintains a list of Guilds (Members/Channels) and PrivateChannels.

This allows a lot of nice things like a really easy 'is a message private' check:
```
func (s *Session) IsMessagePrivate(m *Message) bool {
	_, err := s.State.GetPrivateChannelByID(m.ID)
	return err == nil
}
```

Or a nice check where we grab an invite, and only accept it if we need to.
```
int := "discord.gg/blah"
i, _ := d.Session.Invite(inv)
if _, err := d.Session.State.GetGuildByID(i.Guild.ID); err == nil {
    // There was no error, we are already in the guild.
    fmt.Println("I have already joined that server.")
    return
}
d.Session.InviteAccept(inv)
fmt.Println("I have joined the server.")
```
