### PR TITLE
Develop

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -59,6 +59,7 @@ func New(args ...interface{}) (s *Session, err error) {
 		MaxRestRetries:         3,
 		Client:                 &http.Client{Timeout: (20 * time.Second)},
 		sequence:               new(int64),
+		LastHeartbeatAck:       time.Now().UTC(),
 	}
 
 	// If no arguments are passed return the empty Session interface.

--- a/structs.go
+++ b/structs.go
@@ -78,6 +78,9 @@ type Session struct {
 	// The http client used for REST requests
 	Client *http.Client
 
+	// Stores the last HeartbeatAck that was recieved (in UTC)
+	LastHeartbeatAck time.Time
+
 	// Event handlers
 	handlersMu   sync.RWMutex
 	handlers     map[string][]*eventHandlerInstance

--- a/structs.go
+++ b/structs.go
@@ -52,9 +52,6 @@ type Session struct {
 
 	// Exposed but should not be modified by User.
 
-	// Whether the Data Websocket is ready
-	DataReady bool // NOTE: Maye be deprecated soon
-
 	// Max number of REST API retries
 	MaxRestRetries int
 

--- a/voice.go
+++ b/voice.go
@@ -841,7 +841,11 @@ func (v *VoiceConnection) reconnect() {
 	v.reconnecting = true
 	v.Unlock()
 
-	defer func() { v.reconnecting = false }()
+	defer func() {
+		v.Lock()
+		v.reconnecting = false
+		v.Unlock()
+	}()
 
 	// Close any currently open connections
 	v.Close()
@@ -855,8 +859,8 @@ func (v *VoiceConnection) reconnect() {
 			wait = 600
 		}
 
-		if v.session.DataReady == false || v.session.wsConn == nil {
-			v.log(LogInformational, "cannot reconenct to channel %s with unready session", v.ChannelID)
+		if v.session.wsConn == nil {
+			v.log(LogInformational, "cannot reconnect to channel %s with unready session", v.ChannelID)
 			continue
 		}
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -237,9 +237,6 @@ func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}
 			s.reconnect()
 			return
 		}
-		s.Lock()
-		s.DataReady = true
-		s.Unlock()
 
 		select {
 		case <-ticker.C:
@@ -726,8 +723,6 @@ func (s *Session) Close() (err error) {
 
 	s.log(LogInformational, "called")
 	s.Lock()
-
-	s.DataReady = false
 
 	if s.listening != nil {
 		s.log(LogInformational, "closing listening channel")


### PR DESCRIPTION
DataReady was only used in a voice reconnect function. This seemed unnecessary, because a failure to reconnect would result in retrying anyway, but **I have not been able to test this**. Of more concern is the fact that the function itself is extremely hacky and probably needs
to be fixed up anyway.

This pull request demonstrates what is necessary to remove DataReady, but it might be more appropriate to bundle this change with a pull request that cleans up voice connections in general.