### PR TITLE
Fix leaking tickers

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -479,6 +479,7 @@ func (v *VoiceConnection) wsHeartbeat(wsConn *websocket.Conn, close <-chan struc
 
 	var err error
 	ticker := time.NewTicker(i * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		v.log(LogDebug, "sending heartbeat packet")
 		v.wsMutex.Lock()
@@ -629,6 +630,7 @@ func (v *VoiceConnection) udpKeepAlive(udpConn *net.UDPConn, close <-chan struct
 	packet := make([]byte, 8)
 
 	ticker := time.NewTicker(i)
+	defer ticker.Stop()
 	for {
 
 		binary.LittleEndian.PutUint64(packet, sequence)
@@ -684,6 +686,7 @@ func (v *VoiceConnection) opusSender(udpConn *net.UDPConn, close <-chan struct{}
 
 	// start a send loop that loops until buf chan is closed
 	ticker := time.NewTicker(time.Millisecond * time.Duration(size/(rate/1000)))
+	defer ticker.Stop()
 	for {
 
 		// Get data from chan.  If chan is closed, return.

--- a/wsapi.go
+++ b/wsapi.go
@@ -200,6 +200,7 @@ func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}
 
 	var err error
 	ticker := time.NewTicker(i * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
 		sequence := atomic.LoadInt64(s.sequence)


### PR DESCRIPTION
This was noticeable in stuff like music bots creating a lot of voice connections, more and more cpu will be consumed by the neverending tickers