### PR TITLE
Fix #406: reconnect() can be called while still connected

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -709,6 +709,13 @@ func (s *Session) reconnect() {
 				return
 			}
 
+			// Certain race conditions can call reconnect() twice. If this happens, we
+			// just break out of the reconnect loop
+			if err == ErrWSAlreadyOpen {
+				s.log(LogInformational, "Websocket already exists, no need to reconnect")
+				return
+			}
+
 			s.log(LogError, "error reconnecting to gateway, %s", err)
 
 			<-time.After(wait * time.Second)


### PR DESCRIPTION
This is a small change to gracefully handle the possibility of a race condition attempting to reconnect twice, as shown in #406 .