### PR TITLE
Mapped Event Handlers

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -136,7 +136,7 @@ func (s *Session) AddHandler(handler interface{}) {
 		panic("Unable to add event handler, first argument must be of type *discordgo.Session.")
 	}
 
-	if s.Handlers == nil {
+	if s.handlers == nil {
 		s.Unlock()
 		s.initialize()
 		s.Lock()
@@ -149,13 +149,13 @@ func (s *Session) AddHandler(handler interface{}) {
 		eventType = nil
 	}
 
-	handlers := s.Handlers[eventType]
+	handlers := s.handlers[eventType]
 	if handlers == nil {
 		handlers = []reflect.Value{}
 	}
 
 	handlers = append(handlers, reflect.ValueOf(handler))
-	s.Handlers[eventType] = handlers
+	s.handlers[eventType] = handlers
 }
 
 func (s *Session) handle(event interface{}) {
@@ -164,13 +164,13 @@ func (s *Session) handle(event interface{}) {
 
 	handlerParameters := []reflect.Value{reflect.ValueOf(s), reflect.ValueOf(event)}
 
-	if handlers, ok := s.Handlers[reflect.TypeOf(event)]; ok {
+	if handlers, ok := s.handlers[reflect.TypeOf(event)]; ok {
 		for _, handler := range handlers {
 			handler.Call(handlerParameters)
 		}
 	}
 
-	if handlers, ok := s.Handlers[nil]; ok {
+	if handlers, ok := s.handlers[nil]; ok {
 		for _, handler := range handlers {
 			handler.Call(handlerParameters)
 		}
@@ -180,7 +180,7 @@ func (s *Session) handle(event interface{}) {
 // initialize adds all internal handlers and state tracking handlers.
 func (s *Session) initialize() {
 	s.Lock()
-	s.Handlers = map[interface{}][]reflect.Value{}
+	s.handlers = map[interface{}][]reflect.Value{}
 	s.Unlock()
 
 	s.AddHandler(s.onEvent)

--- a/discord_test.go
+++ b/discord_test.go
@@ -224,3 +224,39 @@ func TestOpenClose(t *testing.T) {
 		t.Fatalf("TestClose, d.Close failed: %+v", err)
 	}
 }
+
+func TestHandlers(t *testing.T) {
+	testHandlerCalled := false
+	testHandler := func(s *Session, t *testing.T) {
+		testHandlerCalled = true
+	}
+
+	interfaceHandlerCalled := false
+	interfaceHandler := func(s *Session, i interface{}) {
+		interfaceHandlerCalled = true
+	}
+
+	bogusHandlerCalled := false
+	bogusHandler := func(s *Session, se *Session) {
+		bogusHandlerCalled = true
+	}
+
+	d := Session{}
+	d.AddHandler(testHandler)
+	d.AddHandler(interfaceHandler)
+	d.AddHandler(bogusHandler)
+
+	d.handle(t)
+
+	if !testHandlerCalled {
+		t.Fatalf("testHandler was not called.")
+	}
+
+	if !interfaceHandlerCalled {
+		t.Fatalf("interfaceHandler was not called.")
+	}
+
+	if bogusHandlerCalled {
+		t.Fatalf("bogusHandler was called.")
+	}
+}

--- a/events.go
+++ b/events.go
@@ -1,0 +1,100 @@
+package discordgo
+
+// Connect is an empty struct for an event.
+type Connect struct{}
+
+// Disconnect is an empty struct for an event.
+type Disconnect struct{}
+
+// MessageCreate is a wrapper struct for an event.
+type MessageCreate struct {
+	*Message
+}
+
+// MessageUpdate is a wrapper struct for an event.
+type MessageUpdate struct {
+	*Message
+}
+
+// MessageDelete is a wrapper struct for an event.
+type MessageDelete struct {
+	*Message
+}
+
+// ChannelCreate is a wrapper struct for an event.
+type ChannelCreate struct {
+	*Channel
+}
+
+// ChannelUpdate is a wrapper struct for an event.
+type ChannelUpdate struct {
+	*Channel
+}
+
+// ChannelDelete is a wrapper struct for an event.
+type ChannelDelete struct {
+	*Channel
+}
+
+// GuildCreate is a wrapper struct for an event.
+type GuildCreate struct {
+	*Guild
+}
+
+// GuildUpdate is a wrapper struct for an event.
+type GuildUpdate struct {
+	*Guild
+}
+
+// GuildDelete is a wrapper struct for an event.
+type GuildDelete struct {
+	*Guild
+}
+
+// GuildBanAdd is a wrapper struct for an event.
+type GuildBanAdd struct {
+	*GuildBan
+}
+
+// GuildBanRemove is a wrapper struct for an event.
+type GuildBanRemove struct {
+	*GuildBan
+}
+
+// GuildMemberAdd is a wrapper struct for an event.
+type GuildMemberAdd struct {
+	*Member
+}
+
+// GuildMemberUpdate is a wrapper struct for an event.
+type GuildMemberUpdate struct {
+	*Member
+}
+
+// GuildMemberRemove is a wrapper struct for an event.
+type GuildMemberRemove struct {
+	*Member
+}
+
+// GuildRoleCreate is a wrapper struct for an event.
+type GuildRoleCreate struct {
+	*GuildRole
+}
+
+// GuildRoleUpdate is a wrapper struct for an event.
+type GuildRoleUpdate struct {
+	*GuildRole
+}
+
+// VoiceStateUpdate is a wrapper struct for an event.
+type VoiceStateUpdate struct {
+	*VoiceState
+}
+
+// UserUpdate is a wrapper struct for an event.
+type UserUpdate struct {
+	*UserUpdate
+}
+
+// UserSettingsUpdate is a map for an event.
+type UserSettingsUpdate map[string]interface{}

--- a/examples/api_basic/api_basic.go
+++ b/examples/api_basic/api_basic.go
@@ -23,9 +23,10 @@ func main() {
 
 	// Create a new Discord Session interface and set a handler for the
 	// OnMessageCreate event that happens for every new message on any channel
-	dg := discordgo.Session{
-		OnMessageCreate: messageCreate,
-	}
+	dg := discordgo.Session{}
+
+	// Register messageCreate as a callback for the messageCreate events.
+	dg.AddHandler(messageCreate)
 
 	// Login to the Discord server and store the authentication token
 	err = dg.Login(os.Args[1], os.Args[2])
@@ -46,9 +47,9 @@ func main() {
 	return
 }
 
-// This function will be called (due to above assignment) every time a new
+// This function will be called (due to AddHandler above) every time a new
 // message is created on any channel that the autenticated user has access to.
-func messageCreate(s *discordgo.Session, m *discordgo.Message) {
+func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// Print message to stdout.
 	fmt.Printf("%20s %20s %20s > %s\n", m.ChannelID, time.Now().Format(time.Stamp), m.Author.Username, m.Content)

--- a/examples/new_basic/new_basic.go
+++ b/examples/new_basic/new_basic.go
@@ -28,8 +28,8 @@ func main() {
 		return
 	}
 
-	// Register messageCreate as a callback for the OnMessageCreate event.
-	dg.OnMessageCreate = messageCreate
+	// Register messageCreate as a callback for the messageCreate events.
+	dg.AddHandler(messageCreate)
 
 	// Open the websocket and begin listening.
 	dg.Open()
@@ -40,9 +40,9 @@ func main() {
 	return
 }
 
-// This function will be called (due to above assignment) every time a new
+// This function will be called (due to AddHandler above) every time a new
 // message is created on any channel that the autenticated user has access to.
-func messageCreate(s *discordgo.Session, m *discordgo.Message) {
+func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// Print message to stdout.
 	fmt.Printf("%20s %20s %20s > %s\n", m.ChannelID, time.Now().Format(time.Stamp), m.Author.Username, m.Content)

--- a/state.go
+++ b/state.go
@@ -469,30 +469,30 @@ func (s *State) Message(channelID, messageID string) (*Message, error) {
 	return nil, errors.New("Message not found.")
 }
 
-// ready is an event handler.
-func (s *State) ready(se *Session, r *Ready) {
+// onReady handles the ready event.
+func (s *State) onReady(se *Session, r *Ready) {
 	if se.StateEnabled {
 		s.OnReady(r)
 	}
 }
 
-// messageCreate is an event handler.
-func (s *State) messageCreate(se *Session, m *MessageCreate) {
+// onMessageCreate handles the messageCreate event.
+func (s *State) onMessageCreate(se *Session, m *MessageCreate) {
 	if se.StateEnabled {
-		s.MessageAdd(&m.Message)
+		s.MessageAdd(m.Message)
 	}
 }
 
-// messageUpdate is an event handler.
-func (s *State) messageUpdate(se *Session, m *MessageUpdate) {
+// onMessageUpdate handles the messageUpdate event.
+func (s *State) onMessageUpdate(se *Session, m *MessageUpdate) {
 	if se.StateEnabled {
-		s.MessageAdd(&m.Message)
+		s.MessageAdd(m.Message)
 	}
 }
 
-// messageDelete is an event handler.
-func (s *State) messageDelete(se *Session, m *MessageDelete) {
+// onMessageDelete handles the messageDelete event.
+func (s *State) onMessageDelete(se *Session, m *MessageDelete) {
 	if se.StateEnabled {
-		s.MessageRemove(&m.Message)
+		s.MessageRemove(m.Message)
 	}
 }

--- a/state.go
+++ b/state.go
@@ -468,3 +468,31 @@ func (s *State) Message(channelID, messageID string) (*Message, error) {
 
 	return nil, errors.New("Message not found.")
 }
+
+// ready is an event handler.
+func (s *State) ready(se *Session, r *Ready) {
+	if se.StateEnabled {
+		s.OnReady(r)
+	}
+}
+
+// messageCreate is an event handler.
+func (s *State) messageCreate(se *Session, m *MessageCreate) {
+	if se.StateEnabled {
+		s.MessageAdd(&m.Message)
+	}
+}
+
+// messageUpdate is an event handler.
+func (s *State) messageUpdate(se *Session, m *MessageUpdate) {
+	if se.StateEnabled {
+		s.MessageAdd(&m.Message)
+	}
+}
+
+// messageDelete is an event handler.
+func (s *State) messageDelete(se *Session, m *MessageDelete) {
+	if se.StateEnabled {
+		s.MessageRemove(&m.Message)
+	}
+}

--- a/state.go
+++ b/state.go
@@ -35,6 +35,7 @@ func (s *State) OnReady(r *Ready) error {
 	if s == nil {
 		return ErrNilState
 	}
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -48,6 +49,7 @@ func (s *State) GuildAdd(guild *Guild) error {
 	if s == nil {
 		return ErrNilState
 	}
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -73,6 +75,7 @@ func (s *State) GuildRemove(guild *Guild) error {
 	if s == nil {
 		return ErrNilState
 	}
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -94,6 +97,7 @@ func (s *State) Guild(guildID string) (*Guild, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
+
 	s.RLock()
 	defer s.RUnlock()
 
@@ -294,6 +298,7 @@ func (s *State) PrivateChannel(channelID string) (*Channel, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
+
 	s.RLock()
 	defer s.RUnlock()
 
@@ -429,6 +434,7 @@ func (s *State) MessageRemove(message *Message) error {
 	if s == nil {
 		return ErrNilState
 	}
+
 	c, err := s.Channel(message.ChannelID)
 	if err != nil {
 		return err
@@ -452,6 +458,7 @@ func (s *State) Message(channelID, messageID string) (*Message, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
+
 	c, err := s.Channel(channelID)
 	if err != nil {
 		return nil, err
@@ -469,30 +476,40 @@ func (s *State) Message(channelID, messageID string) (*Message, error) {
 	return nil, errors.New("Message not found.")
 }
 
-// onReady handles the ready event.
-func (s *State) onReady(se *Session, r *Ready) {
-	if se.StateEnabled {
-		s.OnReady(r)
+// onInterface handles all events related to states.
+func (s *State) onInterface(se *Session, i interface{}) {
+	if s == nil || !se.StateEnabled {
+		return
 	}
-}
 
-// onMessageCreate handles the messageCreate event.
-func (s *State) onMessageCreate(se *Session, m *MessageCreate) {
-	if se.StateEnabled {
-		s.MessageAdd(m.Message)
-	}
-}
-
-// onMessageUpdate handles the messageUpdate event.
-func (s *State) onMessageUpdate(se *Session, m *MessageUpdate) {
-	if se.StateEnabled {
-		s.MessageAdd(m.Message)
-	}
-}
-
-// onMessageDelete handles the messageDelete event.
-func (s *State) onMessageDelete(se *Session, m *MessageDelete) {
-	if se.StateEnabled {
-		s.MessageRemove(m.Message)
+	switch t := i.(type) {
+	case *Ready:
+		s.OnReady(t)
+	case *GuildCreate:
+		s.GuildAdd(t.Guild)
+	case *GuildUpdate:
+		s.GuildAdd(t.Guild)
+	case *GuildDelete:
+		s.GuildRemove(t.Guild)
+	case *GuildMemberAdd:
+		s.MemberAdd(t.Member)
+	case *GuildMemberUpdate:
+		s.MemberAdd(t.Member)
+	case *GuildMemberRemove:
+		s.MemberRemove(t.Member)
+	case *GuildEmojisUpdate:
+		s.EmojisAdd(t.GuildID, t.Emojis)
+	case *ChannelCreate:
+		s.ChannelAdd(t.Channel)
+	case *ChannelUpdate:
+		s.ChannelAdd(t.Channel)
+	case *ChannelDelete:
+		s.ChannelRemove(t.Channel)
+	case *MessageCreate:
+		s.MessageAdd(t.Message)
+	case *MessageUpdate:
+		s.MessageAdd(t.Message)
+	case *MessageDelete:
+		s.MessageRemove(t.Message)
 	}
 }

--- a/structs.go
+++ b/structs.go
@@ -29,45 +29,7 @@ type Session struct {
 	Token string // Authentication token for this session
 	Debug bool   // Debug for printing JSON request/responses
 
-	// Settable Callback functions for Internal Events
-	// OnConnect is called when the websocket connection opens.
-	OnConnect func(*Session)
-	// OnDisconnect is called when the websocket connection closes.
-	// This is a good handler to add reconnection logic to.
-	OnDisconnect func(*Session)
-
 	Handlers map[interface{}][]interface{}
-
-	// Settable Callback functions for Websocket Events
-	OnEvent                   func(*Session, *Event)
-	OnReady                   func(*Session, *Ready)
-	OnTypingStart             func(*Session, *TypingStart)
-	OnMessageCreate           func(*Session, *Message)
-	OnMessageUpdate           func(*Session, *Message)
-	OnMessageDelete           func(*Session, *Message)
-	OnMessageAck              func(*Session, *MessageAck)
-	OnUserUpdate              func(*Session, *User)
-	OnPresenceUpdate          func(*Session, *PresenceUpdate)
-	OnVoiceServerUpdate       func(*Session, *VoiceServerUpdate)
-	OnVoiceStateUpdate        func(*Session, *VoiceState)
-	OnChannelCreate           func(*Session, *Channel)
-	OnChannelUpdate           func(*Session, *Channel)
-	OnChannelDelete           func(*Session, *Channel)
-	OnGuildCreate             func(*Session, *Guild)
-	OnGuildUpdate             func(*Session, *Guild)
-	OnGuildDelete             func(*Session, *Guild)
-	OnGuildMemberAdd          func(*Session, *Member)
-	OnGuildMemberRemove       func(*Session, *Member)
-	OnGuildMemberDelete       func(*Session, *Member)
-	OnGuildMemberUpdate       func(*Session, *Member)
-	OnGuildRoleCreate         func(*Session, *GuildRole)
-	OnGuildRoleUpdate         func(*Session, *GuildRole)
-	OnGuildRoleDelete         func(*Session, *GuildRoleDelete)
-	OnGuildIntegrationsUpdate func(*Session, *GuildIntegrationsUpdate)
-	OnGuildBanAdd             func(*Session, *GuildBan)
-	OnGuildBanRemove          func(*Session, *GuildBan)
-	OnGuildEmojisUpdate       func(*Session, *GuildEmojisUpdate)
-	OnUserSettingsUpdate      func(*Session, map[string]interface{}) // TODO: Find better way?
 
 	// Exposed but should not be modified by User.
 	SessionID  string // from websocket READY packet

--- a/structs.go
+++ b/structs.go
@@ -20,47 +20,59 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// A Session represents a connection to the Discord REST API.
-// token : The authentication token returned from Discord
-// Debug : If set to ture debug logging will be displayed.
+// A Session represents a connection to the Discord API.
 type Session struct {
 	sync.RWMutex
 
 	// General configurable settings.
-	Token string // Authentication token for this session
-	Debug bool   // Debug for printing JSON request/responses
 
-	// This is a mapping of event structs to a reflected value
-	// for event handlers.
-	// We store the reflected value instead of the function
-	// reference as it is more performant, instead of re-reflecting
-	// the function each event.
-	Handlers map[interface{}][]reflect.Value
+	// Authentication token for this session
+	Token string
 
-	// Exposed but should not be modified by User.
-	SessionID  string // from websocket READY packet
-	DataReady  bool   // Set to true when Data Websocket is ready
-	VoiceReady bool   // Set to true when Voice Websocket is ready
-	UDPReady   bool   // Set to true when UDP Connection is ready
-
-	// The websocket connection.
-	wsConn *websocket.Conn
-
-	// Stores all details related to voice connections
-	Voice *Voice
-
-	// Managed state object, updated with events.
-	State        *State
-	StateEnabled bool
-
-	// When nil, the session is not listening.
-	listening chan interface{}
+	// Debug for printing JSON request/responses
+	Debug bool
 
 	// Should the session reconnect the websocket on errors.
 	ShouldReconnectOnError bool
 
 	// Should the session request compressed websocket data.
 	Compress bool
+
+	// Should state tracking be enabled.
+	// State tracking is the best way for getting the the users
+	// active guilds and the members of the guilds.
+	StateEnabled bool
+
+	// Exposed but should not be modified by User.
+
+	// Whether the Data Websocket is ready
+	DataReady bool
+
+	// Whether the Voice Websocket is ready
+	VoiceReady bool
+
+	// Whether the UDP Connection is ready
+	UDPReady bool
+
+	// Stores all details related to voice connections
+	Voice *Voice
+
+	// Managed state object, updated internally with events when
+	// StateEnabled is true.
+	State *State
+
+	// This is a mapping of event structs to a reflected value
+	// for event handlers.
+	// We store the reflected value instead of the function
+	// reference as it is more performant, instead of re-reflecting
+	// the function each event.
+	handlers map[interface{}][]reflect.Value
+
+	// The websocket connection.
+	wsConn *websocket.Conn
+
+	// When nil, the session is not listening.
+	listening chan interface{}
 }
 
 // A VoiceRegion stores data for a specific voice region server.

--- a/structs.go
+++ b/structs.go
@@ -13,6 +13,7 @@ package discordgo
 
 import (
 	"encoding/json"
+	"reflect"
 	"sync"
 	"time"
 
@@ -29,7 +30,12 @@ type Session struct {
 	Token string // Authentication token for this session
 	Debug bool   // Debug for printing JSON request/responses
 
-	Handlers map[interface{}][]interface{}
+	// This is a mapping of event structs to a reflected value
+	// for event handlers.
+	// We store the reflected value instead of the function
+	// reference as it is more performant, instead of re-reflecting
+	// the function each event.
+	Handlers map[interface{}][]reflect.Value
 
 	// Exposed but should not be modified by User.
 	SessionID  string // from websocket READY packet

--- a/structs.go
+++ b/structs.go
@@ -36,6 +36,8 @@ type Session struct {
 	// This is a good handler to add reconnection logic to.
 	OnDisconnect func(*Session)
 
+	Handlers map[interface{}][]interface{}
+
 	// Settable Callback functions for Websocket Events
 	OnEvent                   func(*Session, *Event)
 	OnReady                   func(*Session, *Ready)

--- a/wsapi.go
+++ b/wsapi.go
@@ -285,7 +285,7 @@ var eventToInterface = map[string]interface{}{
 // All unhandled events will then be handled by OnEvent.
 func (s *Session) event(messageType int, message []byte) {
 	s.RLock()
-	if s.Handlers == nil {
+	if s.handlers == nil {
 		s.RUnlock()
 		s.initialize()
 	} else {

--- a/wsapi.go
+++ b/wsapi.go
@@ -247,17 +247,6 @@ func (s *Session) UpdateStatus(idle int, game string) (err error) {
 	return
 }
 
-// Not sure how needed this is and where it would be best to call it.
-// somewhere.
-
-func unmarshalEvent(event *Event, i interface{}) (err error) {
-	if err = unmarshal(event.RawData, i); err != nil {
-		fmt.Println("Unable to unmarshal event data.")
-		printEvent(event)
-	}
-	return
-}
-
 // Front line handler for all Websocket Events.  Determines the
 // event type and passes the message along to the next handler.
 
@@ -266,6 +255,10 @@ func unmarshalEvent(event *Event, i interface{}) (err error) {
 // Events will be handled by any implemented handler in Session.
 // All unhandled events will then be handled by OnEvent.
 func (s *Session) event(messageType int, message []byte) {
+	if s.Handlers == nil {
+		s.initialize()
+	}
+
 	var err error
 	var reader io.Reader
 	reader = bytes.NewBuffer(message)
@@ -296,405 +289,343 @@ func (s *Session) event(messageType int, message []byte) {
 		printEvent(e)
 	}
 
+	var i interface{}
+
 	switch e.Type {
 	case "READY":
-		var st *Ready
-		if err = unmarshalEvent(e, &st); err == nil {
-			go s.heartbeat(s.wsConn, s.listening, st.HeartbeatInterval)
-			if s.StateEnabled {
-				err := s.State.OnReady(st)
-				if err != nil {
-					fmt.Println("error: ", err)
-				}
-
-			}
-			if s.OnReady != nil {
-				s.OnReady(s, st)
-			}
-		}
-		if s.OnReady != nil {
-			return
-		}
-	case "VOICE_SERVER_UPDATE":
-		if s.Voice == nil && s.OnVoiceServerUpdate == nil {
-			break
-		}
-		var st *VoiceServerUpdate
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.Voice != nil {
-				s.onVoiceServerUpdate(st)
-			}
-			if s.OnVoiceServerUpdate != nil {
-				s.OnVoiceServerUpdate(s, st)
-			}
-		}
-		if s.OnVoiceServerUpdate != nil {
-			return
-		}
-	case "VOICE_STATE_UPDATE":
-		if s.Voice == nil && s.OnVoiceStateUpdate == nil {
-			break
-		}
-		var st *VoiceState
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.Voice != nil {
-				s.onVoiceStateUpdate(st)
-			}
-			if s.OnVoiceStateUpdate != nil {
-				s.OnVoiceStateUpdate(s, st)
-			}
-		}
-		if s.OnVoiceStateUpdate != nil {
-			return
-		}
-	case "USER_UPDATE":
-		if s.OnUserUpdate != nil {
-			var st *User
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnUserUpdate(s, st)
-			}
-			return
-		}
-	case "PRESENCE_UPDATE":
-		if s.OnPresenceUpdate != nil {
-			var st *PresenceUpdate
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnPresenceUpdate(s, st)
-			}
-			return
-		}
-	case "TYPING_START":
-		if s.OnTypingStart != nil {
-			var st *TypingStart
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnTypingStart(s, st)
-			}
-			return
-		}
-		/* Never seen this come in but saw it in another Library.
-		case "MESSAGE_ACK":
-			if s.OnMessageAck != nil {
-			}
-		*/
+		i = &Ready{}
 	case "MESSAGE_CREATE":
-		stateEnabled := s.StateEnabled && s.State.MaxMessageCount > 0
-		if !stateEnabled && s.OnMessageCreate == nil {
-			break
-		}
-		var st *Message
-		if err = unmarshalEvent(e, &st); err == nil {
-			if stateEnabled {
-				err := s.State.MessageAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnMessageCreate != nil {
-				s.OnMessageCreate(s, st)
-			}
-		}
-		if s.OnMessageCreate != nil {
-			return
-		}
+		i = &MessageCreate{}
 	case "MESSAGE_UPDATE":
-		stateEnabled := s.StateEnabled && s.State.MaxMessageCount > 0
-		if !stateEnabled && s.OnMessageUpdate == nil {
-			break
-		}
-		var st *Message
-		if err = unmarshalEvent(e, &st); err == nil {
-			if stateEnabled {
-				err := s.State.MessageAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnMessageUpdate != nil {
-				s.OnMessageUpdate(s, st)
-			}
-		}
-		return
+		i = &MessageUpdate{}
 	case "MESSAGE_DELETE":
-		stateEnabled := s.StateEnabled && s.State.MaxMessageCount > 0
-		if !stateEnabled && s.OnMessageDelete == nil {
-			break
-		}
-		var st *Message
-		if err = unmarshalEvent(e, &st); err == nil {
-			if stateEnabled {
-				err := s.State.MessageRemove(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnMessageDelete != nil {
-				s.OnMessageDelete(s, st)
-			}
-		}
-		return
-	case "MESSAGE_ACK":
-		if s.OnMessageAck != nil {
-			var st *MessageAck
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnMessageAck(s, st)
-			}
-			return
-		}
-	case "CHANNEL_CREATE":
-		if !s.StateEnabled && s.OnChannelCreate == nil {
-			break
-		}
-		var st *Channel
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.ChannelAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnChannelCreate != nil {
-				s.OnChannelCreate(s, st)
-			}
-		}
-		if s.OnChannelCreate != nil {
-			return
-		}
-	case "CHANNEL_UPDATE":
-		if !s.StateEnabled && s.OnChannelUpdate == nil {
-			break
-		}
-		var st *Channel
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.ChannelAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnChannelUpdate != nil {
-				s.OnChannelUpdate(s, st)
-			}
-		}
-		if s.OnChannelUpdate != nil {
-			return
-		}
-	case "CHANNEL_DELETE":
-		if !s.StateEnabled && s.OnChannelDelete == nil {
-			break
-		}
-		var st *Channel
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.ChannelRemove(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnChannelDelete != nil {
-				s.OnChannelDelete(s, st)
-			}
-		}
-		if s.OnChannelDelete != nil {
-			return
-		}
-	case "GUILD_CREATE":
-		if !s.StateEnabled && s.OnGuildCreate == nil {
-			break
-		}
-		var st *Guild
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.GuildAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnGuildCreate != nil {
-				s.OnGuildCreate(s, st)
-			}
-		}
-		if s.OnGuildCreate != nil {
-			return
-		}
-	case "GUILD_UPDATE":
-		if !s.StateEnabled && s.OnGuildUpdate == nil {
-			break
-		}
-		var st *Guild
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.GuildAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnGuildCreate != nil {
-				s.OnGuildUpdate(s, st)
-			}
-		}
-		if s.OnGuildUpdate != nil {
-			return
-		}
-	case "GUILD_DELETE":
-		if !s.StateEnabled && s.OnGuildDelete == nil {
-			break
-		}
-		var st *Guild
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.GuildRemove(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnGuildDelete != nil {
-				s.OnGuildDelete(s, st)
-			}
-		}
-		if s.OnGuildDelete != nil {
-			return
-		}
-	case "GUILD_MEMBER_ADD":
-		if !s.StateEnabled && s.OnGuildMemberAdd == nil {
-			break
-		}
-		var st *Member
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.MemberAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnGuildMemberAdd != nil {
-				s.OnGuildMemberAdd(s, st)
-			}
-		}
-		if s.OnGuildMemberAdd != nil {
-			return
-		}
-	case "GUILD_MEMBER_REMOVE":
-		if !s.StateEnabled && s.OnGuildMemberRemove == nil {
-			break
-		}
-		var st *Member
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.MemberRemove(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnGuildMemberRemove != nil {
-				s.OnGuildMemberRemove(s, st)
-			}
-		}
-		if s.OnGuildMemberRemove != nil {
-			return
-		}
-	case "GUILD_MEMBER_UPDATE":
-		if !s.StateEnabled && s.OnGuildMemberUpdate == nil {
-			break
-		}
-		var st *Member
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.MemberAdd(st)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnGuildMemberUpdate != nil {
-				s.OnGuildMemberUpdate(s, st)
-			}
-		}
-		if s.OnGuildMemberUpdate != nil {
-			return
-		}
-	case "GUILD_ROLE_CREATE":
-		if s.OnGuildRoleCreate != nil {
-			var st *GuildRole
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnGuildRoleCreate(s, st)
-			}
-			return
-		}
-	case "GUILD_ROLE_UPDATE":
-		if s.OnGuildRoleUpdate != nil {
-			var st *GuildRole
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnGuildRoleUpdate(s, st)
-			}
-			return
-		}
-	case "GUILD_ROLE_DELETE":
-		if s.OnGuildRoleDelete != nil {
-			var st *GuildRoleDelete
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnGuildRoleDelete(s, st)
-			}
-			return
-		}
-	case "GUILD_INTEGRATIONS_UPDATE":
-		if s.OnGuildIntegrationsUpdate != nil {
-			var st *GuildIntegrationsUpdate
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnGuildIntegrationsUpdate(s, st)
-			}
-			return
-		}
-	case "GUILD_BAN_ADD":
-		if s.OnGuildBanAdd != nil {
-			var st *GuildBan
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnGuildBanAdd(s, st)
-			}
-			return
-		}
-	case "GUILD_BAN_REMOVE":
-		if s.OnGuildBanRemove != nil {
-			var st *GuildBan
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnGuildBanRemove(s, st)
-			}
-			return
-		}
-	case "GUILD_EMOJIS_UPDATE":
-		if !s.StateEnabled && s.OnGuildEmojisUpdate == nil {
-			break
-		}
-		var st *GuildEmojisUpdate
-		if err = unmarshalEvent(e, &st); err == nil {
-			if s.StateEnabled {
-				err := s.State.EmojisAdd(st.GuildID, st.Emojis)
-				if err != nil {
-					fmt.Println("error :", err)
-				}
-			}
-			if s.OnGuildEmojisUpdate != nil {
-				s.OnGuildEmojisUpdate(s, st)
-			}
-		}
-		if s.OnGuildEmojisUpdate != nil {
-			return
-		}
-	case "USER_SETTINGS_UPDATE":
-		if s.OnUserSettingsUpdate != nil {
-			var st map[string]interface{}
-			if err = unmarshalEvent(e, &st); err == nil {
-				s.OnUserSettingsUpdate(s, st)
-			}
-			return
-		}
-	default:
-		fmt.Println("Unknown Event.")
-		printEvent(e)
+		i = &MessageDelete{}
+	case "PRESENCE_UPDATE":
+		i = &PresenceUpdate{}
+	case "TYPING_START":
+		i = &TypingStart{}
 	}
 
-	// if still here, send to generic OnEvent
-	if s.OnEvent != nil {
-		s.OnEvent(s, e)
-		return
+	// case "VOICE_SERVER_UPDATE":
+	// 	if s.Voice == nil && s.OnVoiceServerUpdate == nil {
+	// 		break
+	// 	}
+	// 	var st *VoiceServerUpdate
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.Voice != nil {
+	// 			s.onVoiceServerUpdate(st)
+	// 		}
+	// 		if s.OnVoiceServerUpdate != nil {
+	// 			s.OnVoiceServerUpdate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnVoiceServerUpdate != nil {
+	// 		return
+	// 	}
+	// case "VOICE_STATE_UPDATE":
+	// 	if s.Voice == nil && s.OnVoiceStateUpdate == nil {
+	// 		break
+	// 	}
+	// 	var st *VoiceState
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.Voice != nil {
+	// 			s.onVoiceStateUpdate(st)
+	// 		}
+	// 		if s.OnVoiceStateUpdate != nil {
+	// 			s.OnVoiceStateUpdate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnVoiceStateUpdate != nil {
+	// 		return
+	// 	}
+	// case "USER_UPDATE":
+	// 	if s.OnUserUpdate != nil {
+	// 		var st *User
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnUserUpdate(s, st)
+	// 		}
+	// 		return
+	// 	}
+
+	// 	/* Never seen this come in but saw it in another Library.
+	// 	case "MESSAGE_ACK":
+	// 		if s.OnMessageAck != nil {
+	// 		}
+	// 	*/
+
+	// case "MESSAGE_ACK":
+	// 	if s.OnMessageAck != nil {
+	// 		var st *MessageAck
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnMessageAck(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// case "CHANNEL_CREATE":
+	// 	if !s.StateEnabled && s.OnChannelCreate == nil {
+	// 		break
+	// 	}
+	// 	var st *Channel
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.ChannelAdd(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnChannelCreate != nil {
+	// 			s.OnChannelCreate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnChannelCreate != nil {
+	// 		return
+	// 	}
+	// case "CHANNEL_UPDATE":
+	// 	if !s.StateEnabled && s.OnChannelUpdate == nil {
+	// 		break
+	// 	}
+	// 	var st *Channel
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.ChannelAdd(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnChannelUpdate != nil {
+	// 			s.OnChannelUpdate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnChannelUpdate != nil {
+	// 		return
+	// 	}
+	// case "CHANNEL_DELETE":
+	// 	if !s.StateEnabled && s.OnChannelDelete == nil {
+	// 		break
+	// 	}
+	// 	var st *Channel
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.ChannelRemove(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnChannelDelete != nil {
+	// 			s.OnChannelDelete(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnChannelDelete != nil {
+	// 		return
+	// 	}
+	// case "GUILD_CREATE":
+	// 	if !s.StateEnabled && s.OnGuildCreate == nil {
+	// 		break
+	// 	}
+	// 	var st *Guild
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.GuildAdd(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnGuildCreate != nil {
+	// 			s.OnGuildCreate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnGuildCreate != nil {
+	// 		return
+	// 	}
+	// case "GUILD_UPDATE":
+	// 	if !s.StateEnabled && s.OnGuildUpdate == nil {
+	// 		break
+	// 	}
+	// 	var st *Guild
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.GuildAdd(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnGuildCreate != nil {
+	// 			s.OnGuildUpdate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnGuildUpdate != nil {
+	// 		return
+	// 	}
+	// case "GUILD_DELETE":
+	// 	if !s.StateEnabled && s.OnGuildDelete == nil {
+	// 		break
+	// 	}
+	// 	var st *Guild
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.GuildRemove(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnGuildDelete != nil {
+	// 			s.OnGuildDelete(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnGuildDelete != nil {
+	// 		return
+	// 	}
+	// case "GUILD_MEMBER_ADD":
+	// 	if !s.StateEnabled && s.OnGuildMemberAdd == nil {
+	// 		break
+	// 	}
+	// 	var st *Member
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.MemberAdd(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnGuildMemberAdd != nil {
+	// 			s.OnGuildMemberAdd(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnGuildMemberAdd != nil {
+	// 		return
+	// 	}
+	// case "GUILD_MEMBER_REMOVE":
+	// 	if !s.StateEnabled && s.OnGuildMemberRemove == nil {
+	// 		break
+	// 	}
+	// 	var st *Member
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.MemberRemove(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnGuildMemberRemove != nil {
+	// 			s.OnGuildMemberRemove(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnGuildMemberRemove != nil {
+	// 		return
+	// 	}
+	// case "GUILD_MEMBER_UPDATE":
+	// 	if !s.StateEnabled && s.OnGuildMemberUpdate == nil {
+	// 		break
+	// 	}
+	// 	var st *Member
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.MemberAdd(st)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnGuildMemberUpdate != nil {
+	// 			s.OnGuildMemberUpdate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnGuildMemberUpdate != nil {
+	// 		return
+	// 	}
+	// case "GUILD_ROLE_CREATE":
+	// 	if s.OnGuildRoleCreate != nil {
+	// 		var st *GuildRole
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnGuildRoleCreate(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// case "GUILD_ROLE_UPDATE":
+	// 	if s.OnGuildRoleUpdate != nil {
+	// 		var st *GuildRole
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnGuildRoleUpdate(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// case "GUILD_ROLE_DELETE":
+	// 	if s.OnGuildRoleDelete != nil {
+	// 		var st *GuildRoleDelete
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnGuildRoleDelete(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// case "GUILD_INTEGRATIONS_UPDATE":
+	// 	if s.OnGuildIntegrationsUpdate != nil {
+	// 		var st *GuildIntegrationsUpdate
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnGuildIntegrationsUpdate(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// case "GUILD_BAN_ADD":
+	// 	if s.OnGuildBanAdd != nil {
+	// 		var st *GuildBan
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnGuildBanAdd(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// case "GUILD_BAN_REMOVE":
+	// 	if s.OnGuildBanRemove != nil {
+	// 		var st *GuildBan
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnGuildBanRemove(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// case "GUILD_EMOJIS_UPDATE":
+	// 	if !s.StateEnabled && s.OnGuildEmojisUpdate == nil {
+	// 		break
+	// 	}
+	// 	var st *GuildEmojisUpdate
+	// 	if err = unmarshalEvent(e, &st); err == nil {
+	// 		if s.StateEnabled {
+	// 			err := s.State.EmojisAdd(st.GuildID, st.Emojis)
+	// 			if err != nil {
+	// 				fmt.Println("error :", err)
+	// 			}
+	// 		}
+	// 		if s.OnGuildEmojisUpdate != nil {
+	// 			s.OnGuildEmojisUpdate(s, st)
+	// 		}
+	// 	}
+	// 	if s.OnGuildEmojisUpdate != nil {
+	// 		return
+	// 	}
+	// case "USER_SETTINGS_UPDATE":
+	// 	if s.OnUserSettingsUpdate != nil {
+	// 		var st map[string]interface{}
+	// 		if err = unmarshalEvent(e, &st); err == nil {
+	// 			s.OnUserSettingsUpdate(s, st)
+	// 		}
+	// 		return
+	// 	}
+	// default:
+	// 	fmt.Println("Unknown Event.")
+	// 	printEvent(e)
+	// }
+
+	// Attempt to unmarshal our event.
+	// If there is an error (eg. we don't know how to handle it) we should handle the event itself.
+	if err = unmarshal(e.RawData, i); err != nil {
+		fmt.Println("Unable to unmarshal event data.")
+		printEvent(e)
+		i = e
+	}
+
+	if !s.Handle(i) {
+		if i != e {
+			// If there was not a handler for the struct, handle the event, as long as it wasn't the
+			// event we were trying to handle.
+			s.Handle(e)
+		}
 	}
 
 	return


### PR DESCRIPTION
This change breaks the current API but makes it much more powerful.

Currently only one handler can be added for each event, with this change, any number of handlers can be added for the same event. Additionally it supports adding handlers for interface{} which will be triggered on every event.

The existing code:
```
dg.OnMessageCreate = func(s *discordgo.Session, m *discordgo.Message){
  fmt.Println(m.Content)
}
```
is now:
```
dg.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate){
  fmt.Println(m.Content)
})
```

Not bad for a net delta of -:100: lines.