### PR TITLE
Add NSFW channel field

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -166,6 +166,7 @@ type Channel struct {
 	Topic                string                 `json:"topic"`
 	Type                 ChannelType            `json:"type"`
 	LastMessageID        string                 `json:"last_message_id"`
+	NSFW                 bool                   `json:"nsfw"`
 	Position             int                    `json:"position"`
 	Bitrate              int                    `json:"bitrate"`
 	Recipients           []*User                `json:"recipient"`


### PR DESCRIPTION
Note: NSFW channels which haven't been modified since the update that introduced this field have it set to `false`.