### PR TITLE
Fix typo in description of VERSION constant

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -15,7 +15,7 @@ package discordgo
 
 import "fmt"
 
-// VERSION of Discordgo, follows Symantic Versioning. (http://semver.org/)
+// VERSION of Discordgo, follows Semantic Versioning. (http://semver.org/)
 const VERSION = "0.15.0"
 
 // New creates a new Discord session and will automate some startup


### PR DESCRIPTION
It is called 'Semantic Versioning' and I thought it's a typo worth fixing.