### PR TITLE
Fix README format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img align="right" src="http://bwmarrin.github.io/discordgo/img/discordgo.png">
 DiscordGo 
 ====
+
 [![GoDoc](https://godoc.org/github.com/bwmarrin/discordgo?status.svg)](https://godoc.org/github.com/bwmarrin/discordgo) [![Go report](http://goreportcard.com/badge/bwmarrin/discordgo)](http://goreportcard.com/report/bwmarrin/discordgo) [![Build Status](https://travis-ci.org/bwmarrin/discordgo.svg?branch=master)](https://travis-ci.org/bwmarrin/discordgo) 
 [![Discord Gophers](https://img.shields.io/badge/Discord%20Gophers-%23discordgo-blue.svg)](https://discord.gg/0f1SbxBZjYoCtNPP) [![Discord API](https://img.shields.io/badge/Discord%20API-%23go_discordgo-blue.svg)](https://discord.gg/0SBTUU1wZTWT6sqd)
 


### PR DESCRIPTION
Weirdly enough, the README was getting out of wack, probably due to the minor GitHub markdown changes that happened recently:

https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown

Anyhow, this is how it was looking before on the web:

![format](https://cloud.githubusercontent.com/assets/1459320/24390264/76a49524-134d-11e7-9100-3cfdd27317a9.PNG)

And adding that single line break seems to fix it. :stuck_out_tongue: 