### PR TITLE
Fix lazy guild loading

### DIFF
--- a/state.go
+++ b/state.go
@@ -57,22 +57,24 @@ func (s *State) GuildAdd(guild *Guild) error {
 	s.Lock()
 	defer s.Unlock()
 
-	// If the guild exists, replace it.
-	for i, g := range s.Guilds {
-		if g.ID == guild.ID {
-			// Don't stomp on properties that don't come in updates.
-			guild.Members = g.Members
-			guild.Presences = g.Presences
-			guild.Channels = g.Channels
-			guild.VoiceStates = g.VoiceStates
-			s.Guilds[i] = guild
-			return nil
-		}
-	}
-
 	// Otherwise, update the channels to point to the right guild
 	for _, c := range guild.Channels {
 		c.GuildID = guild.ID
+	}
+
+	// If the guild exists, replace it.
+	for i, g := range s.Guilds {
+		if g.ID == guild.ID {
+			// If this guild already exists with data, don't stomp on props
+			if !g.Unavailable {
+				guild.Members = g.Members
+				guild.Presences = g.Presences
+				guild.Channels = g.Channels
+				guild.VoiceStates = g.VoiceStates
+			}
+			s.Guilds[i] = guild
+			return nil
+		}
 	}
 
 	s.Guilds = append(s.Guilds, guild)

--- a/structs.go
+++ b/structs.go
@@ -178,6 +178,7 @@ type Guild struct {
 	Presences         []*Presence       `json:"presences"`
 	Channels          []*Channel        `json:"channels"`
 	VoiceStates       []*VoiceState     `json:"voice_states"`
+	Unavailable       bool              `json:"unavailable"`
 }
 
 // A GuildParams stores all the data needed to update discord guild settings


### PR DESCRIPTION
We're (Discord) moving to a method of lazy-loading guilds to help with extremely large `READY` packets. With this new method, clients will now receive only the 'id' and 'unavailable' fields for every guild in the `READY` packet, and will lazily receive `GUILD_CREATE` events for those guilds as they are connected by our backend.

Previously discordgo used the Guild objects originally passed in the `READY` payload as the base object for all future events, however with this new method we now case this to when the original guild is not unavailable.

Something this commit does not add, but may be helpful is a way to detect the difference between `GUILD_CREATE`'s used for the handshake process, vs `GUILD_CREATE`'s that actually represent a guild being created/added. Due to the way the state works right now, the handler is always called before any of the users and therefore you cannot compare the state before/after the GUILD_CREATE to understand whether it is a new or lazily loaded guild.

:eyes: @iopred @bwmarrin 