### PR TITLE
Add GuildReady event emitted when all guilds have been lazy loaded.

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -249,7 +249,7 @@ func (s *Session) initialize() {
 func (s *Session) onReady(se *Session, r *Ready) {
 
 	for _, g := range r.Guilds {
-		if g.Unavailable != nil && !*g.Unavailable {
+		if g.Unavailable != nil {
 			s.loadedGuildMap[g.ID] = false
 		}
 	}
@@ -282,6 +282,6 @@ func (s *Session) onGuildCreate(se *Session, gc *GuildCreate) {
 
 	// If guilds are fully lazy loaded, emit a 'GuildReady' evnet.
 	if fullyLoaded {
-		s.handle(GuildReady{})
+		s.handle(&GuildReady{})
 	}
 }

--- a/discord.go
+++ b/discord.go
@@ -249,7 +249,7 @@ func (s *Session) initialize() {
 func (s *Session) onReady(se *Session, r *Ready) {
 
 	for _, g := range r.Guilds {
-		if g.Unavailable == false {
+		if g.Unavailable == true {
 			s.loadedGuildMap[g.ID] = false
 		}
 	}

--- a/discord.go
+++ b/discord.go
@@ -270,18 +270,22 @@ func (s *Session) onResumed(se *Session, r *Resumed) {
 
 // onGuildCreate handles the guild creation event.
 func (s *Session) onGuildCreate(se *Session, gc *GuildCreate) {
-	s.loadedGuildMap[gc.ID] = true
+	if _, ok := s.loadedGuildMap[gc.ID]; ok {
+		s.loadedGuildMap[gc.ID] = true
+	}
 
 	// Iterate over the guilds that must be loaded, and check if they all have been.
-	fullyLoaded := true
+	numLoadedGuilds := 0
 	for _, g := range s.loadedGuildMap {
-		if g != true {
-			fullyLoaded = false
+		if g == true {
+			numLoadedGuilds++
 		}
 	}
 
-	// If guilds are fully lazy loaded, emit a 'GuildReady' evnet.
-	if fullyLoaded {
+	// If guilds are fully lazy loaded, emit a 'GuildReady' event.
+	if len(s.loadedGuildMap) > 0 && numLoadedGuilds == len(s.loadedGuildMap) {
+		// Clear the map, so the event won't be emitted unless another 'Ready' event is emitted.
+		s.loadedGuildMap = make(map[string]bool)
 		s.handle(&GuildReady{})
 	}
 }

--- a/discord.go
+++ b/discord.go
@@ -249,7 +249,7 @@ func (s *Session) initialize() {
 func (s *Session) onReady(se *Session, r *Ready) {
 
 	for _, g := range r.Guilds {
-		if g.Unavailable != nil {
+		if g.Unavailable == false {
 			s.loadedGuildMap[g.ID] = false
 		}
 	}

--- a/events.go
+++ b/events.go
@@ -31,6 +31,7 @@ var eventToInterface = map[string]interface{}{
 	"GUILD_INTEGRATIONS_UPDATE":  GuildIntegrationsUpdate{},
 	"GUILD_EMOJIS_UPDATE":        GuildEmojisUpdate{},
 	"GUILD_MEMBERS_CHUNK":        GuildMembersChunk{},
+	"GUILD_READY":                GuildReady{},
 	"MESSAGE_ACK":                MessageAck{},
 	"MESSAGE_CREATE":             MessageCreate{},
 	"MESSAGE_UPDATE":             MessageUpdate{},
@@ -152,6 +153,9 @@ type GuildRoleCreate struct {
 type GuildRoleUpdate struct {
 	*GuildRole
 }
+
+// GuildReady is an empty struct for an event.
+type GuildReady struct{}
 
 // PresencesReplace is an array of Presences for an event.
 type PresencesReplace []*Presence

--- a/structs.go
+++ b/structs.go
@@ -101,6 +101,9 @@ type Session struct {
 
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
+
+	// used to determine whether all guilds have been lazy loaded
+	loadedGuildMap map[string]bool
 }
 
 type rateLimitMutex struct {


### PR DESCRIPTION
This pull request fixes #205, adding a new event that is emitted when all the guilds from the initial Ready event have been lazy loaded.

Not quite sure if events should be used in this way, or if they should be exclusively for Discord gateway events. Let me know if there are any changes I should make to this.

Note: This is the same pull request as #277, I forgot to fork from the `develop` branch on that pull request though.