### PR TITLE
Add sharding support

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -38,6 +38,10 @@ type Session struct {
 	// Should the session request compressed websocket data.
 	Compress bool
 
+	// Sharding
+	ShardID   int
+	NumShards int
+
 	// Should state tracking be enabled.
 	// State tracking is the best way for getting the the users
 	// active guilds and the members of the guilds.

--- a/wsapi.go
+++ b/wsapi.go
@@ -39,6 +39,7 @@ type handshakeData struct {
 	Properties     handshakeProperties `json:"properties"`
 	LargeThreshold int                 `json:"large_threshold"`
 	Compress       bool                `json:"compress"`
+	Shard          [2]int              `json:"shard"`
 }
 
 type handshakeOp struct {
@@ -78,7 +79,20 @@ func (s *Session) Open() (err error) {
 		return
 	}
 
-	err = s.wsConn.WriteJSON(handshakeOp{2, handshakeData{3, s.Token, handshakeProperties{runtime.GOOS, "Discordgo v" + VERSION, "", "", ""}, 250, s.Compress}})
+	handshake := handshakeData{
+		Version:        4,
+		Token:          s.Token,
+		Properties:     handshakeProperties{runtime.GOOS, "Discordgo v" + VERSION, "", "", ""},
+		LargeThreshold: 250,
+		Compress:       s.Compress,
+	}
+
+	// If we've set NumShards, add the shard information to the handshake
+	if s.NumShards > 0 {
+		handshake.Shard = [2]int{s.ShardID, s.NumShards}
+	}
+
+	err = s.wsConn.WriteJSON(handshakeOp{2, handshake})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**Do not merge this until hammerandchisel/discord-api-docs#17 is ready**

This PR adds support for Discords new builtin sharding implementation, which allows users to segment guilds across multiple websocket connections.