### PR TITLE
Add support for relationships

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -87,10 +87,10 @@ var (
 	EndpointChannelMessagesBulkDelete = func(cID string) string { return EndpointChannel(cID) + "/messages/bulk_delete" }
 	EndpointChannelMessagesPins       = func(cID string) string { return EndpointChannel(cID) + "/pins" }
 	EndpointChannelMessagePin         = func(cID, mID string) string { return EndpointChannel(cID) + "/pins/" + mID }
-	EndpointChannelWebhooks           = func(cID string) string { return EndpointChannel(cID) + "/webhooks" }
 
-	EndpointWebhook      = func(wID string) string { return EndpointWebhooks + wID }
-	EndpointWebhookToken = func(wID, token string) string { return EndpointWebhooks + wID + "/" + token }
+	EndpointChannelWebhooks = func(cID string) string { return EndpointChannel(cID) + "/webhooks" }
+	EndpointWebhook         = func(wID string) string { return EndpointWebhooks + wID }
+	EndpointWebhookToken    = func(wID, token string) string { return EndpointWebhooks + wID + "/" + token }
 
 	EndpointMessageReactions = func(cID, mID, eID string) string {
 		return EndpointChannelMessage(cID, mID) + "/reactions/" + eID
@@ -98,6 +98,10 @@ var (
 	EndpointMessageReaction = func(cID, mID, eID, uID string) string {
 		return EndpointMessageReactions(cID, mID, eID) + "/" + uID
 	}
+
+	EndpointRelationships       = func() string { return EndpointUsers + "@me" + "/relationships" }
+	EndpointRelationship        = func(uID string) string { return EndpointRelationships() + "/" + uID }
+	EndpointRelationshipsMutual = func(uID string) string { return EndpointUsers + uID + "/relationships" }
 
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invite/" + iID }
 

--- a/events.go
+++ b/events.go
@@ -40,6 +40,8 @@ var eventToInterface = map[string]interface{}{
 	"PRESENCE_UPDATE":            PresenceUpdate{},
 	"PRESENCES_REPLACE":          PresencesReplace{},
 	"READY":                      Ready{},
+	"RELATIONSHIP_ADD":           RelationshipAdd{},
+	"RELATIONSHIP_REMOVE":        RelationshipRemove{},
 	"USER_UPDATE":                UserUpdate{},
 	"USER_SETTINGS_UPDATE":       UserSettingsUpdate{},
 	"USER_GUILD_SETTINGS_UPDATE": UserGuildSettingsUpdate{},
@@ -155,6 +157,16 @@ type GuildRoleUpdate struct {
 
 // PresencesReplace is an array of Presences for an event.
 type PresencesReplace []*Presence
+
+// RelationshipAdd is a wrapper struct for an event.
+type RelationshipAdd struct {
+	*Relationship
+}
+
+// RelationshipRemove is a wrapper struct for an event.
+type RelationshipRemove struct {
+	*Relationship
+}
 
 // VoiceStateUpdate is a wrapper struct for an event.
 type VoiceStateUpdate struct {

--- a/restapi.go
+++ b/restapi.go
@@ -1754,7 +1754,7 @@ func (s *Session) RelationshipsGet() (r []*Relationship, err error) {
 
 // relationshipCreate creates a new relationship. (I.e. send or accept a friend request, block a user.)
 // relationshipType : 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
-func (s *Session) relationshipCreate(userID string, relationshipType uint8) (err error) {
+func (s *Session) relationshipCreate(userID string, relationshipType int) (err error) {
 	data := struct {
 		Type int `json:"type"`
 	}{relationshipType}

--- a/restapi.go
+++ b/restapi.go
@@ -1756,7 +1756,7 @@ func (s *Session) RelationshipsGet() (r []*Relationship, err error) {
 // relationshipType : 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
 func (s *Session) relationshipCreate(userID string, relationshipType uint8) (err error) {
 	data := struct {
-		Type uint8 `json:"type"`
+		Type int `json:"type"`
 	}{relationshipType}
 
 	fmt.Println("Data: " + fmt.Sprintf("%v", data))

--- a/restapi.go
+++ b/restapi.go
@@ -1736,3 +1736,71 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 	err = unmarshal(body, &st)
 	return
 }
+
+// ------------------------------------------------------------------------------------------------
+// Functions specific to Discord Relationships (Friends list)
+// ------------------------------------------------------------------------------------------------
+
+// RelationshipsGet returns an array of all the relationships of the user.
+func (s *Session) RelationshipsGet() (r []*Relationship, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointRelationships(), nil, EndpointRelationships())
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &r)
+	return
+}
+
+// relationshipCreate creates a new relationship. (I.e. send or accept a friend request, block a user.)
+// relationshipType : 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
+func (s *Session) relationshipCreate(userID string, relationshipType uint8) (err error) {
+	data := struct {
+		Type uint8 `json:"type"`
+	}{relationshipType}
+
+	fmt.Println("Data: " + fmt.Sprintf("%v", data))
+
+	_, err = s.RequestWithBucketID("PUT", EndpointRelationship(userID), data, EndpointRelationships())
+	return
+}
+
+// RelationshipFriendRequestSend sends a friend request to a user.
+// userID: ID of the user.
+func (s *Session) RelationshipFriendRequestSend(userID string) (err error) {
+	err = s.relationshipCreate(userID, 4)
+	return
+}
+
+// RelationshipFriendRequestAccept accepts a friend request from a user.
+// userID: ID of the user.
+func (s *Session) RelationshipFriendRequestAccept(userID string) (err error) {
+	err = s.relationshipCreate(userID, 1)
+	return
+}
+
+// RelationshipUserBlock blocks a user.
+// userID: ID of the user.
+func (s *Session) RelationshipUserBlock(userID string) (err error) {
+	err = s.relationshipCreate(userID, 2)
+	return
+}
+
+// RelationshipDelete removes the relationship with a user.
+// userID: ID of the user.
+func (s *Session) RelationshipDelete(userID string) (err error) {
+	_, err = s.RequestWithBucketID("DELETE", EndpointRelationship(userID), nil, EndpointRelationships())
+	return
+}
+
+// RelationshipsMutualGet returns an array of all the users both @me and the given user is friends with.
+// userID: ID of the user.
+func (s *Session) RelationshipsMutualGet(userID string) (mf []*User, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointRelationshipsMutual(userID), nil, EndpointRelationshipsMutual(userID))
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &mf)
+	return
+}

--- a/structs.go
+++ b/structs.go
@@ -381,7 +381,7 @@ type Ready struct {
 // A Relationship between the logged in user and Relationship.User
 type Relationship struct {
 	User *User  `json:"user"`
-	Type uint8  `json:"type"` // 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
+	Type int    `json:"type"` // 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
 	ID   string `json:"id"`
 }
 

--- a/structs.go
+++ b/structs.go
@@ -381,7 +381,7 @@ type Ready struct {
 // A Relationship between the logged in user and Relationship.User
 type Relationship struct {
 	User *User  `json:"user"`
-	Type int    `json:"type"` // 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
+	Type uint8  `json:"type"` // 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
 	ID   string `json:"id"`
 }
 


### PR DESCRIPTION
Adds Support for:
  - Sending friend request.
  - Accepting friend request.
  - Getting all the relationships.
  - Getting all the mutual friends with another user.
  - Blocking a user.

**Note:**
  - Bot accounts are not allowed to access the endpoint.
  - May close bwmarrin/discordgo#150