### PR TITLE
Fix presence update after breaking API change

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -311,7 +311,7 @@ type Presence struct {
 type Game struct {
 	Name string `json:"name"`
 	Type int    `json:"type"`
-	URL  string `json:"url"`
+	URL  string `json:"url,omitempty"`
 }
 
 // UnmarshalJSON unmarshals json to Game struct

--- a/wsapi.go
+++ b/wsapi.go
@@ -250,8 +250,10 @@ func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}
 }
 
 type updateStatusData struct {
-	IdleSince *int  `json:"idle_since"`
-	Game      *Game `json:"game"`
+	IdleSince *int   `json:"since"`
+	Game      *Game  `json:"game"`
+	AFK       bool   `json:"afk"`
+	Status    string `json:"status"`
 }
 
 type updateStatusOp struct {
@@ -274,7 +276,10 @@ func (s *Session) UpdateStreamingStatus(idle int, game string, url string) (err 
 		return ErrWSNotFound
 	}
 
-	var usd updateStatusData
+	usd := updateStatusData{
+		Status: "online",
+	}
+
 	if idle > 0 {
 		usd.IdleSince = &idle
 	}


### PR DESCRIPTION
https://discordapp.com/developers/docs/change-log#august-16-2017-—-breaking-change

While discordgo does always include type there were some other parts they forgot to mention.

I  had to add `omitempty` to Game.Url, and add `afk` and `status` otherwise i would get disconnected from the gateway.

I also changed `idle_since` to `since`,  probably forgot about that in the Gatway 6 update