### PR TITLE
Fix airhorn example

### DIFF
--- a/examples/airhorn/main.go
+++ b/examples/airhorn/main.go
@@ -132,7 +132,7 @@ func loadSound() error {
 		// If this is the end of the file, just return.
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			file.Close()
-			if err != nil {
+			if err != nil && err != io.EOF {
 				return err
 			}
 			return nil


### PR DESCRIPTION
The current example instantly throws an error because it returns err on EOF.