### PR TITLE
Fix concurrrency in voice connect/disconnect

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -140,6 +140,14 @@ func (v *VoiceConnection) ChangeChannel(channelID string, mute, deaf bool) (err 
 // !!! NOTE !!! this function may be removed in favour of ChannelVoiceLeave
 func (v *VoiceConnection) Disconnect() (err error) {
 
+	// Close websocket and udp connections
+	v.Close()
+	v.log(LogInformational, "Deleting VoiceConnection %s", v.GuildID)
+
+	v.session.Lock()
+	delete(v.session.VoiceConnections, v.GuildID)
+	v.session.Unlock()
+
 	// Send a OP4 with a nil channel to disconnect
 	if v.sessionID != "" {
 		data := voiceChannelJoinOp{4, voiceChannelJoinData{&v.GuildID, nil, true, true}}
@@ -148,15 +156,6 @@ func (v *VoiceConnection) Disconnect() (err error) {
 		v.session.wsMutex.Unlock()
 		v.sessionID = ""
 	}
-
-	// Close websocket and udp connections
-	v.Close()
-
-	v.log(LogInformational, "Deleting VoiceConnection %s", v.GuildID)
-
-	v.session.Lock()
-	delete(v.session.VoiceConnections, v.GuildID)
-	v.session.Unlock()
 
 	return
 }


### PR DESCRIPTION
Background: if a bot has to connect to a voice channel just after disconnecting from one, it "dies" in the channel (it can't play sound and `voice.waitUntilConnected` error with *"timeout waiting for voice"*).

I tested it with the airhorn example, you have to send *"!airhorn"* the moment the bot leaves and it will connect to the channel and stay in an error state indefinitely. You can make it change channel by typing *"!airhorn"* while being in another channel but it stays in this "errored" state. (the manipulation sounds far fetched, but it happens quite often naturally with the users on my server and I have to restart the bot manually)

Enabling logging, it seems to happens because waiting first for the **wsapi lock** let discordgo create the VoiceConnection with the new information, then subsequently delete it once the **session lock** is released from the connect side, meanwhile connecting with wsapi.

So inverting lock order seems to do the trick, without apparent performance loss or API problem (but I may have overlooked something). 😃
