### PR TITLE
Fix voice connections not decoding data properly

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -796,7 +796,7 @@ func (v *VoiceConnection) opusReceiver(udpConn *net.UDPConn, close <-chan struct
 		}
 
 		// For now, skip anything except audio.
-		if rlen < 12 || recvbuf[0] != 0x80 {
+		if rlen < 12 || recvbuf[0] != 0x80 && recvbuf[0] != 0x90 {
 			continue
 		}
 
@@ -809,6 +809,10 @@ func (v *VoiceConnection) opusReceiver(udpConn *net.UDPConn, close <-chan struct
 		// decrypt opus data
 		copy(nonce[:], recvbuf[0:12])
 		p.Opus, _ = secretbox.Open(nil, recvbuf[12:rlen], &nonce, &v.op4.SecretKey)
+		
+		if recvbuf[0] == 0x90 && len(p.Opus) > 8 {
+			p.Opus = p.Opus[8:]
+		}
 
 		if c != nil {
 			c <- &p


### PR DESCRIPTION
For some reason the type was updated to 0x90, likely due to a Chromium update (the issue was present in Discord with Chrome/browsers before, just never patched). This will ensure that we handle the data correctly.

This fixes #423.