### PR TITLE
add ChannelEditTopic and ChannelEditObject

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1187,6 +1187,41 @@ func (s *Session) ChannelEdit(channelID, name string) (st *Channel, err error) {
 	return
 }
 
+// ChannelEditTopic edits the given channel
+// channelID  : The ID of a Channel
+// topic       : The new topic to assign the channel.
+func (s *Session) ChannelEditTopic(channelID, topic string) (st *Channel, err error) {
+
+	data := struct {
+		Topic string `json:"topic"`
+	}{topic}
+
+	body, err := s.RequestWithBucketID("PATCH", EndpointChannel(channelID), data, EndpointChannel(channelID))
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
+// ChannelEditObject Edit channel from structure.
+// channelID  : The ID of a Channel
+// object : The channel object
+func (s *Session) ChannelEditObject(channelID string, object interface{}) (st *Channel, err error) {
+	if object == nil {
+		return
+	}
+
+	body, err := s.RequestWithBucketID("PATCH", EndpointChannel(channelID), object, EndpointChannel(channelID))
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
 // ChannelDelete deletes the given channel
 // channelID  : The ID of a Channel
 func (s *Session) ChannelDelete(channelID string) (st *Channel, err error) {


### PR DESCRIPTION
ChannelEditObject allows developers to have more freedom when editing channels.
ChannelEditTopic allows developers to change the channel topic.