### PR TITLE
Fix issue with trailing slashes in MacOS

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1380,6 +1380,7 @@ func (s *Session) VoiceICE() (st *VoiceICE, err error) {
 // ------------------------------------------------------------------------------------------------
 // Functions specific to Discord Websockets
 // ------------------------------------------------------------------------------------------------
+
 // Gateway returns the a websocket Gateway address
 func (s *Session) Gateway() (gateway string, err error) {
 

--- a/restapi.go
+++ b/restapi.go
@@ -1380,7 +1380,6 @@ func (s *Session) VoiceICE() (st *VoiceICE, err error) {
 // ------------------------------------------------------------------------------------------------
 // Functions specific to Discord Websockets
 // ------------------------------------------------------------------------------------------------
-
 // Gateway returns the a websocket Gateway address
 func (s *Session) Gateway() (gateway string, err error) {
 
@@ -1399,5 +1398,12 @@ func (s *Session) Gateway() (gateway string, err error) {
 	}
 
 	gateway = temp.URL
+
+	// Ensure the gateway always has a trailing slash.
+	// MacOS will fail to connect if we add query params without a trailing slash on the base domain.
+	if !strings.HasSuffix(gateway, "/") {
+		gateway += "/"
+	}
+
 	return
 }


### PR DESCRIPTION
I discovered that macOS will fail to resolve the gateway if there isn't a slash in between the domain and the query params.

At some point in time discord removed this trailing slash on the gateway api `https://discordapp.com/api/gateway`

 This PR ensures that the gateway always has a trailing slash.

For reference I was getting the following error before `dial tcp: lookup gateway.discord.gg?v=4&encoding=json: no such host`