### PR TITLE
Add support for custom event muxers

### DIFF
--- a/state.go
+++ b/state.go
@@ -783,7 +783,7 @@ func (s *State) onReady(se *Session, r *Ready) (err error) {
 }
 
 // onInterface handles all events related to states.
-func (s *State) onInterface(se *Session, i interface{}) (err error) {
+func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 	if s == nil {
 		return ErrNilState
 	}

--- a/structs.go
+++ b/structs.go
@@ -50,6 +50,10 @@ type Session struct {
 	// active guilds and the members of the guilds.
 	StateEnabled bool
 
+	// Custom event muxer to be used for incoming events if the
+	// default behaviour is not enough.
+	CustomEventMuxer EventMuxer
+
 	// Exposed but should not be modified by User.
 
 	// Whether the Data Websocket is ready


### PR DESCRIPTION
One muxing behaviour does not fit everyone, atleast not a limited one like this, I've run into several problems that could be solved by being able to modify the behaviour slightly (although breaking things that relied on the old behaviour) 

Wrapping the current event muxer would not work either, because you would still lose the event order, there are no guarantees which goroutine runs when afaik.

So the only solution without breaking existing code is to allow custom event muxers.

I also exported states OnInterface method because i feel like that should be up to the muxer, giving the ability to detect changes of objects in the state by having your handler run before state.