### PR TITLE
Fix for 401 Auth Error

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -86,7 +86,7 @@ func (s *Session) request(method, urlStr, contentType string, b []byte) (respons
 	// Not used on initial login..
 	// TODO: Verify if a login, otherwise complain about no-token
 	if s.Token != "" {
-		req.Header.Set("authorization", s.Token)
+		req.Header.Set("authorization", "Bot " + s.Token)
 	}
 
 	req.Header.Set("Content-Type", contentType)


### PR DESCRIPTION
It seems like the API requires a "Bot " + Token in the HTTP Auth header from now on.


"Authorization: TOKEN_TYPE TOKEN"

- From https://discordapp.com/developers/docs/reference
