### PR TITLE
Add and fix support for multiple file uploads via ChannelMessageSendComplex via the new field MessageSend.Files.

### DIFF
--- a/message.go
+++ b/message.go
@@ -34,8 +34,9 @@ type Message struct {
 
 // File stores info about files you e.g. send in messages.
 type File struct {
-	Name   string
-	Reader io.Reader
+	Name        string
+	ContentType string
+	Reader      io.Reader
 }
 
 // MessageSend stores all parameters you can send with ChannelMessageSendComplex.
@@ -43,7 +44,10 @@ type MessageSend struct {
 	Content string        `json:"content,omitempty"`
 	Embed   *MessageEmbed `json:"embed,omitempty"`
 	Tts     bool          `json:"tts"`
-	File    *File         `json:"file"`
+	Files   []*File       `json:"-"`
+
+	// TODO: Remove this when compatibility is not required.
+	File *File `json:"-"`
 }
 
 // MessageEdit is used to chain parameters via ChannelMessageEditComplex, which


### PR DESCRIPTION
For compatibility with existing library consumers, the File field is retained but will behave as if Files contained that single file. If both are specified, ChannelMessageSendComplex will return an error.

The message JSON payload is moved to a form-data field called `payload_json`, instead of set in multipart form data. This is supported and the recommended way, as per the API docs.

Apparently, you can attach multiple files if you just name the parts names differently in the multipart request. The parts are named here using the order the files were specified, as `file%d`. This is not documented in the API docs, but definitely works.

This also removes serialization of the File field via json.Marshal, as it will never be directly serialized in the JSON. The new field, Files, is similarly not marshaled.

This additionally adds a ContentType field in File, which can be used to specify the content type of the attached file. The ContentType field will default to setting the header to `application/octet-stream` if empty. Discord currently doesn't do much with the Content-Type header, but we should pass this information along anyway in accordance to the MIME standard.