### PR TITLE
Remove type checks for handlers.

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -70,8 +70,6 @@ func (eh channelCreateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = channelCreateEventHandler(nil)
-
 // channelDeleteEventHandler is an event handler for ChannelDelete events.
 type channelDeleteEventHandler func(*Session, *ChannelDelete)
 
@@ -91,8 +89,6 @@ func (eh channelDeleteEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = channelDeleteEventHandler(nil)
 
 // channelPinsUpdateEventHandler is an event handler for ChannelPinsUpdate events.
 type channelPinsUpdateEventHandler func(*Session, *ChannelPinsUpdate)
@@ -114,8 +110,6 @@ func (eh channelPinsUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = channelPinsUpdateEventHandler(nil)
-
 // channelUpdateEventHandler is an event handler for ChannelUpdate events.
 type channelUpdateEventHandler func(*Session, *ChannelUpdate)
 
@@ -136,8 +130,6 @@ func (eh channelUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = channelUpdateEventHandler(nil)
-
 // connectEventHandler is an event handler for Connect events.
 type connectEventHandler func(*Session, *Connect)
 
@@ -152,8 +144,6 @@ func (eh connectEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = connectEventHandler(nil)
 
 // disconnectEventHandler is an event handler for Disconnect events.
 type disconnectEventHandler func(*Session, *Disconnect)
@@ -170,8 +160,6 @@ func (eh disconnectEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = disconnectEventHandler(nil)
-
 // eventEventHandler is an event handler for Event events.
 type eventEventHandler func(*Session, *Event)
 
@@ -186,8 +174,6 @@ func (eh eventEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = eventEventHandler(nil)
 
 // guildBanAddEventHandler is an event handler for GuildBanAdd events.
 type guildBanAddEventHandler func(*Session, *GuildBanAdd)
@@ -209,8 +195,6 @@ func (eh guildBanAddEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = guildBanAddEventHandler(nil)
-
 // guildBanRemoveEventHandler is an event handler for GuildBanRemove events.
 type guildBanRemoveEventHandler func(*Session, *GuildBanRemove)
 
@@ -230,8 +214,6 @@ func (eh guildBanRemoveEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = guildBanRemoveEventHandler(nil)
 
 // guildCreateEventHandler is an event handler for GuildCreate events.
 type guildCreateEventHandler func(*Session, *GuildCreate)
@@ -253,8 +235,6 @@ func (eh guildCreateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = guildCreateEventHandler(nil)
-
 // guildDeleteEventHandler is an event handler for GuildDelete events.
 type guildDeleteEventHandler func(*Session, *GuildDelete)
 
@@ -274,8 +254,6 @@ func (eh guildDeleteEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = guildDeleteEventHandler(nil)
 
 // guildEmojisUpdateEventHandler is an event handler for GuildEmojisUpdate events.
 type guildEmojisUpdateEventHandler func(*Session, *GuildEmojisUpdate)
@@ -297,8 +275,6 @@ func (eh guildEmojisUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = guildEmojisUpdateEventHandler(nil)
-
 // guildIntegrationsUpdateEventHandler is an event handler for GuildIntegrationsUpdate events.
 type guildIntegrationsUpdateEventHandler func(*Session, *GuildIntegrationsUpdate)
 
@@ -318,8 +294,6 @@ func (eh guildIntegrationsUpdateEventHandler) Handle(s *Session, i interface{}) 
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = guildIntegrationsUpdateEventHandler(nil)
 
 // guildMemberAddEventHandler is an event handler for GuildMemberAdd events.
 type guildMemberAddEventHandler func(*Session, *GuildMemberAdd)
@@ -341,8 +315,6 @@ func (eh guildMemberAddEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = guildMemberAddEventHandler(nil)
-
 // guildMemberRemoveEventHandler is an event handler for GuildMemberRemove events.
 type guildMemberRemoveEventHandler func(*Session, *GuildMemberRemove)
 
@@ -362,8 +334,6 @@ func (eh guildMemberRemoveEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = guildMemberRemoveEventHandler(nil)
 
 // guildMemberUpdateEventHandler is an event handler for GuildMemberUpdate events.
 type guildMemberUpdateEventHandler func(*Session, *GuildMemberUpdate)
@@ -385,8 +355,6 @@ func (eh guildMemberUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = guildMemberUpdateEventHandler(nil)
-
 // guildMembersChunkEventHandler is an event handler for GuildMembersChunk events.
 type guildMembersChunkEventHandler func(*Session, *GuildMembersChunk)
 
@@ -406,8 +374,6 @@ func (eh guildMembersChunkEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = guildMembersChunkEventHandler(nil)
 
 // guildRoleCreateEventHandler is an event handler for GuildRoleCreate events.
 type guildRoleCreateEventHandler func(*Session, *GuildRoleCreate)
@@ -429,8 +395,6 @@ func (eh guildRoleCreateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = guildRoleCreateEventHandler(nil)
-
 // guildRoleDeleteEventHandler is an event handler for GuildRoleDelete events.
 type guildRoleDeleteEventHandler func(*Session, *GuildRoleDelete)
 
@@ -450,8 +414,6 @@ func (eh guildRoleDeleteEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = guildRoleDeleteEventHandler(nil)
 
 // guildRoleUpdateEventHandler is an event handler for GuildRoleUpdate events.
 type guildRoleUpdateEventHandler func(*Session, *GuildRoleUpdate)
@@ -473,8 +435,6 @@ func (eh guildRoleUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = guildRoleUpdateEventHandler(nil)
-
 // guildUpdateEventHandler is an event handler for GuildUpdate events.
 type guildUpdateEventHandler func(*Session, *GuildUpdate)
 
@@ -494,8 +454,6 @@ func (eh guildUpdateEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = guildUpdateEventHandler(nil)
 
 // messageAckEventHandler is an event handler for MessageAck events.
 type messageAckEventHandler func(*Session, *MessageAck)
@@ -517,8 +475,6 @@ func (eh messageAckEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = messageAckEventHandler(nil)
-
 // messageCreateEventHandler is an event handler for MessageCreate events.
 type messageCreateEventHandler func(*Session, *MessageCreate)
 
@@ -538,8 +494,6 @@ func (eh messageCreateEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = messageCreateEventHandler(nil)
 
 // messageDeleteEventHandler is an event handler for MessageDelete events.
 type messageDeleteEventHandler func(*Session, *MessageDelete)
@@ -561,8 +515,6 @@ func (eh messageDeleteEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = messageDeleteEventHandler(nil)
-
 // messageDeleteBulkEventHandler is an event handler for MessageDeleteBulk events.
 type messageDeleteBulkEventHandler func(*Session, *MessageDeleteBulk)
 
@@ -582,8 +534,6 @@ func (eh messageDeleteBulkEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = messageDeleteBulkEventHandler(nil)
 
 // messageReactionAddEventHandler is an event handler for MessageReactionAdd events.
 type messageReactionAddEventHandler func(*Session, *MessageReactionAdd)
@@ -605,8 +555,6 @@ func (eh messageReactionAddEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = messageReactionAddEventHandler(nil)
-
 // messageReactionRemoveEventHandler is an event handler for MessageReactionRemove events.
 type messageReactionRemoveEventHandler func(*Session, *MessageReactionRemove)
 
@@ -626,8 +574,6 @@ func (eh messageReactionRemoveEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = messageReactionRemoveEventHandler(nil)
 
 // messageUpdateEventHandler is an event handler for MessageUpdate events.
 type messageUpdateEventHandler func(*Session, *MessageUpdate)
@@ -649,8 +595,6 @@ func (eh messageUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = messageUpdateEventHandler(nil)
-
 // presenceUpdateEventHandler is an event handler for PresenceUpdate events.
 type presenceUpdateEventHandler func(*Session, *PresenceUpdate)
 
@@ -670,8 +614,6 @@ func (eh presenceUpdateEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = presenceUpdateEventHandler(nil)
 
 // presencesReplaceEventHandler is an event handler for PresencesReplace events.
 type presencesReplaceEventHandler func(*Session, *PresencesReplace)
@@ -693,8 +635,6 @@ func (eh presencesReplaceEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = presencesReplaceEventHandler(nil)
-
 // rateLimitEventHandler is an event handler for RateLimit events.
 type rateLimitEventHandler func(*Session, *RateLimit)
 
@@ -709,8 +649,6 @@ func (eh rateLimitEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = rateLimitEventHandler(nil)
 
 // readyEventHandler is an event handler for Ready events.
 type readyEventHandler func(*Session, *Ready)
@@ -732,8 +670,6 @@ func (eh readyEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = readyEventHandler(nil)
-
 // relationshipAddEventHandler is an event handler for RelationshipAdd events.
 type relationshipAddEventHandler func(*Session, *RelationshipAdd)
 
@@ -753,8 +689,6 @@ func (eh relationshipAddEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = relationshipAddEventHandler(nil)
 
 // relationshipRemoveEventHandler is an event handler for RelationshipRemove events.
 type relationshipRemoveEventHandler func(*Session, *RelationshipRemove)
@@ -776,8 +710,6 @@ func (eh relationshipRemoveEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = relationshipRemoveEventHandler(nil)
-
 // resumedEventHandler is an event handler for Resumed events.
 type resumedEventHandler func(*Session, *Resumed)
 
@@ -797,8 +729,6 @@ func (eh resumedEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = resumedEventHandler(nil)
 
 // typingStartEventHandler is an event handler for TypingStart events.
 type typingStartEventHandler func(*Session, *TypingStart)
@@ -820,8 +750,6 @@ func (eh typingStartEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = typingStartEventHandler(nil)
-
 // userGuildSettingsUpdateEventHandler is an event handler for UserGuildSettingsUpdate events.
 type userGuildSettingsUpdateEventHandler func(*Session, *UserGuildSettingsUpdate)
 
@@ -841,8 +769,6 @@ func (eh userGuildSettingsUpdateEventHandler) Handle(s *Session, i interface{}) 
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = userGuildSettingsUpdateEventHandler(nil)
 
 // userSettingsUpdateEventHandler is an event handler for UserSettingsUpdate events.
 type userSettingsUpdateEventHandler func(*Session, *UserSettingsUpdate)
@@ -864,8 +790,6 @@ func (eh userSettingsUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = userSettingsUpdateEventHandler(nil)
-
 // userUpdateEventHandler is an event handler for UserUpdate events.
 type userUpdateEventHandler func(*Session, *UserUpdate)
 
@@ -885,8 +809,6 @@ func (eh userUpdateEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = userUpdateEventHandler(nil)
 
 // voiceServerUpdateEventHandler is an event handler for VoiceServerUpdate events.
 type voiceServerUpdateEventHandler func(*Session, *VoiceServerUpdate)
@@ -908,8 +830,6 @@ func (eh voiceServerUpdateEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
-var _ EventHandler = voiceServerUpdateEventHandler(nil)
-
 // voiceStateUpdateEventHandler is an event handler for VoiceStateUpdate events.
 type voiceStateUpdateEventHandler func(*Session, *VoiceStateUpdate)
 
@@ -929,8 +849,6 @@ func (eh voiceStateUpdateEventHandler) Handle(s *Session, i interface{}) {
 		eh(s, t)
 	}
 }
-
-var _ EventHandler = voiceStateUpdateEventHandler(nil)
 
 func handlerForInterface(handler interface{}) EventHandler {
 	switch v := handler.(type) {

--- a/tools/cmd/eventhandlers/main.go
+++ b/tools/cmd/eventhandlers/main.go
@@ -49,7 +49,6 @@ func (eh {{privateName .}}EventHandler) Handle(s *Session, i interface{}) {
   }
 }
 
-var _ EventHandler = {{privateName .}}EventHandler(nil)
 {{end}}
 func handlerForInterface(handler interface{}) EventHandler {
   switch v := handler.(type) {


### PR DESCRIPTION
 it's done implicitly in the handlerForInterface call.