### PR TITLE
ChannelMessageSendComplex

### DIFF
--- a/message.go
+++ b/message.go
@@ -36,7 +36,7 @@ type MessageSend struct {
 	Content string        `json:"content"`
 	Tts     bool          `json:"tts"`
 	Embed   *MessageEmbed `json:"embed"`
-	Nounce  string        `json:"nounce"`
+	Nonce   string        `json:"nonce"`
 }
 
 // MessageEdit stores all parameters you can send with ChannelMessageSendComplex.

--- a/message.go
+++ b/message.go
@@ -31,6 +31,14 @@ type Message struct {
 	Reactions       []*MessageReactions  `json:"reactions"`
 }
 
+// A MessageSend stores all parameters you can send with ChannelMessageSendComplex.
+type MessageSend struct {
+	Content string        `json:"content"`
+	Tts     bool          `json:"tts"`
+	Embed   *MessageEmbed `json:"embed"`
+	Nounce  string        `json:"nounce"`
+}
+
 // A MessageAttachment stores data for message attachments.
 type MessageAttachment struct {
 	ID       string `json:"id"`

--- a/message.go
+++ b/message.go
@@ -31,12 +31,18 @@ type Message struct {
 	Reactions       []*MessageReactions  `json:"reactions"`
 }
 
-// A MessageSend stores all parameters you can send with ChannelMessageSendComplex.
+// MessageSend stores all parameters you can send with ChannelMessageSendComplex.
 type MessageSend struct {
 	Content string        `json:"content"`
 	Tts     bool          `json:"tts"`
 	Embed   *MessageEmbed `json:"embed"`
 	Nounce  string        `json:"nounce"`
+}
+
+// MessageEdit stores all parameters you can send with ChannelMessageSendComplex.
+type MessageEdit struct {
+	Content string        `json:"content"`
+	Embed   *MessageEmbed `json:"embed"`
 }
 
 // A MessageAttachment stores data for message attachments.

--- a/restapi.go
+++ b/restapi.go
@@ -1319,14 +1319,6 @@ func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed)
 	return s.ChannelMessageSendEmbedWithMessage(channelID, "", embed)
 }
 
-// ChannelMessageSendEmbedWithMessage sends a message to the given channel with embedded data and a message.
-// channelID : The ID of a Channel.
-// content   : The message to send.
-// embed     : The embed data to send.
-func (s *Session) ChannelMessageSendEmbedWithMessage(channelID string, content string, embed *MessageEmbed) (*Message, error) {
-	return s.ChannelMessageSendComplex(channelID, &MessageSend{Content: content, Embed: embed})
-}
-
 // ChannelMessageEdit edits an existing message, replacing it entirely with
 // the given content.
 // channeld  : The ID of a Channel

--- a/restapi.go
+++ b/restapi.go
@@ -1316,7 +1316,7 @@ func (s *Session) ChannelMessageSendTTS(channelID string, content string) (*Mess
 // channelID : The ID of a Channel.
 // embed     : The embed data to send.
 func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed) (*Message, error) {
-	return s.ChannelMessageSendEmbedWithMessage(channelID, "", embed)
+	return s.ChannelMessageSendComplex(channelID, &MessageSend{Embed: embed})
 }
 
 // ChannelMessageEdit edits an existing message, replacing it entirely with

--- a/restapi.go
+++ b/restapi.go
@@ -1284,18 +1284,18 @@ func (s *Session) ChannelMessageAck(channelID, messageID, lastToken string) (st 
 // ChannelMessageSend sends a message to the given channel.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSend(channelID string, content string) (st *Message, err error) {
+func (s *Session) ChannelMessageSend(channelID string, content string) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{Content: content})
 }
 
 // ChannelMessageSendComplex sends a message to the given channel.
 // channelID : The ID of a Channel.
-// message   : The message struct to send.
+// data      : The message struct to send.
 func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend) (st *Message, err error) {
 	if data.Embed != nil && data.Embed.Type == "" {
 		data.Embed.Type = "rich"
 	}
-	// Send the message to the given channel
+
 	response, err := s.RequestWithBucketID("POST", EndpointChannelMessages(channelID), data, EndpointChannelMessages(channelID))
 	if err != nil {
 		return
@@ -1308,14 +1308,14 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 // ChannelMessageSendTTS sends a message to the given channel with Text to Speech.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSendTTS(channelID string, content string) (st *Message, err error) {
+func (s *Session) ChannelMessageSendTTS(channelID string, content string) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{Content: content, Tts: true})
 }
 
 // ChannelMessageSendEmbed sends a message to the given channel with embedded data.
 // channelID : The ID of a Channel.
 // embed     : The embed data to send.
-func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed) (st *Message, err error) {
+func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed) (*Message, error) {
 	return s.ChannelMessageSendEmbedWithMessage(channelID, "", embed)
 }
 
@@ -1323,19 +1323,28 @@ func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed)
 // channelID : The ID of a Channel.
 // content   : The message to send.
 // embed     : The embed data to send.
-func (s *Session) ChannelMessageSendEmbedWithMessage(channelID string, content string, embed *MessageEmbed) (st *Message, err error) {
+func (s *Session) ChannelMessageSendEmbedWithMessage(channelID string, content string, embed *MessageEmbed) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{Content: content, Embed: embed})
 }
 
 // ChannelMessageEdit edits an existing message, replacing it entirely with
 // the given content.
 // channeld  : The ID of a Channel
-// messageID : the ID of a Message
-func (s *Session) ChannelMessageEdit(channelID, messageID, content string) (st *Message, err error) {
+// messageID : The ID of a Message
+// content   : The contents of the message
+func (s *Session) ChannelMessageEdit(channelID, messageID, content string) (*Message, error) {
+	return s.ChannelMessageEditComplex(channelID, messageID, &MessageEdit{Content: content})
+}
 
-	data := struct {
-		Content string `json:"content"`
-	}{content}
+// ChannelMessageEditComplex edits an existing message, replacing it entirely with
+// the given MessageEdit struct
+// channeld  : The ID of a Channel
+// messageID : The ID of a Message
+// data      : The MessageEdit struct to send
+func (s *Session) ChannelMessageEditComplex(channelID, messageID string, data *MessageEdit) (st *Message, err error) {
+	if data.Embed != nil && data.Embed.Type == "" {
+		data.Embed.Type = "rich"
+	}
 
 	response, err := s.RequestWithBucketID("PATCH", EndpointChannelMessage(channelID, messageID), data, EndpointChannelMessage(channelID, ""))
 	if err != nil {
@@ -1350,22 +1359,8 @@ func (s *Session) ChannelMessageEdit(channelID, messageID, content string) (st *
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
 // embed     : The embed data to send
-func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed) (st *Message, err error) {
-	if embed != nil && embed.Type == "" {
-		embed.Type = "rich"
-	}
-
-	data := struct {
-		Embed *MessageEmbed `json:"embed"`
-	}{embed}
-
-	response, err := s.RequestWithBucketID("PATCH", EndpointChannelMessage(channelID, messageID), data, EndpointChannelMessage(channelID, ""))
-	if err != nil {
-		return
-	}
-
-	err = unmarshal(response, &st)
-	return
+func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed) (*Message, error) {
+	return s.ChannelMessageEditComplex(channelID, messageID, &MessageEdit{Embed: embed})
 }
 
 // ChannelMessageDelete deletes a message from the Channel.


### PR DESCRIPTION
I was getting tired of all the ChannelMessageSendThisWithThisAndThisAndThis.  
So, well, this is my solution.

I kept the others for compatibility. And `ChannelMessageSend` should always be kept for ease of use.

Anyways, I'm unsure whether I should also include `ChannelFileSend` in this as well. It'd certainly be useful (sending embeds and files together, maybe).  
But that's for later.