### PR TITLE
UserAvatar to accept user object.

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -264,7 +264,7 @@ func (s *Session) User(userID string) (st *User, err error) {
 	return
 }
 
-// UserAvatar returns an image.Image of a users Avatar.
+// Deprecated. Please use UserAvatarDecode
 // userID    : A user ID or "@me" which is a shortcut of current user ID
 func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 	u, err := s.User(userID)
@@ -272,6 +272,13 @@ func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 		return
 	}
 
+	img, err := UserAvatarDecode(u)
+	return
+}
+
+// UserAvatarDecode returns an image.Image of a users Avatar.
+// user : The user which avatar should be retrieved.
+func (s *Session) UserAvatarDecode(u *discordgo.User) (img image.Image, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(userID, u.Avatar), nil, EndpointUserAvatar("", ""))
 	if err != nil {
 		return

--- a/restapi.go
+++ b/restapi.go
@@ -272,11 +272,11 @@ func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 		return
 	}
 
-	img, err := UserAvatarDecode(u)
+	img, err = s.UserAvatarDecode(u)
 	return
 }
 
-// UserAvatarDecode returns an image.Image of a users Avatar.
+// UserAvatarDecode returns an image.Image of a user's Avatar.
 // user : The user which avatar should be retrieved.
 func (s *Session) UserAvatarDecode(u *discordgo.User) (img image.Image, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(userID, u.Avatar), nil, EndpointUserAvatar("", ""))

--- a/restapi.go
+++ b/restapi.go
@@ -278,8 +278,8 @@ func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 
 // UserAvatarDecode returns an image.Image of a user's Avatar.
 // user : The user which avatar should be retrieved.
-func (s *Session) UserAvatarDecode(u *discordgo.User) (img image.Image, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(userID, u.Avatar), nil, EndpointUserAvatar("", ""))
+func (s *Session) UserAvatarDecode(u *User) (img image.Image, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(u.ID, u.Avatar), nil, EndpointUserAvatar("", ""))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
One of the most important thing with this library is that it does 1 request per function. You have 100% control over how many web requests get made.
UserAvatar breaks that.

UserAvatar now accepts a user, which not only makes you know how many web requests gets made, but might also save on web requests if you have an existing user object.