### PR TITLE
Revert "Add sharding support"

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -38,10 +38,6 @@ type Session struct {
 	// Should the session request compressed websocket data.
 	Compress bool
 
-	// Sharding
-	ShardID   int
-	NumShards int
-
 	// Should state tracking be enabled.
 	// State tracking is the best way for getting the the users
 	// active guilds and the members of the guilds.

--- a/wsapi.go
+++ b/wsapi.go
@@ -40,7 +40,6 @@ type handshakeData struct {
 	Properties     handshakeProperties `json:"properties"`
 	LargeThreshold int                 `json:"large_threshold"`
 	Compress       bool                `json:"compress"`
-	Shard          [2]int              `json:"shard"`
 }
 
 type handshakeOp struct {
@@ -80,20 +79,7 @@ func (s *Session) Open() (err error) {
 		return
 	}
 
-	handshake := handshakeData{
-		Version:        4,
-		Token:          s.Token,
-		Properties:     handshakeProperties{runtime.GOOS, "Discordgo v" + VERSION, "", "", ""},
-		LargeThreshold: 250,
-		Compress:       s.Compress,
-	}
-
-	// If we've set NumShards, add the shard information to the handshake
-	if s.NumShards > 0 {
-		handshake.Shard = [2]int{s.ShardID, s.NumShards}
-	}
-
-	err = s.wsConn.WriteJSON(handshakeOp{2, handshake})
+	err = s.wsConn.WriteJSON(handshakeOp{2, handshakeData{3, s.Token, handshakeProperties{runtime.GOOS, "Discordgo v" + VERSION, "", "", ""}, 250, s.Compress}})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Reverts bwmarrin/discordgo#166

*cough* *cough* 
discord_test.go:207: DataReady never became true.

Somehow I failed to notice this PR causes discordgo to not work anymore.  @b1naryth1ef 

With this change, dgo goes into a loop trying to connect and gets disconnected and so on, it never makes a connection to the data websocket that can be used.