### PR TITLE
Prevent UserColor from modifying the guild.Roles slice

### DIFF
--- a/state.go
+++ b/state.go
@@ -169,14 +169,10 @@ func (s *State) PresenceAdd(guildID string, presence *Presence) error {
 			//guild.Presences[i] = presence
 
 			//Update status
-			//if presence.Game != nil {
 			guild.Presences[i].Game = presence.Game
-			//}
+			guild.Presences[i].Roles = presence.Roles
 			if presence.Status != "" {
 				guild.Presences[i].Status = presence.Status
-			}
-			if presence.Roles != nil {
-				guild.Presences[i].Roles = presence.Roles
 			}
 			if presence.Nick != "" {
 				guild.Presences[i].Nick = presence.Nick

--- a/state.go
+++ b/state.go
@@ -202,7 +202,7 @@ func (s *State) PresenceAdd(guildID string, presence *Presence) error {
 		}
 	}
 
-	guild.Presences = append(guild.Presences)
+	guild.Presences = append(guild.Presences, presence)
 	return nil
 }
 
@@ -398,7 +398,7 @@ func (s *State) Role(guildID, roleID string) (*Role, error) {
 	return nil, errors.New("role not found")
 }
 
-// ChannelAdd adds a guild to the current world state, or
+// ChannelAdd adds a channel to the current world state, or
 // updates it if it already exists.
 // Channels may exist either as PrivateChannels or inside
 // a guild.

--- a/state.go
+++ b/state.go
@@ -928,8 +928,9 @@ func (s *State) UserColor(userID, channelID string) int {
 		return 0
 	}
 
-	roles := Roles(guild.Roles)
-	sort.Sort(roles)
+	roles := make([]*Role, len(guild.Roles))
+	copy(roles, guild.Roles)
+	sort.Sort(Roles(roles))
 
 	for _, role := range roles {
 		for _, roleID := range member.Roles {


### PR DESCRIPTION
Edit: I don't think I PR'd this correctly, but copying the roles like this fixed the issue for me.
Its at line 931
```go
roles := make([]*Role, len(guild.Roles))
copy(roles, guild.Roles)
sort.Sort(Roles(roles))
```

Input
```go
	case ">usercolor":
		guild, _ := b.Guild(m)
		fmt.Println("--------Roles before calling UserColor-------")
		for _, v := range guild.Roles {
			fmt.Println(v.Position)
		}
		b.DG.State.UserColor(m.Author.ID, m.ChannelID)
		fmt.Println("--------Roles after calling UserColor--------")
		for _, v := range guild.Roles {
			fmt.Println(v.Position)
		}
```
Output:
![image](https://cloud.githubusercontent.com/assets/16108486/25733669/c310ab06-3129-11e7-99c9-215de083b029.png)

In this example, calling UserColor has the side effect of also sorting the roles in a guild.