### PR TITLE
Sendfile enhancement

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1218,11 +1218,27 @@ func (s *Session) ChannelMessagesPinned(channelID string) (st []*Message, err er
 
 // ChannelFileSend sends a file to the given channel.
 // channelID : The ID of a Channel.
+// name: The name of the file.
 // io.Reader : A reader for the file contents.
 func (s *Session) ChannelFileSend(channelID, name string, r io.Reader) (st *Message, err error) {
+	return s.ChannelFileSendWithMessage(channelID, "", name, r)
+}
+
+// ChannelFileSendWithMessage sends a file to the given channel with an message.
+// channelID : The ID of a Channel.
+// content: Optional Message content.
+// name: The name of the file.
+// io.Reader : A reader for the file contents.
+func (s *Session) ChannelFileSendWithMessage(channelID, content string, name string, r io.Reader) (st *Message, err error) {
 
 	body := &bytes.Buffer{}
 	bodywriter := multipart.NewWriter(body)
+
+	if len(content) != 0 {
+		if err := bodywriter.WriteField("content", content); err != nil {
+			return nil, err
+		}
+	}
 
 	writer, err := bodywriter.CreateFormFile("file", name)
 	if err != nil {


### PR DESCRIPTION
added a new method with the following signature
```
func (s *Session) ChannelFileSendWithMessage(channelID, content string, name string, r io.Reader) (st *Message, err error)
```
to keep backwards compatability i kept the old method but it just calls the full method.