### PR TITLE
Add memberMap to State to speed up member queries

### DIFF
--- a/state.go
+++ b/state.go
@@ -89,7 +89,6 @@ func (s *State) GuildAdd(guild *Guild) error {
 
 	// If this guild contains a new member slice, we must regenerate the member map so the pointers stay valid
 	if guild.Members != nil {
-		delete(s.memberMap, guild.ID)
 		s.createMemberMap(guild)
 	}
 
@@ -349,7 +348,7 @@ func (s *State) Member(guildID, userID string) (*Member, error) {
 
 	members, ok := s.memberMap[guildID]
 	if !ok {
-		return nil, errors.New("guild not found")
+		return nil, ErrStateNotFound
 	}
 
 	m, ok := members[userID]

--- a/state.go
+++ b/state.go
@@ -42,6 +42,7 @@ type State struct {
 
 	guildMap   map[string]*Guild
 	channelMap map[string]*Channel
+	memberMap  map[string]map[string]*Member
 }
 
 // NewState creates an empty state.
@@ -59,7 +60,16 @@ func NewState() *State {
 		TrackPresences: true,
 		guildMap:       make(map[string]*Guild),
 		channelMap:     make(map[string]*Channel),
+		memberMap:      make(map[string]map[string]*Member),
 	}
+}
+
+func (s *State) createMemberMap(guild *Guild) {
+	members := make(map[string]*Member)
+	for _, m := range guild.Members {
+		members[m.User.ID] = m
+	}
+	s.memberMap[guild.ID] = members
 }
 
 // GuildAdd adds a guild to the current world state, or
@@ -75,6 +85,12 @@ func (s *State) GuildAdd(guild *Guild) error {
 	// Update the channels to point to the right guild, adding them to the channelMap as we go
 	for _, c := range guild.Channels {
 		s.channelMap[c.ID] = c
+	}
+
+	// If this guild contains a new member slice, we must regenerate the member map so the pointers stay valid
+	if guild.Members != nil {
+		delete(s.memberMap, guild.ID)
+		s.createMemberMap(guild)
 	}
 
 	if g, ok := s.guildMap[guild.ID]; ok {
@@ -271,14 +287,19 @@ func (s *State) MemberAdd(member *Member) error {
 	s.Lock()
 	defer s.Unlock()
 
-	for i, m := range guild.Members {
-		if m.User.ID == member.User.ID {
-			guild.Members[i] = member
-			return nil
-		}
+	members, ok := s.memberMap[member.GuildID]
+	if !ok {
+		return ErrStateNotFound
 	}
 
-	guild.Members = append(guild.Members, member)
+	m, ok := members[member.User.ID]
+	if !ok {
+		members[member.User.ID] = member
+		guild.Members = append(guild.Members, member)
+	} else {
+		*m = *member // Update the actual data, which will also update the member pointer in the slice
+	}
+
 	return nil
 }
 
@@ -296,6 +317,17 @@ func (s *State) MemberRemove(member *Member) error {
 	s.Lock()
 	defer s.Unlock()
 
+	members, ok := s.memberMap[member.GuildID]
+	if !ok {
+		return ErrStateNotFound
+	}
+
+	_, ok = members[member.User.ID]
+	if !ok {
+		return ErrStateNotFound
+	}
+	delete(members, member.User.ID)
+
 	for i, m := range guild.Members {
 		if m.User.ID == member.User.ID {
 			guild.Members = append(guild.Members[:i], guild.Members[i+1:]...)
@@ -312,18 +344,17 @@ func (s *State) Member(guildID, userID string) (*Member, error) {
 		return nil, ErrNilState
 	}
 
-	guild, err := s.Guild(guildID)
-	if err != nil {
-		return nil, err
-	}
-
 	s.RLock()
 	defer s.RUnlock()
 
-	for _, m := range guild.Members {
-		if m.User.ID == userID {
-			return m, nil
-		}
+	members, ok := s.memberMap[guildID]
+	if !ok {
+		return nil, errors.New("guild not found")
+	}
+
+	m, ok := members[userID]
+	if ok {
+		return m, nil
 	}
 
 	return nil, ErrStateNotFound
@@ -735,6 +766,7 @@ func (s *State) onReady(se *Session, r *Ready) (err error) {
 
 	for _, g := range s.Guilds {
 		s.guildMap[g.ID] = g
+		s.createMemberMap(g)
 
 		for _, c := range g.Channels {
 			s.channelMap[c.ID] = c

--- a/state.go
+++ b/state.go
@@ -90,6 +90,9 @@ func (s *State) GuildAdd(guild *Guild) error {
 	// If this guild contains a new member slice, we must regenerate the member map so the pointers stay valid
 	if guild.Members != nil {
 		s.createMemberMap(guild)
+	} else if _, ok := s.memberMap[guild.ID]; !ok {
+		// Even if we have no new member slice, we still initialize the member map for this guild if it doesn't exist
+		s.memberMap[guild.ID] = make(map[string]*Member)
 	}
 
 	if g, ok := s.guildMap[guild.ID]; ok {

--- a/wsapi.go
+++ b/wsapi.go
@@ -709,6 +709,13 @@ func (s *Session) reconnect() {
 				return
 			}
 
+			// Certain race conditions can call reconnect() twice. If this happens, we
+			// just break out of the reconnect loop
+			if err == ErrWSAlreadyOpen {
+				s.log(LogInformational, "Websocket already exists, no need to reconnect")
+				return
+			}
+
 			s.log(LogError, "error reconnecting to gateway, %s", err)
 
 			<-time.After(wait * time.Second)


### PR DESCRIPTION
This adds `memberMap` to the State object, in the same vein as the existing `guildMap` and `channelMap`, except it's a map of maps, mapping each guild ID to a map of member IDs paired to members. The map is replaced if necessary in `GuildAdd` so that all the pointers are always up-to-date, and is created in the `OnReady` function.

The Add, Remove, and Get functions have been updated to use the map, but still modify the slice if necessary, so the Member slice is still kept up to date. Speed tests indicate this approach is roughly 4-5 times faster for servers with 500+ members in them.