### PR TITLE
Support for passing contexts to handlers

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -3,6 +3,10 @@
 
 package discordgo
 
+import (
+	"context"
+)
+
 // Following are all the event types.
 // Event type values are used to match the events returned by Discord.
 // EventTypes surrounded by __ are synthetic and are internal to DiscordGo.
@@ -53,7 +57,7 @@ const (
 )
 
 // channelCreateEventHandler is an event handler for ChannelCreate events.
-type channelCreateEventHandler func(*Session, *ChannelCreate)
+type channelCreateEventHandler func(*Session, *ChannelCreate, context.Context)
 
 // Type returns the event type for ChannelCreate events.
 func (eh channelCreateEventHandler) Type() string {
@@ -66,14 +70,14 @@ func (eh channelCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelCreate events.
-func (eh channelCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelCreateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*ChannelCreate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // channelDeleteEventHandler is an event handler for ChannelDelete events.
-type channelDeleteEventHandler func(*Session, *ChannelDelete)
+type channelDeleteEventHandler func(*Session, *ChannelDelete, context.Context)
 
 // Type returns the event type for ChannelDelete events.
 func (eh channelDeleteEventHandler) Type() string {
@@ -86,14 +90,14 @@ func (eh channelDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelDelete events.
-func (eh channelDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelDeleteEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*ChannelDelete); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // channelPinsUpdateEventHandler is an event handler for ChannelPinsUpdate events.
-type channelPinsUpdateEventHandler func(*Session, *ChannelPinsUpdate)
+type channelPinsUpdateEventHandler func(*Session, *ChannelPinsUpdate, context.Context)
 
 // Type returns the event type for ChannelPinsUpdate events.
 func (eh channelPinsUpdateEventHandler) Type() string {
@@ -106,14 +110,14 @@ func (eh channelPinsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelPinsUpdate events.
-func (eh channelPinsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelPinsUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*ChannelPinsUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // channelUpdateEventHandler is an event handler for ChannelUpdate events.
-type channelUpdateEventHandler func(*Session, *ChannelUpdate)
+type channelUpdateEventHandler func(*Session, *ChannelUpdate, context.Context)
 
 // Type returns the event type for ChannelUpdate events.
 func (eh channelUpdateEventHandler) Type() string {
@@ -126,14 +130,14 @@ func (eh channelUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelUpdate events.
-func (eh channelUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*ChannelUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // connectEventHandler is an event handler for Connect events.
-type connectEventHandler func(*Session, *Connect)
+type connectEventHandler func(*Session, *Connect, context.Context)
 
 // Type returns the event type for Connect events.
 func (eh connectEventHandler) Type() string {
@@ -141,14 +145,14 @@ func (eh connectEventHandler) Type() string {
 }
 
 // Handle is the handler for Connect events.
-func (eh connectEventHandler) Handle(s *Session, i interface{}) {
+func (eh connectEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*Connect); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // disconnectEventHandler is an event handler for Disconnect events.
-type disconnectEventHandler func(*Session, *Disconnect)
+type disconnectEventHandler func(*Session, *Disconnect, context.Context)
 
 // Type returns the event type for Disconnect events.
 func (eh disconnectEventHandler) Type() string {
@@ -156,14 +160,14 @@ func (eh disconnectEventHandler) Type() string {
 }
 
 // Handle is the handler for Disconnect events.
-func (eh disconnectEventHandler) Handle(s *Session, i interface{}) {
+func (eh disconnectEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*Disconnect); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // eventEventHandler is an event handler for Event events.
-type eventEventHandler func(*Session, *Event)
+type eventEventHandler func(*Session, *Event, context.Context)
 
 // Type returns the event type for Event events.
 func (eh eventEventHandler) Type() string {
@@ -171,14 +175,14 @@ func (eh eventEventHandler) Type() string {
 }
 
 // Handle is the handler for Event events.
-func (eh eventEventHandler) Handle(s *Session, i interface{}) {
+func (eh eventEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*Event); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildBanAddEventHandler is an event handler for GuildBanAdd events.
-type guildBanAddEventHandler func(*Session, *GuildBanAdd)
+type guildBanAddEventHandler func(*Session, *GuildBanAdd, context.Context)
 
 // Type returns the event type for GuildBanAdd events.
 func (eh guildBanAddEventHandler) Type() string {
@@ -191,14 +195,14 @@ func (eh guildBanAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildBanAdd events.
-func (eh guildBanAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildBanAddEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildBanAdd); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildBanRemoveEventHandler is an event handler for GuildBanRemove events.
-type guildBanRemoveEventHandler func(*Session, *GuildBanRemove)
+type guildBanRemoveEventHandler func(*Session, *GuildBanRemove, context.Context)
 
 // Type returns the event type for GuildBanRemove events.
 func (eh guildBanRemoveEventHandler) Type() string {
@@ -211,14 +215,14 @@ func (eh guildBanRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildBanRemove events.
-func (eh guildBanRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildBanRemoveEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildBanRemove); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildCreateEventHandler is an event handler for GuildCreate events.
-type guildCreateEventHandler func(*Session, *GuildCreate)
+type guildCreateEventHandler func(*Session, *GuildCreate, context.Context)
 
 // Type returns the event type for GuildCreate events.
 func (eh guildCreateEventHandler) Type() string {
@@ -231,14 +235,14 @@ func (eh guildCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildCreate events.
-func (eh guildCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildCreateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildCreate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildDeleteEventHandler is an event handler for GuildDelete events.
-type guildDeleteEventHandler func(*Session, *GuildDelete)
+type guildDeleteEventHandler func(*Session, *GuildDelete, context.Context)
 
 // Type returns the event type for GuildDelete events.
 func (eh guildDeleteEventHandler) Type() string {
@@ -251,14 +255,14 @@ func (eh guildDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildDelete events.
-func (eh guildDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildDeleteEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildDelete); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildEmojisUpdateEventHandler is an event handler for GuildEmojisUpdate events.
-type guildEmojisUpdateEventHandler func(*Session, *GuildEmojisUpdate)
+type guildEmojisUpdateEventHandler func(*Session, *GuildEmojisUpdate, context.Context)
 
 // Type returns the event type for GuildEmojisUpdate events.
 func (eh guildEmojisUpdateEventHandler) Type() string {
@@ -271,14 +275,14 @@ func (eh guildEmojisUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildEmojisUpdate events.
-func (eh guildEmojisUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildEmojisUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildEmojisUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildIntegrationsUpdateEventHandler is an event handler for GuildIntegrationsUpdate events.
-type guildIntegrationsUpdateEventHandler func(*Session, *GuildIntegrationsUpdate)
+type guildIntegrationsUpdateEventHandler func(*Session, *GuildIntegrationsUpdate, context.Context)
 
 // Type returns the event type for GuildIntegrationsUpdate events.
 func (eh guildIntegrationsUpdateEventHandler) Type() string {
@@ -291,14 +295,14 @@ func (eh guildIntegrationsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildIntegrationsUpdate events.
-func (eh guildIntegrationsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildIntegrationsUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildIntegrationsUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildMemberAddEventHandler is an event handler for GuildMemberAdd events.
-type guildMemberAddEventHandler func(*Session, *GuildMemberAdd)
+type guildMemberAddEventHandler func(*Session, *GuildMemberAdd, context.Context)
 
 // Type returns the event type for GuildMemberAdd events.
 func (eh guildMemberAddEventHandler) Type() string {
@@ -311,14 +315,14 @@ func (eh guildMemberAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMemberAdd events.
-func (eh guildMemberAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMemberAddEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildMemberAdd); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildMemberRemoveEventHandler is an event handler for GuildMemberRemove events.
-type guildMemberRemoveEventHandler func(*Session, *GuildMemberRemove)
+type guildMemberRemoveEventHandler func(*Session, *GuildMemberRemove, context.Context)
 
 // Type returns the event type for GuildMemberRemove events.
 func (eh guildMemberRemoveEventHandler) Type() string {
@@ -331,14 +335,14 @@ func (eh guildMemberRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMemberRemove events.
-func (eh guildMemberRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMemberRemoveEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildMemberRemove); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildMemberUpdateEventHandler is an event handler for GuildMemberUpdate events.
-type guildMemberUpdateEventHandler func(*Session, *GuildMemberUpdate)
+type guildMemberUpdateEventHandler func(*Session, *GuildMemberUpdate, context.Context)
 
 // Type returns the event type for GuildMemberUpdate events.
 func (eh guildMemberUpdateEventHandler) Type() string {
@@ -351,14 +355,14 @@ func (eh guildMemberUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMemberUpdate events.
-func (eh guildMemberUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMemberUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildMemberUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildMembersChunkEventHandler is an event handler for GuildMembersChunk events.
-type guildMembersChunkEventHandler func(*Session, *GuildMembersChunk)
+type guildMembersChunkEventHandler func(*Session, *GuildMembersChunk, context.Context)
 
 // Type returns the event type for GuildMembersChunk events.
 func (eh guildMembersChunkEventHandler) Type() string {
@@ -371,14 +375,14 @@ func (eh guildMembersChunkEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMembersChunk events.
-func (eh guildMembersChunkEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMembersChunkEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildMembersChunk); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildRoleCreateEventHandler is an event handler for GuildRoleCreate events.
-type guildRoleCreateEventHandler func(*Session, *GuildRoleCreate)
+type guildRoleCreateEventHandler func(*Session, *GuildRoleCreate, context.Context)
 
 // Type returns the event type for GuildRoleCreate events.
 func (eh guildRoleCreateEventHandler) Type() string {
@@ -391,14 +395,14 @@ func (eh guildRoleCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildRoleCreate events.
-func (eh guildRoleCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildRoleCreateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildRoleCreate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildRoleDeleteEventHandler is an event handler for GuildRoleDelete events.
-type guildRoleDeleteEventHandler func(*Session, *GuildRoleDelete)
+type guildRoleDeleteEventHandler func(*Session, *GuildRoleDelete, context.Context)
 
 // Type returns the event type for GuildRoleDelete events.
 func (eh guildRoleDeleteEventHandler) Type() string {
@@ -411,14 +415,14 @@ func (eh guildRoleDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildRoleDelete events.
-func (eh guildRoleDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildRoleDeleteEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildRoleDelete); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildRoleUpdateEventHandler is an event handler for GuildRoleUpdate events.
-type guildRoleUpdateEventHandler func(*Session, *GuildRoleUpdate)
+type guildRoleUpdateEventHandler func(*Session, *GuildRoleUpdate, context.Context)
 
 // Type returns the event type for GuildRoleUpdate events.
 func (eh guildRoleUpdateEventHandler) Type() string {
@@ -431,14 +435,14 @@ func (eh guildRoleUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildRoleUpdate events.
-func (eh guildRoleUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildRoleUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildRoleUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // guildUpdateEventHandler is an event handler for GuildUpdate events.
-type guildUpdateEventHandler func(*Session, *GuildUpdate)
+type guildUpdateEventHandler func(*Session, *GuildUpdate, context.Context)
 
 // Type returns the event type for GuildUpdate events.
 func (eh guildUpdateEventHandler) Type() string {
@@ -451,14 +455,14 @@ func (eh guildUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildUpdate events.
-func (eh guildUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*GuildUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageAckEventHandler is an event handler for MessageAck events.
-type messageAckEventHandler func(*Session, *MessageAck)
+type messageAckEventHandler func(*Session, *MessageAck, context.Context)
 
 // Type returns the event type for MessageAck events.
 func (eh messageAckEventHandler) Type() string {
@@ -471,14 +475,14 @@ func (eh messageAckEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageAck events.
-func (eh messageAckEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageAckEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageAck); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageCreateEventHandler is an event handler for MessageCreate events.
-type messageCreateEventHandler func(*Session, *MessageCreate)
+type messageCreateEventHandler func(*Session, *MessageCreate, context.Context)
 
 // Type returns the event type for MessageCreate events.
 func (eh messageCreateEventHandler) Type() string {
@@ -491,14 +495,14 @@ func (eh messageCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageCreate events.
-func (eh messageCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageCreateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageCreate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageDeleteEventHandler is an event handler for MessageDelete events.
-type messageDeleteEventHandler func(*Session, *MessageDelete)
+type messageDeleteEventHandler func(*Session, *MessageDelete, context.Context)
 
 // Type returns the event type for MessageDelete events.
 func (eh messageDeleteEventHandler) Type() string {
@@ -511,14 +515,14 @@ func (eh messageDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageDelete events.
-func (eh messageDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageDeleteEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageDelete); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageDeleteBulkEventHandler is an event handler for MessageDeleteBulk events.
-type messageDeleteBulkEventHandler func(*Session, *MessageDeleteBulk)
+type messageDeleteBulkEventHandler func(*Session, *MessageDeleteBulk, context.Context)
 
 // Type returns the event type for MessageDeleteBulk events.
 func (eh messageDeleteBulkEventHandler) Type() string {
@@ -531,14 +535,14 @@ func (eh messageDeleteBulkEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageDeleteBulk events.
-func (eh messageDeleteBulkEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageDeleteBulkEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageDeleteBulk); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageReactionAddEventHandler is an event handler for MessageReactionAdd events.
-type messageReactionAddEventHandler func(*Session, *MessageReactionAdd)
+type messageReactionAddEventHandler func(*Session, *MessageReactionAdd, context.Context)
 
 // Type returns the event type for MessageReactionAdd events.
 func (eh messageReactionAddEventHandler) Type() string {
@@ -551,14 +555,14 @@ func (eh messageReactionAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageReactionAdd events.
-func (eh messageReactionAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageReactionAddEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageReactionAdd); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageReactionRemoveEventHandler is an event handler for MessageReactionRemove events.
-type messageReactionRemoveEventHandler func(*Session, *MessageReactionRemove)
+type messageReactionRemoveEventHandler func(*Session, *MessageReactionRemove, context.Context)
 
 // Type returns the event type for MessageReactionRemove events.
 func (eh messageReactionRemoveEventHandler) Type() string {
@@ -571,14 +575,14 @@ func (eh messageReactionRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageReactionRemove events.
-func (eh messageReactionRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageReactionRemoveEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageReactionRemove); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageReactionRemoveAllEventHandler is an event handler for MessageReactionRemoveAll events.
-type messageReactionRemoveAllEventHandler func(*Session, *MessageReactionRemoveAll)
+type messageReactionRemoveAllEventHandler func(*Session, *MessageReactionRemoveAll, context.Context)
 
 // Type returns the event type for MessageReactionRemoveAll events.
 func (eh messageReactionRemoveAllEventHandler) Type() string {
@@ -591,14 +595,14 @@ func (eh messageReactionRemoveAllEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageReactionRemoveAll events.
-func (eh messageReactionRemoveAllEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageReactionRemoveAllEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageReactionRemoveAll); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // messageUpdateEventHandler is an event handler for MessageUpdate events.
-type messageUpdateEventHandler func(*Session, *MessageUpdate)
+type messageUpdateEventHandler func(*Session, *MessageUpdate, context.Context)
 
 // Type returns the event type for MessageUpdate events.
 func (eh messageUpdateEventHandler) Type() string {
@@ -611,14 +615,14 @@ func (eh messageUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageUpdate events.
-func (eh messageUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*MessageUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // presenceUpdateEventHandler is an event handler for PresenceUpdate events.
-type presenceUpdateEventHandler func(*Session, *PresenceUpdate)
+type presenceUpdateEventHandler func(*Session, *PresenceUpdate, context.Context)
 
 // Type returns the event type for PresenceUpdate events.
 func (eh presenceUpdateEventHandler) Type() string {
@@ -631,14 +635,14 @@ func (eh presenceUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for PresenceUpdate events.
-func (eh presenceUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh presenceUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*PresenceUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // presencesReplaceEventHandler is an event handler for PresencesReplace events.
-type presencesReplaceEventHandler func(*Session, *PresencesReplace)
+type presencesReplaceEventHandler func(*Session, *PresencesReplace, context.Context)
 
 // Type returns the event type for PresencesReplace events.
 func (eh presencesReplaceEventHandler) Type() string {
@@ -651,14 +655,14 @@ func (eh presencesReplaceEventHandler) New() interface{} {
 }
 
 // Handle is the handler for PresencesReplace events.
-func (eh presencesReplaceEventHandler) Handle(s *Session, i interface{}) {
+func (eh presencesReplaceEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*PresencesReplace); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // rateLimitEventHandler is an event handler for RateLimit events.
-type rateLimitEventHandler func(*Session, *RateLimit)
+type rateLimitEventHandler func(*Session, *RateLimit, context.Context)
 
 // Type returns the event type for RateLimit events.
 func (eh rateLimitEventHandler) Type() string {
@@ -666,14 +670,14 @@ func (eh rateLimitEventHandler) Type() string {
 }
 
 // Handle is the handler for RateLimit events.
-func (eh rateLimitEventHandler) Handle(s *Session, i interface{}) {
+func (eh rateLimitEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*RateLimit); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // readyEventHandler is an event handler for Ready events.
-type readyEventHandler func(*Session, *Ready)
+type readyEventHandler func(*Session, *Ready, context.Context)
 
 // Type returns the event type for Ready events.
 func (eh readyEventHandler) Type() string {
@@ -686,14 +690,14 @@ func (eh readyEventHandler) New() interface{} {
 }
 
 // Handle is the handler for Ready events.
-func (eh readyEventHandler) Handle(s *Session, i interface{}) {
+func (eh readyEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*Ready); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // relationshipAddEventHandler is an event handler for RelationshipAdd events.
-type relationshipAddEventHandler func(*Session, *RelationshipAdd)
+type relationshipAddEventHandler func(*Session, *RelationshipAdd, context.Context)
 
 // Type returns the event type for RelationshipAdd events.
 func (eh relationshipAddEventHandler) Type() string {
@@ -706,14 +710,14 @@ func (eh relationshipAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for RelationshipAdd events.
-func (eh relationshipAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh relationshipAddEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*RelationshipAdd); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // relationshipRemoveEventHandler is an event handler for RelationshipRemove events.
-type relationshipRemoveEventHandler func(*Session, *RelationshipRemove)
+type relationshipRemoveEventHandler func(*Session, *RelationshipRemove, context.Context)
 
 // Type returns the event type for RelationshipRemove events.
 func (eh relationshipRemoveEventHandler) Type() string {
@@ -726,14 +730,14 @@ func (eh relationshipRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for RelationshipRemove events.
-func (eh relationshipRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh relationshipRemoveEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*RelationshipRemove); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // resumedEventHandler is an event handler for Resumed events.
-type resumedEventHandler func(*Session, *Resumed)
+type resumedEventHandler func(*Session, *Resumed, context.Context)
 
 // Type returns the event type for Resumed events.
 func (eh resumedEventHandler) Type() string {
@@ -746,14 +750,14 @@ func (eh resumedEventHandler) New() interface{} {
 }
 
 // Handle is the handler for Resumed events.
-func (eh resumedEventHandler) Handle(s *Session, i interface{}) {
+func (eh resumedEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*Resumed); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // typingStartEventHandler is an event handler for TypingStart events.
-type typingStartEventHandler func(*Session, *TypingStart)
+type typingStartEventHandler func(*Session, *TypingStart, context.Context)
 
 // Type returns the event type for TypingStart events.
 func (eh typingStartEventHandler) Type() string {
@@ -766,14 +770,14 @@ func (eh typingStartEventHandler) New() interface{} {
 }
 
 // Handle is the handler for TypingStart events.
-func (eh typingStartEventHandler) Handle(s *Session, i interface{}) {
+func (eh typingStartEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*TypingStart); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // userGuildSettingsUpdateEventHandler is an event handler for UserGuildSettingsUpdate events.
-type userGuildSettingsUpdateEventHandler func(*Session, *UserGuildSettingsUpdate)
+type userGuildSettingsUpdateEventHandler func(*Session, *UserGuildSettingsUpdate, context.Context)
 
 // Type returns the event type for UserGuildSettingsUpdate events.
 func (eh userGuildSettingsUpdateEventHandler) Type() string {
@@ -786,14 +790,14 @@ func (eh userGuildSettingsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserGuildSettingsUpdate events.
-func (eh userGuildSettingsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userGuildSettingsUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*UserGuildSettingsUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // userNoteUpdateEventHandler is an event handler for UserNoteUpdate events.
-type userNoteUpdateEventHandler func(*Session, *UserNoteUpdate)
+type userNoteUpdateEventHandler func(*Session, *UserNoteUpdate, context.Context)
 
 // Type returns the event type for UserNoteUpdate events.
 func (eh userNoteUpdateEventHandler) Type() string {
@@ -806,14 +810,14 @@ func (eh userNoteUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserNoteUpdate events.
-func (eh userNoteUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userNoteUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*UserNoteUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // userSettingsUpdateEventHandler is an event handler for UserSettingsUpdate events.
-type userSettingsUpdateEventHandler func(*Session, *UserSettingsUpdate)
+type userSettingsUpdateEventHandler func(*Session, *UserSettingsUpdate, context.Context)
 
 // Type returns the event type for UserSettingsUpdate events.
 func (eh userSettingsUpdateEventHandler) Type() string {
@@ -826,14 +830,14 @@ func (eh userSettingsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserSettingsUpdate events.
-func (eh userSettingsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userSettingsUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*UserSettingsUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // userUpdateEventHandler is an event handler for UserUpdate events.
-type userUpdateEventHandler func(*Session, *UserUpdate)
+type userUpdateEventHandler func(*Session, *UserUpdate, context.Context)
 
 // Type returns the event type for UserUpdate events.
 func (eh userUpdateEventHandler) Type() string {
@@ -846,14 +850,14 @@ func (eh userUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserUpdate events.
-func (eh userUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*UserUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // voiceServerUpdateEventHandler is an event handler for VoiceServerUpdate events.
-type voiceServerUpdateEventHandler func(*Session, *VoiceServerUpdate)
+type voiceServerUpdateEventHandler func(*Session, *VoiceServerUpdate, context.Context)
 
 // Type returns the event type for VoiceServerUpdate events.
 func (eh voiceServerUpdateEventHandler) Type() string {
@@ -866,14 +870,14 @@ func (eh voiceServerUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for VoiceServerUpdate events.
-func (eh voiceServerUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh voiceServerUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*VoiceServerUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 // voiceStateUpdateEventHandler is an event handler for VoiceStateUpdate events.
-type voiceStateUpdateEventHandler func(*Session, *VoiceStateUpdate)
+type voiceStateUpdateEventHandler func(*Session, *VoiceStateUpdate, context.Context)
 
 // Type returns the event type for VoiceStateUpdate events.
 func (eh voiceStateUpdateEventHandler) Type() string {
@@ -886,102 +890,234 @@ func (eh voiceStateUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for VoiceStateUpdate events.
-func (eh voiceStateUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh voiceStateUpdateEventHandler) Handle(s *Session, i interface{}, c context.Context) {
 	if t, ok := i.(*VoiceStateUpdate); ok {
-		eh(s, t)
+		eh(s, t, c)
 	}
 }
 
 func handlerForInterface(handler interface{}) EventHandler {
 	switch v := handler.(type) {
-	case func(*Session, interface{}):
+	case func(*Session, interface{}, context.Context):
 		return interfaceEventHandler(v)
-	case func(*Session, *ChannelCreate):
+	case func(*Session, *ChannelCreate, context.Context):
 		return channelCreateEventHandler(v)
-	case func(*Session, *ChannelDelete):
+	case func(*Session, *ChannelDelete, context.Context):
 		return channelDeleteEventHandler(v)
-	case func(*Session, *ChannelPinsUpdate):
+	case func(*Session, *ChannelPinsUpdate, context.Context):
 		return channelPinsUpdateEventHandler(v)
-	case func(*Session, *ChannelUpdate):
+	case func(*Session, *ChannelUpdate, context.Context):
 		return channelUpdateEventHandler(v)
-	case func(*Session, *Connect):
+	case func(*Session, *Connect, context.Context):
 		return connectEventHandler(v)
-	case func(*Session, *Disconnect):
+	case func(*Session, *Disconnect, context.Context):
 		return disconnectEventHandler(v)
-	case func(*Session, *Event):
+	case func(*Session, *Event, context.Context):
 		return eventEventHandler(v)
-	case func(*Session, *GuildBanAdd):
+	case func(*Session, *GuildBanAdd, context.Context):
 		return guildBanAddEventHandler(v)
-	case func(*Session, *GuildBanRemove):
+	case func(*Session, *GuildBanRemove, context.Context):
 		return guildBanRemoveEventHandler(v)
-	case func(*Session, *GuildCreate):
+	case func(*Session, *GuildCreate, context.Context):
 		return guildCreateEventHandler(v)
-	case func(*Session, *GuildDelete):
+	case func(*Session, *GuildDelete, context.Context):
 		return guildDeleteEventHandler(v)
-	case func(*Session, *GuildEmojisUpdate):
+	case func(*Session, *GuildEmojisUpdate, context.Context):
 		return guildEmojisUpdateEventHandler(v)
-	case func(*Session, *GuildIntegrationsUpdate):
+	case func(*Session, *GuildIntegrationsUpdate, context.Context):
 		return guildIntegrationsUpdateEventHandler(v)
-	case func(*Session, *GuildMemberAdd):
+	case func(*Session, *GuildMemberAdd, context.Context):
 		return guildMemberAddEventHandler(v)
-	case func(*Session, *GuildMemberRemove):
+	case func(*Session, *GuildMemberRemove, context.Context):
 		return guildMemberRemoveEventHandler(v)
-	case func(*Session, *GuildMemberUpdate):
+	case func(*Session, *GuildMemberUpdate, context.Context):
 		return guildMemberUpdateEventHandler(v)
-	case func(*Session, *GuildMembersChunk):
+	case func(*Session, *GuildMembersChunk, context.Context):
 		return guildMembersChunkEventHandler(v)
-	case func(*Session, *GuildRoleCreate):
+	case func(*Session, *GuildRoleCreate, context.Context):
 		return guildRoleCreateEventHandler(v)
-	case func(*Session, *GuildRoleDelete):
+	case func(*Session, *GuildRoleDelete, context.Context):
 		return guildRoleDeleteEventHandler(v)
-	case func(*Session, *GuildRoleUpdate):
+	case func(*Session, *GuildRoleUpdate, context.Context):
 		return guildRoleUpdateEventHandler(v)
-	case func(*Session, *GuildUpdate):
+	case func(*Session, *GuildUpdate, context.Context):
 		return guildUpdateEventHandler(v)
-	case func(*Session, *MessageAck):
+	case func(*Session, *MessageAck, context.Context):
 		return messageAckEventHandler(v)
-	case func(*Session, *MessageCreate):
+	case func(*Session, *MessageCreate, context.Context):
 		return messageCreateEventHandler(v)
-	case func(*Session, *MessageDelete):
+	case func(*Session, *MessageDelete, context.Context):
 		return messageDeleteEventHandler(v)
-	case func(*Session, *MessageDeleteBulk):
+	case func(*Session, *MessageDeleteBulk, context.Context):
 		return messageDeleteBulkEventHandler(v)
-	case func(*Session, *MessageReactionAdd):
+	case func(*Session, *MessageReactionAdd, context.Context):
 		return messageReactionAddEventHandler(v)
-	case func(*Session, *MessageReactionRemove):
+	case func(*Session, *MessageReactionRemove, context.Context):
 		return messageReactionRemoveEventHandler(v)
-	case func(*Session, *MessageReactionRemoveAll):
+	case func(*Session, *MessageReactionRemoveAll, context.Context):
 		return messageReactionRemoveAllEventHandler(v)
-	case func(*Session, *MessageUpdate):
+	case func(*Session, *MessageUpdate, context.Context):
 		return messageUpdateEventHandler(v)
-	case func(*Session, *PresenceUpdate):
+	case func(*Session, *PresenceUpdate, context.Context):
 		return presenceUpdateEventHandler(v)
-	case func(*Session, *PresencesReplace):
+	case func(*Session, *PresencesReplace, context.Context):
 		return presencesReplaceEventHandler(v)
-	case func(*Session, *RateLimit):
+	case func(*Session, *RateLimit, context.Context):
 		return rateLimitEventHandler(v)
-	case func(*Session, *Ready):
+	case func(*Session, *Ready, context.Context):
 		return readyEventHandler(v)
-	case func(*Session, *RelationshipAdd):
+	case func(*Session, *RelationshipAdd, context.Context):
 		return relationshipAddEventHandler(v)
-	case func(*Session, *RelationshipRemove):
+	case func(*Session, *RelationshipRemove, context.Context):
 		return relationshipRemoveEventHandler(v)
-	case func(*Session, *Resumed):
+	case func(*Session, *Resumed, context.Context):
 		return resumedEventHandler(v)
-	case func(*Session, *TypingStart):
+	case func(*Session, *TypingStart, context.Context):
 		return typingStartEventHandler(v)
-	case func(*Session, *UserGuildSettingsUpdate):
+	case func(*Session, *UserGuildSettingsUpdate, context.Context):
 		return userGuildSettingsUpdateEventHandler(v)
-	case func(*Session, *UserNoteUpdate):
+	case func(*Session, *UserNoteUpdate, context.Context):
 		return userNoteUpdateEventHandler(v)
-	case func(*Session, *UserSettingsUpdate):
+	case func(*Session, *UserSettingsUpdate, context.Context):
 		return userSettingsUpdateEventHandler(v)
-	case func(*Session, *UserUpdate):
+	case func(*Session, *UserUpdate, context.Context):
 		return userUpdateEventHandler(v)
-	case func(*Session, *VoiceServerUpdate):
+	case func(*Session, *VoiceServerUpdate, context.Context):
 		return voiceServerUpdateEventHandler(v)
-	case func(*Session, *VoiceStateUpdate):
+	case func(*Session, *VoiceStateUpdate, context.Context):
 		return voiceStateUpdateEventHandler(v)
+	case func(*Session, interface{}):
+		w := func(s *Session, i interface{}, c context.Context) { v(s, i) }
+		return interfaceEventHandler(w)
+	case func(*Session, *ChannelCreate):
+		w := func(s *Session, i *ChannelCreate, _ context.Context) { v(s, i) }
+		return channelCreateEventHandler(w)
+	case func(*Session, *ChannelDelete):
+		w := func(s *Session, i *ChannelDelete, _ context.Context) { v(s, i) }
+		return channelDeleteEventHandler(w)
+	case func(*Session, *ChannelPinsUpdate):
+		w := func(s *Session, i *ChannelPinsUpdate, _ context.Context) { v(s, i) }
+		return channelPinsUpdateEventHandler(w)
+	case func(*Session, *ChannelUpdate):
+		w := func(s *Session, i *ChannelUpdate, _ context.Context) { v(s, i) }
+		return channelUpdateEventHandler(w)
+	case func(*Session, *Connect):
+		w := func(s *Session, i *Connect, _ context.Context) { v(s, i) }
+		return connectEventHandler(w)
+	case func(*Session, *Disconnect):
+		w := func(s *Session, i *Disconnect, _ context.Context) { v(s, i) }
+		return disconnectEventHandler(w)
+	case func(*Session, *Event):
+		w := func(s *Session, i *Event, _ context.Context) { v(s, i) }
+		return eventEventHandler(w)
+	case func(*Session, *GuildBanAdd):
+		w := func(s *Session, i *GuildBanAdd, _ context.Context) { v(s, i) }
+		return guildBanAddEventHandler(w)
+	case func(*Session, *GuildBanRemove):
+		w := func(s *Session, i *GuildBanRemove, _ context.Context) { v(s, i) }
+		return guildBanRemoveEventHandler(w)
+	case func(*Session, *GuildCreate):
+		w := func(s *Session, i *GuildCreate, _ context.Context) { v(s, i) }
+		return guildCreateEventHandler(w)
+	case func(*Session, *GuildDelete):
+		w := func(s *Session, i *GuildDelete, _ context.Context) { v(s, i) }
+		return guildDeleteEventHandler(w)
+	case func(*Session, *GuildEmojisUpdate):
+		w := func(s *Session, i *GuildEmojisUpdate, _ context.Context) { v(s, i) }
+		return guildEmojisUpdateEventHandler(w)
+	case func(*Session, *GuildIntegrationsUpdate):
+		w := func(s *Session, i *GuildIntegrationsUpdate, _ context.Context) { v(s, i) }
+		return guildIntegrationsUpdateEventHandler(w)
+	case func(*Session, *GuildMemberAdd):
+		w := func(s *Session, i *GuildMemberAdd, _ context.Context) { v(s, i) }
+		return guildMemberAddEventHandler(w)
+	case func(*Session, *GuildMemberRemove):
+		w := func(s *Session, i *GuildMemberRemove, _ context.Context) { v(s, i) }
+		return guildMemberRemoveEventHandler(w)
+	case func(*Session, *GuildMemberUpdate):
+		w := func(s *Session, i *GuildMemberUpdate, _ context.Context) { v(s, i) }
+		return guildMemberUpdateEventHandler(w)
+	case func(*Session, *GuildMembersChunk):
+		w := func(s *Session, i *GuildMembersChunk, _ context.Context) { v(s, i) }
+		return guildMembersChunkEventHandler(w)
+	case func(*Session, *GuildRoleCreate):
+		w := func(s *Session, i *GuildRoleCreate, _ context.Context) { v(s, i) }
+		return guildRoleCreateEventHandler(w)
+	case func(*Session, *GuildRoleDelete):
+		w := func(s *Session, i *GuildRoleDelete, _ context.Context) { v(s, i) }
+		return guildRoleDeleteEventHandler(w)
+	case func(*Session, *GuildRoleUpdate):
+		w := func(s *Session, i *GuildRoleUpdate, _ context.Context) { v(s, i) }
+		return guildRoleUpdateEventHandler(w)
+	case func(*Session, *GuildUpdate):
+		w := func(s *Session, i *GuildUpdate, _ context.Context) { v(s, i) }
+		return guildUpdateEventHandler(w)
+	case func(*Session, *MessageAck):
+		w := func(s *Session, i *MessageAck, _ context.Context) { v(s, i) }
+		return messageAckEventHandler(w)
+	case func(*Session, *MessageCreate):
+		w := func(s *Session, i *MessageCreate, _ context.Context) { v(s, i) }
+		return messageCreateEventHandler(w)
+	case func(*Session, *MessageDelete):
+		w := func(s *Session, i *MessageDelete, _ context.Context) { v(s, i) }
+		return messageDeleteEventHandler(w)
+	case func(*Session, *MessageDeleteBulk):
+		w := func(s *Session, i *MessageDeleteBulk, _ context.Context) { v(s, i) }
+		return messageDeleteBulkEventHandler(w)
+	case func(*Session, *MessageReactionAdd):
+		w := func(s *Session, i *MessageReactionAdd, _ context.Context) { v(s, i) }
+		return messageReactionAddEventHandler(w)
+	case func(*Session, *MessageReactionRemove):
+		w := func(s *Session, i *MessageReactionRemove, _ context.Context) { v(s, i) }
+		return messageReactionRemoveEventHandler(w)
+	case func(*Session, *MessageReactionRemoveAll):
+		w := func(s *Session, i *MessageReactionRemoveAll, _ context.Context) { v(s, i) }
+		return messageReactionRemoveAllEventHandler(w)
+	case func(*Session, *MessageUpdate):
+		w := func(s *Session, i *MessageUpdate, _ context.Context) { v(s, i) }
+		return messageUpdateEventHandler(w)
+	case func(*Session, *PresenceUpdate):
+		w := func(s *Session, i *PresenceUpdate, _ context.Context) { v(s, i) }
+		return presenceUpdateEventHandler(w)
+	case func(*Session, *PresencesReplace):
+		w := func(s *Session, i *PresencesReplace, _ context.Context) { v(s, i) }
+		return presencesReplaceEventHandler(w)
+	case func(*Session, *RateLimit):
+		w := func(s *Session, i *RateLimit, _ context.Context) { v(s, i) }
+		return rateLimitEventHandler(w)
+	case func(*Session, *Ready):
+		w := func(s *Session, i *Ready, _ context.Context) { v(s, i) }
+		return readyEventHandler(w)
+	case func(*Session, *RelationshipAdd):
+		w := func(s *Session, i *RelationshipAdd, _ context.Context) { v(s, i) }
+		return relationshipAddEventHandler(w)
+	case func(*Session, *RelationshipRemove):
+		w := func(s *Session, i *RelationshipRemove, _ context.Context) { v(s, i) }
+		return relationshipRemoveEventHandler(w)
+	case func(*Session, *Resumed):
+		w := func(s *Session, i *Resumed, _ context.Context) { v(s, i) }
+		return resumedEventHandler(w)
+	case func(*Session, *TypingStart):
+		w := func(s *Session, i *TypingStart, _ context.Context) { v(s, i) }
+		return typingStartEventHandler(w)
+	case func(*Session, *UserGuildSettingsUpdate):
+		w := func(s *Session, i *UserGuildSettingsUpdate, _ context.Context) { v(s, i) }
+		return userGuildSettingsUpdateEventHandler(w)
+	case func(*Session, *UserNoteUpdate):
+		w := func(s *Session, i *UserNoteUpdate, _ context.Context) { v(s, i) }
+		return userNoteUpdateEventHandler(w)
+	case func(*Session, *UserSettingsUpdate):
+		w := func(s *Session, i *UserSettingsUpdate, _ context.Context) { v(s, i) }
+		return userSettingsUpdateEventHandler(w)
+	case func(*Session, *UserUpdate):
+		w := func(s *Session, i *UserUpdate, _ context.Context) { v(s, i) }
+		return userUpdateEventHandler(w)
+	case func(*Session, *VoiceServerUpdate):
+		w := func(s *Session, i *VoiceServerUpdate, _ context.Context) { v(s, i) }
+		return voiceServerUpdateEventHandler(w)
+	case func(*Session, *VoiceStateUpdate):
+		w := func(s *Session, i *VoiceStateUpdate, _ context.Context) { v(s, i) }
+		return voiceStateUpdateEventHandler(w)
 	}
 
 	return nil

--- a/structs.go
+++ b/structs.go
@@ -12,6 +12,7 @@
 package discordgo
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -77,6 +78,10 @@ type Session struct {
 
 	// The http client used for REST requests
 	Client *http.Client
+
+	// Returns the context to be passed to a handler.
+	// Called once per received event, not per handler.
+	ContextFactory func() context.Context
 
 	// Event handlers
 	handlersMu   sync.RWMutex


### PR DESCRIPTION
Adds support for `func(*discordgo.Session, *discordgo.EVENT, context.Context)` handlers, and a factory function on Session to create passed contexts.