### PR TITLE
Fix channels from a GUILD_CREATE packet having null GuildID's

### DIFF
--- a/state.go
+++ b/state.go
@@ -73,6 +73,11 @@ func (s *State) GuildAdd(guild *Guild) error {
 		}
 	}
 
+	// Otherwise, update the channels to point to the right guild
+	for _, c := range guild.Channels {
+		c.GuildID = guild.ID
+	}
+
 	s.Guilds = append(s.Guilds, guild)
 	return nil
 }


### PR DESCRIPTION
For any channels that are part of the Guild object given within a GUILD_CREATE packet, discord doesn't send 'guild_id' keys to save space within the WS frame. This means when handling GUILD_CREATE packets for brand new (e.g. untracked) we need to manually set the `guild_id` for every channel.