### PR TITLE
Add GuildReady event emitted when all guilds have been lazy loaded.

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -42,6 +42,8 @@ func New(args ...interface{}) (s *Session, err error) {
 		ShouldReconnectOnError: true,
 		ShardID:                0,
 		ShardCount:             1,
+
+		loadedGuildMap: make(map[string]bool),
 	}
 
 	// If no arguments are passed return the empty Session interface.
@@ -237,10 +239,17 @@ func (s *Session) initialize() {
 	s.AddHandler(s.onVoiceServerUpdate)
 	s.AddHandler(s.onVoiceStateUpdate)
 	s.AddHandler(s.State.onInterface)
+	s.AddHandler(s.onGuildCreate)
 }
 
 // onReady handles the ready event.
 func (s *Session) onReady(se *Session, r *Ready) {
+
+	for _, g := range r.Guilds {
+		if g.Unavailable != nil && !*g.Unavailable {
+			s.loadedGuildMap[g.ID] = false
+		}
+	}
 
 	// Store the SessionID within the Session struct.
 	s.sessionID = r.SessionID
@@ -254,4 +263,22 @@ func (s *Session) onResumed(se *Session, r *Resumed) {
 
 	// Start the heartbeat to keep the connection alive.
 	go s.heartbeat(s.wsConn, s.listening, r.HeartbeatInterval)
+}
+
+// onGuildCreate handles the guild creation event.
+func (s *Session) onGuildCreate(se *Session, gc *GuildCreate) {
+	s.loadedGuildMap[gc.ID] = true
+
+	// Iterate over the guilds that must be loaded, and check if they all have been.
+	fullyLoaded := true
+	for _, g := range s.loadedGuildMap {
+		if g != true {
+			fullyLoaded = false
+		}
+	}
+
+	// If guilds are fully lazy loaded, emit a 'GuildReady' evnet.
+	if fullyLoaded {
+		s.handle(GuildReady{})
+	}
 }

--- a/discord.go
+++ b/discord.go
@@ -246,7 +246,7 @@ func (s *Session) initialize() {
 func (s *Session) onReady(se *Session, r *Ready) {
 
 	for _, g := range r.Guilds {
-		if g.Unavailable != nil && !*g.Unavailable {
+		if g.Unavailable != nil {
 			s.loadedGuildMap[g.ID] = false
 		}
 	}
@@ -279,6 +279,6 @@ func (s *Session) onGuildCreate(se *Session, gc *GuildCreate) {
 
 	// If guilds are fully lazy loaded, emit a 'GuildReady' evnet.
 	if fullyLoaded {
-		s.handle(GuildReady{})
+		s.handle(&GuildReady{})
 	}
 }

--- a/events.go
+++ b/events.go
@@ -29,6 +29,7 @@ var eventToInterface = map[string]interface{}{
 	"GUILD_ROLE_DELETE":          GuildRoleDelete{},
 	"GUILD_INTEGRATIONS_UPDATE":  GuildIntegrationsUpdate{},
 	"GUILD_EMOJIS_UPDATE":        GuildEmojisUpdate{},
+	"GUILD_READY":                GuildReady{},
 	"MESSAGE_ACK":                MessageAck{},
 	"MESSAGE_CREATE":             MessageCreate{},
 	"MESSAGE_UPDATE":             MessageUpdate{},
@@ -136,6 +137,9 @@ type GuildRoleCreate struct {
 type GuildRoleUpdate struct {
 	*GuildRole
 }
+
+// GuildReady is an empty struct for an event.
+type GuildReady struct{}
 
 // PresencesReplace is an array of Presences for an event.
 type PresencesReplace []*Presence

--- a/structs.go
+++ b/structs.go
@@ -100,6 +100,9 @@ type Session struct {
 
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
+
+	// used to determine whether all guilds have been lazy loaded
+	loadedGuildMap map[string]bool
 }
 
 type rateLimitMutex struct {


### PR DESCRIPTION
This pull request fixes #205, adding a new event that is emitted when all the guilds from the initial `Ready` event have been lazy loaded.

Not quite sure if events should be used in this way, or if they should be exclusively for Discord gateway events. Let me know if there are any changes I should make to this.