### PR TITLE
Add a new optional token to New, which is a cheaper way to login. Closes #89.

### DIFF
--- a/examples/api_basic/api_basic.go
+++ b/examples/api_basic/api_basic.go
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	// Login to the Discord server and store the authentication token
-	dg.Token, err = dg.Login(os.Args[1], os.Args[2])
+	err = dg.Login(os.Args[1], os.Args[2])
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/restapi.go
+++ b/restapi.go
@@ -128,8 +128,8 @@ func unmarshal(data []byte, v interface{}) error {
 // Functions specific to Discord Sessions
 // ------------------------------------------------------------------------------------------------
 
-// Login asks the Discord server for an authentication token
-func (s *Session) Login(email string, password string) (token string, err error) {
+// Login asks the Discord server for an authentication token.
+func (s *Session) Login(email, password string) (token string, err error) {
 
 	data := struct {
 		Email    string `json:"email"`
@@ -151,6 +151,18 @@ func (s *Session) Login(email string, password string) (token string, err error)
 	}
 
 	token = temp.Token
+	return
+}
+
+// LoginWithToken will verify a login token, or return a new one if it is invalid.
+// This is the preferred way to login, as it uses less rate limiting quota.
+func (s *Session) LoginWithToken(email, password, token string) (token string, err error) {
+
+	old := s.Token
+	s.Token = token
+	token, err = s.Login(email, password)
+	s.Token = old
+
 	return
 }
 

--- a/restapi.go
+++ b/restapi.go
@@ -156,11 +156,11 @@ func (s *Session) Login(email, password string) (token string, err error) {
 
 // LoginWithToken will verify a login token, or return a new one if it is invalid.
 // This is the preferred way to login, as it uses less rate limiting quota.
-func (s *Session) LoginWithToken(email, password, token string) (token string, err error) {
+func (s *Session) LoginWithToken(email, password, token string) (newToken string, err error) {
 
 	old := s.Token
 	s.Token = token
-	token, err = s.Login(email, password)
+	newToken, err = s.Login(email, password)
 	s.Token = old
 
 	return

--- a/restapi.go
+++ b/restapi.go
@@ -129,7 +129,7 @@ func unmarshal(data []byte, v interface{}) error {
 // ------------------------------------------------------------------------------------------------
 
 // Login asks the Discord server for an authentication token.
-func (s *Session) Login(email, password string) (token string, err error) {
+func (s *Session) Login(email, password string) (err error) {
 
 	data := struct {
 		Email    string `json:"email"`
@@ -150,19 +150,7 @@ func (s *Session) Login(email, password string) (token string, err error) {
 		return
 	}
 
-	token = temp.Token
-	return
-}
-
-// LoginWithToken will verify a login token, or return a new one if it is invalid.
-// This is the preferred way to login, as it uses less rate limiting quota.
-func (s *Session) LoginWithToken(email, password, token string) (newToken string, err error) {
-
-	old := s.Token
-	s.Token = token
-	newToken, err = s.Login(email, password)
-	s.Token = old
-
+	s.Token = temp.Token
 	return
 }
 


### PR DESCRIPTION
Eventually we should consider allowing Login/LoginWithToken to mutate
s.Token, it would probably simplify the API a bit.