### PR TITLE
Prevent login crash by assuming a json.Unmarshal "just works"

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -111,6 +111,10 @@ func (s *Session) Login(email string, password string) (token string, err error)
 
 	var temp map[string]interface{}
 	err = json.Unmarshal(response, &temp)
+	// prevent crashing by manipulating a map that has no data
+	if err != nil {
+		return
+	}
 	token = temp["token"].(string)
 	return
 }


### PR DESCRIPTION
Tested (with $ iptables -A INPUT -s 104.16.59.5 -j DROP )
It works.
Fixes #46 