### PR TITLE
Add the Bot prefix to authorization.

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -27,6 +27,7 @@ const VERSION = "0.14.0-dev"
 // There are 3 ways to call New:
 //     With a single auth token - All requests will use the token blindly,
 //         no verification of the token will be done and requests may fail.
+//				 Please use this way only for bot users.
 //     With an email and password - Discord will sign in with the provided
 //         credentials.
 //     With an email, password and auth token - Discord will verify the auth
@@ -107,9 +108,12 @@ func New(args ...interface{}) (s *Session, err error) {
 	// Otherwise get auth token from Discord, if a token was specified
 	// Discord will verify it for free, or log the user in if it is
 	// invalid.
+	// Assume that Token auth is the bot auth
 	if pass == "" {
 		s.Token = auth
+		s.Bot = true
 	} else {
+		s.Bot = false
 		err = s.Login(auth, pass)
 		if err != nil || s.Token == "" {
 			err = fmt.Errorf("Unable to fetch discord authentication token. %v", err)

--- a/restapi.go
+++ b/restapi.go
@@ -86,7 +86,11 @@ func (s *Session) request(method, urlStr, contentType string, b []byte) (respons
 	// Not used on initial login..
 	// TODO: Verify if a login, otherwise complain about no-token
 	if s.Token != "" {
-		req.Header.Set("authorization", "Bot "+s.Token)
+		if s.Bot {
+			req.Header.Set("authorization", "Bot "+s.Token)
+		} else {
+			req.Header.Set("authorization", s.Token)
+		}
 	}
 
 	req.Header.Set("Content-Type", contentType)

--- a/restapi.go
+++ b/restapi.go
@@ -86,7 +86,7 @@ func (s *Session) request(method, urlStr, contentType string, b []byte) (respons
 	// Not used on initial login..
 	// TODO: Verify if a login, otherwise complain about no-token
 	if s.Token != "" {
-		req.Header.Set("authorization", s.Token)
+		req.Header.Set("authorization", "Bot "+s.Token)
 	}
 
 	req.Header.Set("Content-Type", contentType)

--- a/structs.go
+++ b/structs.go
@@ -70,6 +70,9 @@ type Session struct {
 	// StateEnabled is true.
 	State *State
 
+	// used to know if user is a bot
+	Bot bool
+
 	handlersMu sync.RWMutex
 	// This is a mapping of event struct to a reflected value
 	// for event handlers.


### PR DESCRIPTION
Closes #247
See https://github.com/hammerandchisel/discord-api-docs/issues/119

Current problem. This PR don't Authorize discordgo to use normal users however discordgo don't know if it connect has a Bot or as a normal user.

Do we keep allowed normal user accounts on Discordgo ?