### PR TITLE
Register & Verify

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -242,21 +242,6 @@ func (s *Session) UserGuilds(userID string) (st []Guild, err error) {
 	return
 }
 
-// UserVerify updates account information to make vertification possible.
-// Account still needs to be activated using the send email
-func (s *Session) UserVerify(username, email, password string) (st User, err error) {
-
-	data := struct {
-		Username string `json:"username"`
-		Email    string `json:"email"`
-		Password string `json:"password"`
-	}{username, email, password}
-
-	body, err := s.Request("PATCH", USER("@me"), data)
-	err = json.Unmarshal(body, &st)
-	return
-}
-
 // ------------------------------------------------------------------------------------------------
 // Functions specific to Discord Guilds
 // ------------------------------------------------------------------------------------------------

--- a/restapi.go
+++ b/restapi.go
@@ -119,6 +119,27 @@ func (s *Session) Login(email string, password string) (token string, err error)
 	return
 }
 
+// Register sends a Register request to Discord, and returns the authentication token
+// Note that this account is temporary and should be verified for future use.
+// Another option is to save the authentication token external, but this isn't recommended.
+func (s *Session) Register(username string) (token string, err error) {
+
+	data := struct {
+		Username string `json:"username"`
+	}{username}
+
+	response, err := s.Request("POST", REGISTER, data)
+
+	var temp map[string]interface{}
+	err = json.Unmarshal(response, &temp)
+	if err != nil {
+		return
+	}
+
+	token = temp["token"].(string)
+	return
+}
+
 // Logout sends a logout request to Discord.
 // This does not seem to actually invalidate the token.  So you can still
 // make API calls even after a Logout.  So, it seems almost pointless to

--- a/restapi.go
+++ b/restapi.go
@@ -242,6 +242,21 @@ func (s *Session) UserGuilds(userID string) (st []Guild, err error) {
 	return
 }
 
+// UserVerify updates account information to make vertification possible.
+// Account still needs to be activated using the send email
+func (s *Session) UserVerify(username, email, password string) (st User, err error) {
+
+	data := struct {
+		Username string `json:"username"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}{username, email, password}
+
+	body, err := s.Request("PATCH", USER("@me"), data)
+	err = json.Unmarshal(body, &st)
+	return
+}
+
 // ------------------------------------------------------------------------------------------------
 // Functions specific to Discord Guilds
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This would fix: https://github.com/bwmarrin/discordgo/issues/49

A first handshake with the Discord API, without having any authentication details would be:
```go
	// Register to the Discord server and store the authentication token
	dg.Token, err = dg.Register("Username")
	if err != nil {
		fmt.Println(err)
		return
	}

	// Add authentication information to User
	_, err = dg.UserVerify("Username", "myemail@address.com", "Password")
	if err != nil {
		fmt.Println(err)
		return
	}

	// Login to the Discord Server and store the new authentication token
	dg.Token, err = dg.Login("myemail@address.com", "Password")
	if err != nil {
		fmt.Println(err)
		return
	}
```
Afterwards it is just like in the api_basic example:

```go
	// Login to the Discord Server and store the new authentication token
	dg.Token, err = dg.Login("myemail@address.com", "Password")
	if err != nil {
		fmt.Println(err)
		return
	}
```
Note that actually verifying the account by using the link in the email is necessary, but I could still login using the details without having to actually verify it.

This is all using the api_basic example, it doesn't integrate at the moment with the New() function. I'll have to look into that since I'm still using the old way in my bot. 

