### PR TITLE
voice.go: remove runtime.LockOSThread call from opusSender

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -658,8 +657,6 @@ func (v *VoiceConnection) opusSender(udpConn *net.UDPConn, close <-chan struct{}
 	if udpConn == nil || close == nil {
 		return
 	}
-
-	runtime.LockOSThread()
 
 	// VoiceConnection is now ready to receive audio packets
 	// TODO: this needs reviewed as I think there must be a better way.


### PR DESCRIPTION
runtime.LockOSThread does not do anything for performance and is instead
intended for interfacing with libraries that use thread local data structures.

Closes #402