### PR TITLE
Change all string ids to int64 ids

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -143,4 +144,8 @@ func New(args ...interface{}) (s *Session, err error) {
 	// It is recommended that you now call Open() so that events will trigger.
 
 	return
+}
+
+func StrID(id int64) string {
+	return strconv.FormatInt(id, 10)
 }

--- a/discord_test.go
+++ b/discord_test.go
@@ -16,11 +16,11 @@ var (
 	dg    *Session // Stores a global discordgo user session
 	dgBot *Session // Stores a global discordgo bot session
 
-	envToken    = os.Getenv("DGU_TOKEN")  // Token to use when authenticating the user account
-	envBotToken = os.Getenv("DGB_TOKEN")  // Token to use when authenticating the bot account
-	envGuild    = os.Getenv("DG_GUILD")   // Guild ID to use for tests
-	envChannel  = os.Getenv("DG_CHANNEL") // Channel ID to use for tests
-	envAdmin    = os.Getenv("DG_ADMIN")   // User ID of admin user to use for tests
+	envToken    = os.Getenv("DGU_TOKEN")           // Token to use when authenticating the user account
+	envBotToken = os.Getenv("DGB_TOKEN")           // Token to use when authenticating the bot account
+	envGuild    = parseID(os.Getenv("DG_GUILD"))   // Guild ID to use for tests
+	envChannel  = parseID(os.Getenv("DG_CHANNEL")) // Channel ID to use for tests
+	envAdmin    = parseID(os.Getenv("DG_ADMIN"))   // User ID of admin user to use for tests
 )
 
 func parseID(str string) int64 {

--- a/discord_test.go
+++ b/discord_test.go
@@ -3,6 +3,7 @@ package discordgo
 import (
 	"os"
 	"runtime"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,15 +15,20 @@ var (
 	dg    *Session // Stores a global discordgo user session
 	dgBot *Session // Stores a global discordgo bot session
 
-	envToken    = os.Getenv("DG_TOKEN")    // Token to use when authenticating the user account
-	envBotToken = os.Getenv("DGB_TOKEN")   // Token to use when authenticating the bot account
-	envEmail    = os.Getenv("DG_EMAIL")    // Email to use when authenticating
-	envPassword = os.Getenv("DG_PASSWORD") // Password to use when authenticating
-	envGuild    = os.Getenv("DG_GUILD")    // Guild ID to use for tests
-	envChannel  = os.Getenv("DG_CHANNEL")  // Channel ID to use for tests
-	//	envUser     = os.Getenv("DG_USER")     // User ID to use for tests
-	envAdmin = os.Getenv("DG_ADMIN") // User ID of admin user to use for tests
+	envToken    = os.Getenv("DG_TOKEN")            // Token to use when authenticating the user account
+	envBotToken = os.Getenv("DGB_TOKEN")           // Token to use when authenticating the bot account
+	envEmail    = os.Getenv("DG_EMAIL")            // Email to use when authenticating
+	envPassword = os.Getenv("DG_PASSWORD")         // Password to use when authenticating
+	envGuild    = parseID(os.Getenv("DG_GUILD"))   // Guild ID to use for tests
+	envChannel  = parseID(os.Getenv("DG_CHANNEL")) // Channel ID to use for tests
+	//	envUser     = parseID(os.Getenv("DG_USER"))     // User ID to use for tests
+	envAdmin = parseID(os.Getenv("DG_ADMIN")) // User ID of admin user to use for tests
 )
+
+func parseID(str string) int64 {
+	id, _ := strconv.ParseInt(str, 10, 64)
+	return id
+}
 
 func init() {
 	if envBotToken != "" {

--- a/endpoints.go
+++ b/endpoints.go
@@ -59,77 +59,82 @@ var (
 	EndpointIntegrations = EndpointAPI + "integrations"
 
 	EndpointUser               = func(uID string) string { return EndpointUsers + uID }
-	EndpointUserAvatar         = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".png" }
-	EndpointUserAvatarAnimated = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".gif" }
+	EndpointUserAvatar         = func(uID int64, aID string) string { return EndpointCDNAvatars + StrID(uID) + "/" + aID + ".png" }
+	EndpointUserAvatarAnimated = func(uID int64, aID string) string { return EndpointCDNAvatars + StrID(uID) + "/" + aID + ".gif" }
 	EndpointUserSettings       = func(uID string) string { return EndpointUsers + uID + "/settings" }
 	EndpointUserGuilds         = func(uID string) string { return EndpointUsers + uID + "/guilds" }
-	EndpointUserGuild          = func(uID, gID string) string { return EndpointUsers + uID + "/guilds/" + gID }
-	EndpointUserGuildSettings  = func(uID, gID string) string { return EndpointUsers + uID + "/guilds/" + gID + "/settings" }
+	EndpointUserGuild          = func(uID string, gID int64) string { return EndpointUsers + uID + "/guilds/" + StrID(gID) }
+	EndpointUserGuildSettings  = func(uID string, gID int64) string { return EndpointUsers + uID + "/guilds/" + StrID(gID) + "/settings" }
 	EndpointUserChannels       = func(uID string) string { return EndpointUsers + uID + "/channels" }
 	EndpointUserDevices        = func(uID string) string { return EndpointUsers + uID + "/devices" }
 	EndpointUserConnections    = func(uID string) string { return EndpointUsers + uID + "/connections" }
-	EndpointUserNotes          = func(uID string) string { return EndpointUsers + "@me/notes/" + uID }
+	EndpointUserNotes          = func(uID int64) string { return EndpointUsers + "@me/notes/" + StrID(uID) }
 
-	EndpointGuild                = func(gID string) string { return EndpointGuilds + gID }
-	EndpointGuildInivtes         = func(gID string) string { return EndpointGuilds + gID + "/invites" }
-	EndpointGuildChannels        = func(gID string) string { return EndpointGuilds + gID + "/channels" }
-	EndpointGuildMembers         = func(gID string) string { return EndpointGuilds + gID + "/members" }
-	EndpointGuildMember          = func(gID, uID string) string { return EndpointGuilds + gID + "/members/" + uID }
-	EndpointGuildMemberRole      = func(gID, uID, rID string) string { return EndpointGuilds + gID + "/members/" + uID + "/roles/" + rID }
-	EndpointGuildBans            = func(gID string) string { return EndpointGuilds + gID + "/bans" }
-	EndpointGuildBan             = func(gID, uID string) string { return EndpointGuilds + gID + "/bans/" + uID }
-	EndpointGuildIntegrations    = func(gID string) string { return EndpointGuilds + gID + "/integrations" }
-	EndpointGuildIntegration     = func(gID, iID string) string { return EndpointGuilds + gID + "/integrations/" + iID }
-	EndpointGuildIntegrationSync = func(gID, iID string) string { return EndpointGuilds + gID + "/integrations/" + iID + "/sync" }
-	EndpointGuildRoles           = func(gID string) string { return EndpointGuilds + gID + "/roles" }
-	EndpointGuildRole            = func(gID, rID string) string { return EndpointGuilds + gID + "/roles/" + rID }
-	EndpointGuildInvites         = func(gID string) string { return EndpointGuilds + gID + "/invites" }
-	EndpointGuildEmbed           = func(gID string) string { return EndpointGuilds + gID + "/embed" }
-	EndpointGuildPrune           = func(gID string) string { return EndpointGuilds + gID + "/prune" }
-	EndpointGuildIcon            = func(gID, hash string) string { return EndpointCDNIcons + gID + "/" + hash + ".png" }
-	EndpointGuildSplash          = func(gID, hash string) string { return EndpointCDNSplashes + gID + "/" + hash + ".png" }
-	EndpointGuildWebhooks        = func(gID string) string { return EndpointGuilds + gID + "/webhooks" }
+	EndpointGuild           = func(gID int64) string { return EndpointGuilds + StrID(gID) }
+	EndpointGuildInivtes    = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/invites" }
+	EndpointGuildChannels   = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/channels" }
+	EndpointGuildMembers    = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/members" }
+	EndpointGuildMember     = func(gID int64, uID int64) string { return EndpointGuilds + StrID(gID) + "/members/" + StrID(uID) }
+	EndpointGuildMemberMe   = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/members/@me" }
+	EndpointGuildMemberRole = func(gID, uID, rID int64) string {
+		return EndpointGuilds + StrID(gID) + "/members/" + StrID(uID) + "/roles/" + StrID(rID)
+	}
+	EndpointGuildBans            = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/bans" }
+	EndpointGuildBan             = func(gID, uID int64) string { return EndpointGuilds + StrID(gID) + "/bans/" + StrID(uID) }
+	EndpointGuildIntegrations    = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/integrations" }
+	EndpointGuildIntegration     = func(gID, iID int64) string { return EndpointGuilds + StrID(gID) + "/integrations/" + StrID(iID) }
+	EndpointGuildIntegrationSync = func(gID, iID int64) string {
+		return EndpointGuilds + StrID(gID) + "/integrations/" + StrID(iID) + "/sync"
+	}
+	EndpointGuildRoles    = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/roles" }
+	EndpointGuildRole     = func(gID, rID int64) string { return EndpointGuilds + StrID(gID) + "/roles/" + StrID(rID) }
+	EndpointGuildInvites  = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/invites" }
+	EndpointGuildEmbed    = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/embed" }
+	EndpointGuildPrune    = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/prune" }
+	EndpointGuildIcon     = func(gID int64, hash string) string { return EndpointCDNIcons + StrID(gID) + "/" + hash + ".png" }
+	EndpointGuildSplash   = func(gID int64, hash string) string { return EndpointCDNSplashes + StrID(gID) + "/" + hash + ".png" }
+	EndpointGuildWebhooks = func(gID int64) string { return EndpointGuilds + StrID(gID) + "/webhooks" }
 
-	EndpointChannel                   = func(cID string) string { return EndpointChannels + cID }
-	EndpointChannelPermissions        = func(cID string) string { return EndpointChannels + cID + "/permissions" }
-	EndpointChannelPermission         = func(cID, tID string) string { return EndpointChannels + cID + "/permissions/" + tID }
-	EndpointChannelInvites            = func(cID string) string { return EndpointChannels + cID + "/invites" }
-	EndpointChannelTyping             = func(cID string) string { return EndpointChannels + cID + "/typing" }
-	EndpointChannelMessages           = func(cID string) string { return EndpointChannels + cID + "/messages" }
-	EndpointChannelMessage            = func(cID, mID string) string { return EndpointChannels + cID + "/messages/" + mID }
-	EndpointChannelMessageAck         = func(cID, mID string) string { return EndpointChannels + cID + "/messages/" + mID + "/ack" }
-	EndpointChannelMessagesBulkDelete = func(cID string) string { return EndpointChannel(cID) + "/messages/bulk_delete" }
-	EndpointChannelMessagesPins       = func(cID string) string { return EndpointChannel(cID) + "/pins" }
-	EndpointChannelMessagePin         = func(cID, mID string) string { return EndpointChannel(cID) + "/pins/" + mID }
+	EndpointChannel                   = func(cID int64) string { return EndpointChannels + StrID(cID) }
+	EndpointChannelPermissions        = func(cID int64) string { return EndpointChannels + StrID(cID) + "/permissions" }
+	EndpointChannelPermission         = func(cID, tID int64) string { return EndpointChannels + StrID(cID) + "/permissions/" + StrID(tID) }
+	EndpointChannelInvites            = func(cID int64) string { return EndpointChannels + StrID(cID) + "/invites" }
+	EndpointChannelTyping             = func(cID int64) string { return EndpointChannels + StrID(cID) + "/typing" }
+	EndpointChannelMessages           = func(cID int64) string { return EndpointChannels + StrID(cID) + "/messages" }
+	EndpointChannelMessage            = func(cID, mID int64) string { return EndpointChannels + StrID(cID) + "/messages/" + StrID(mID) }
+	EndpointChannelMessageAck         = func(cID, mID int64) string { return EndpointChannels + StrID(cID) + "/messages/" + StrID(mID) + "/ack" }
+	EndpointChannelMessagesBulkDelete = func(cID int64) string { return EndpointChannel(cID) + "/messages/bulk_delete" }
+	EndpointChannelMessagesPins       = func(cID int64) string { return EndpointChannel(cID) + "/pins" }
+	EndpointChannelMessagePin         = func(cID, mID int64) string { return EndpointChannel(cID) + "/pins/" + StrID(mID) }
 
-	EndpointGroupIcon = func(cID, hash string) string { return EndpointCDNChannelIcons + cID + "/" + hash + ".png" }
+	EndpointGroupIcon = func(cID int64, hash string) string { return EndpointCDNChannelIcons + StrID(cID) + "/" + hash + ".png" }
 
-	EndpointChannelWebhooks = func(cID string) string { return EndpointChannel(cID) + "/webhooks" }
-	EndpointWebhook         = func(wID string) string { return EndpointWebhooks + wID }
-	EndpointWebhookToken    = func(wID, token string) string { return EndpointWebhooks + wID + "/" + token }
+	EndpointChannelWebhooks = func(cID int64) string { return EndpointChannel(cID) + "/webhooks" }
+	EndpointWebhook         = func(wID int64) string { return EndpointWebhooks + StrID(wID) }
+	EndpointWebhookToken    = func(wID int64, token string) string { return EndpointWebhooks + StrID(wID) + "/" + token }
 
-	EndpointMessageReactionsAll = func(cID, mID string) string {
+	EndpointMessageReactionsAll = func(cID, mID int64) string {
 		return EndpointChannelMessage(cID, mID) + "/reactions"
 	}
-	EndpointMessageReactions = func(cID, mID, eID string) string {
-		return EndpointChannelMessage(cID, mID) + "/reactions/" + eID
+	EndpointMessageReactions = func(cID, mID, eID int64) string {
+		return EndpointChannelMessage(cID, mID) + "/reactions/" + StrID(eID)
 	}
-	EndpointMessageReaction = func(cID, mID, eID, uID string) string {
+	EndpointMessageReaction = func(cID, mID, eID int64, uID string) string {
 		return EndpointMessageReactions(cID, mID, eID) + "/" + uID
 	}
 
 	EndpointRelationships       = func() string { return EndpointUsers + "@me" + "/relationships" }
-	EndpointRelationship        = func(uID string) string { return EndpointRelationships() + "/" + uID }
-	EndpointRelationshipsMutual = func(uID string) string { return EndpointUsers + uID + "/relationships" }
+	EndpointRelationship        = func(uID int64) string { return EndpointRelationships() + "/" + StrID(uID) }
+	EndpointRelationshipsMutual = func(uID int64) string { return EndpointUsers + StrID(uID) + "/relationships" }
 
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invite/" + iID }
 
 	EndpointIntegrationsJoin = func(iID string) string { return EndpointAPI + "integrations/" + iID + "/join" }
 
-	EndpointEmoji = func(eID string) string { return EndpointAPI + "emojis/" + eID + ".png" }
+	EndpointEmoji = func(eID int64) string { return EndpointAPI + "emojis/" + StrID(eID) + ".png" }
 
 	EndpointOauth2          = EndpointAPI + "oauth2/"
 	EndpointApplications    = EndpointOauth2 + "applications"
-	EndpointApplication     = func(aID string) string { return EndpointApplications + "/" + aID }
-	EndpointApplicationsBot = func(aID string) string { return EndpointApplications + "/" + aID + "/bot" }
+	EndpointApplication     = func(aID int64) string { return EndpointApplications + "/" + StrID(aID) }
+	EndpointApplicationsBot = func(aID int64) string { return EndpointApplications + "/" + StrID(aID) + "/bot" }
 )

--- a/endpoints.go
+++ b/endpoints.go
@@ -123,10 +123,10 @@ var (
 	EndpointMessageReactionsAll = func(cID, mID int64) string {
 		return EndpointChannelMessage(cID, mID) + "/reactions"
 	}
-	EndpointMessageReactions = func(cID, mID, eID int64) string {
-		return EndpointChannelMessage(cID, mID) + "/reactions/" + StrID(eID)
+	EndpointMessageReactions = func(cID, mID int64, eID string) string {
+		return EndpointChannelMessage(cID, mID) + "/reactions/" + eID
 	}
-	EndpointMessageReaction = func(cID, mID, eID int64, uID string) string {
+	EndpointMessageReaction = func(cID, mID int64, eID string, uID string) string {
 		return EndpointMessageReactions(cID, mID, eID) + "/" + uID
 	}
 

--- a/events.go
+++ b/events.go
@@ -126,31 +126,31 @@ type GuildRoleUpdate struct {
 
 // A GuildRoleDelete is the data for a GuildRoleDelete event.
 type GuildRoleDelete struct {
-	RoleID  string `json:"role_id"`
-	GuildID string `json:"guild_id"`
+	RoleID  int64 `json:"role_id,string"`
+	GuildID int64 `json:"guild_id,string"`
 }
 
 // A GuildEmojisUpdate is the data for a guild emoji update event.
 type GuildEmojisUpdate struct {
-	GuildID string   `json:"guild_id"`
+	GuildID int64    `json:"guild_id,string"`
 	Emojis  []*Emoji `json:"emojis"`
 }
 
 // A GuildMembersChunk is the data for a GuildMembersChunk event.
 type GuildMembersChunk struct {
-	GuildID string    `json:"guild_id"`
+	GuildID int64     `json:"guild_id,string"`
 	Members []*Member `json:"members"`
 }
 
 // GuildIntegrationsUpdate is the data for a GuildIntegrationsUpdate event.
 type GuildIntegrationsUpdate struct {
-	GuildID string `json:"guild_id"`
+	GuildID int64 `json:"guild_id,string"`
 }
 
 // MessageAck is the data for a MessageAck event.
 type MessageAck struct {
-	MessageID string `json:"message_id"`
-	ChannelID string `json:"channel_id"`
+	MessageID int64 `json:"message_id,string"`
+	ChannelID int64 `json:"channel_id,string"`
 }
 
 // MessageCreate is the data for a MessageCreate event.
@@ -189,8 +189,8 @@ type PresencesReplace []*Presence
 // PresenceUpdate is the data for a PresenceUpdate event.
 type PresenceUpdate struct {
 	Presence
-	GuildID string   `json:"guild_id"`
-	Roles   []string `json:"roles"`
+	GuildID int64   `json:"guild_id,string"`
+	Roles   IDSlice `json:"roles,string"`
 }
 
 // Resumed is the data for a Resumed event.
@@ -210,9 +210,9 @@ type RelationshipRemove struct {
 
 // TypingStart is the data for a TypingStart event.
 type TypingStart struct {
-	UserID    string `json:"user_id"`
-	ChannelID string `json:"channel_id"`
-	Timestamp int    `json:"timestamp"`
+	UserID    int64 `json:"user_id,string"`
+	ChannelID int64 `json:"channel_id,string"`
+	Timestamp int   `json:"timestamp"`
 }
 
 // UserUpdate is the data for a UserUpdate event.
@@ -230,14 +230,14 @@ type UserGuildSettingsUpdate struct {
 
 // UserNoteUpdate is the data for a UserNoteUpdate event.
 type UserNoteUpdate struct {
-	ID   string `json:"id"`
+	ID   int64  `json:"id,string"`
 	Note string `json:"note"`
 }
 
 // VoiceServerUpdate is the data for a VoiceServerUpdate event.
 type VoiceServerUpdate struct {
 	Token    string `json:"token"`
-	GuildID  string `json:"guild_id"`
+	GuildID  int64  `json:"guild_id,string"`
 	Endpoint string `json:"endpoint"`
 }
 
@@ -248,6 +248,6 @@ type VoiceStateUpdate struct {
 
 // MessageDeleteBulk is the data for a MessageDeleteBulk event
 type MessageDeleteBulk struct {
-	Messages  []string `json:"ids"`
-	ChannelID string   `json:"channel_id"`
+	Messages  IDSlice `json:"ids,string"`
+	ChannelID int64   `json:"channel_id,string"`
 }

--- a/events.go
+++ b/events.go
@@ -69,7 +69,7 @@ type ChannelDelete struct {
 // ChannelPinsUpdate stores data for a ChannelPinsUpdate event.
 type ChannelPinsUpdate struct {
 	LastPinTimestamp string `json:"last_pin_timestamp"`
-	ChannelID        string `json:"channel_id"`
+	ChannelID        int64  `json:"channel_id,string"`
 }
 
 // GuildCreate is the data for a GuildCreate event.
@@ -89,14 +89,14 @@ type GuildDelete struct {
 
 // GuildBanAdd is the data for a GuildBanAdd event.
 type GuildBanAdd struct {
-	User    *User  `json:"user"`
-	GuildID string `json:"guild_id"`
+	User    *User `json:"user"`
+	GuildID int64 `json:"guild_id,string"`
 }
 
 // GuildBanRemove is the data for a GuildBanRemove event.
 type GuildBanRemove struct {
-	User    *User  `json:"user"`
-	GuildID string `json:"guild_id"`
+	User    *User `json:"user"`
+	GuildID int64 `json:"guild_id,string"`
 }
 
 // GuildMemberAdd is the data for a GuildMemberAdd event.

--- a/examples/airhorn/main.go
+++ b/examples/airhorn/main.go
@@ -179,7 +179,7 @@ func loadSound() error {
 }
 
 // playSound plays the current buffer to the provided channel.
-func playSound(s *discordgo.Session, guildID, channelID string) (err error) {
+func playSound(s *discordgo.Session, guildID, channelID int64) (err error) {
 
 	// Join the provided voice channel.
 	vc, err := s.ChannelVoiceJoin(guildID, channelID, false, true)

--- a/message.go
+++ b/message.go
@@ -53,7 +53,7 @@ type Message struct {
 	EditedTimestamp Timestamp `json:"edited_timestamp"`
 
 	// The roles mentioned in the message.
-	MentionRoles []string `json:"mention_roles"`
+	MentionRoles IDSlice `json:"mention_roles,string"`
 
 	// Whether the message is text-to-speech.
 	Tts bool `json:"tts"`

--- a/message.go
+++ b/message.go
@@ -12,6 +12,7 @@ package discordgo
 import (
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -30,12 +31,12 @@ const (
 
 // A Message stores all data related to a specific Discord message.
 type Message struct {
-	ID              string               `json:"id"`
-	ChannelID       string               `json:"channel_id"`
+	ID              int64                `json:"id,string"`
+	ChannelID       int64                `json:"channel_id,string"`
 	Content         string               `json:"content"`
 	Timestamp       Timestamp            `json:"timestamp"`
 	EditedTimestamp Timestamp            `json:"edited_timestamp"`
-	MentionRoles    []string             `json:"mention_roles"`
+	MentionRoles    IDSlice              `json:"mention_roles"`
 	Tts             bool                 `json:"tts"`
 	MentionEveryone bool                 `json:"mention_everyone"`
 	Author          *User                `json:"author"`
@@ -70,13 +71,13 @@ type MessageEdit struct {
 	Content *string       `json:"content,omitempty"`
 	Embed   *MessageEmbed `json:"embed,omitempty"`
 
-	ID      string
-	Channel string
+	ID      int64
+	Channel int64
 }
 
 // NewMessageEdit returns a MessageEdit struct, initialized
 // with the Channel and ID.
-func NewMessageEdit(channelID string, messageID string) *MessageEdit {
+func NewMessageEdit(channelID int64, messageID int64) *MessageEdit {
 	return &MessageEdit{
 		Channel: channelID,
 		ID:      messageID,
@@ -191,8 +192,8 @@ func (m *Message) ContentWithMentionsReplaced() (content string) {
 
 	for _, user := range m.Mentions {
 		content = strings.NewReplacer(
-			"<@"+user.ID+">", "@"+user.Username,
-			"<@!"+user.ID+">", "@"+user.Username,
+			"<@"+StrID(user.ID)+">", "@"+user.Username,
+			"<@!"+StrID(user.ID)+">", "@"+user.Username,
 		).Replace(content)
 	}
 	return
@@ -225,8 +226,8 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 		}
 
 		content = strings.NewReplacer(
-			"<@"+user.ID+">", "@"+user.Username,
-			"<@!"+user.ID+">", "@"+nick,
+			"<@"+StrID(user.ID)+">", "@"+user.Username,
+			"<@!"+StrID(user.ID)+">", "@"+nick,
 		).Replace(content)
 	}
 	for _, roleID := range m.MentionRoles {
@@ -235,11 +236,16 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 			continue
 		}
 
-		content = strings.Replace(content, "<&"+role.ID+">", "@"+role.Name, -1)
+		content = strings.Replace(content, "<&"+StrID(role.ID)+">", "@"+role.Name, -1)
 	}
 
 	content = patternChannels.ReplaceAllStringFunc(content, func(mention string) string {
-		channel, err := s.State.Channel(mention[2 : len(mention)-1])
+		id, err := strconv.ParseInt(mention[2:len(mention)-1], 10, 64)
+		if err != nil {
+			return mention
+		}
+
+		channel, err := s.State.Channel(id)
 		if err != nil || channel.Type == ChannelTypeGuildVoice {
 			return mention
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -8,31 +8,31 @@ func TestContentWithMoreMentionsReplaced(t *testing.T) {
 	s := &Session{StateEnabled: true, State: NewState()}
 
 	user := &User{
-		ID:       "user",
+		ID:       1,
 		Username: "User Name",
 	}
 
 	s.StateEnabled = true
-	s.State.GuildAdd(&Guild{ID: "guild"})
-	s.State.RoleAdd("guild", &Role{
-		ID:          "role",
+	s.State.GuildAdd(&Guild{ID: 10})
+	s.State.RoleAdd(10, &Role{
+		ID:          20,
 		Name:        "Role Name",
 		Mentionable: true,
 	})
 	s.State.MemberAdd(&Member{
 		User:    user,
 		Nick:    "User Nick",
-		GuildID: "guild",
+		GuildID: 10,
 	})
 	s.State.ChannelAdd(&Channel{
 		Name:    "Channel Name",
-		GuildID: "guild",
-		ID:      "channel",
+		GuildID: 10,
+		ID:      30,
 	})
 	m := &Message{
-		Content:      "<&role> <@!user> <@user> <#channel>",
-		ChannelID:    "channel",
-		MentionRoles: []string{"role"},
+		Content:      "<&20> <@!1> <@1> <#30>",
+		ChannelID:    30,
+		MentionRoles: []int64{20},
 		Mentions:     []*User{user},
 	}
 	if result, _ := m.ContentWithMoreMentionsReplaced(s); result != "@Role Name @User Nick @User Name #Channel Name" {

--- a/oauth2.go
+++ b/oauth2.go
@@ -15,7 +15,7 @@ package discordgo
 
 // An Application struct stores values for a Discord OAuth2 Application
 type Application struct {
-	ID                  string    `json:"id,omitempty"`
+	ID                  int64     `json:"id,omitempty"`
 	Name                string    `json:"name"`
 	Description         string    `json:"description,omitempty"`
 	Icon                string    `json:"icon,omitempty"`
@@ -31,9 +31,9 @@ type Application struct {
 
 // Application returns an Application structure of a specific Application
 //   appID : The ID of an Application
-func (s *Session) Application(appID string) (st *Application, err error) {
+func (s *Session) Application(appID int64) (st *Application, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointApplication(appID), nil, EndpointApplication(""))
+	body, err := s.RequestWithBucketID("GET", EndpointApplication(appID), nil, EndpointApplication(0))
 	if err != nil {
 		return
 	}
@@ -76,7 +76,7 @@ func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error
 
 // ApplicationUpdate updates an existing Application
 //   var : desc
-func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Application, err error) {
+func (s *Session) ApplicationUpdate(appID int64, ap *Application) (st *Application, err error) {
 
 	data := struct {
 		Name         string    `json:"name"`
@@ -84,7 +84,7 @@ func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Applicat
 		RedirectURIs *[]string `json:"redirect_uris,omitempty"`
 	}{ap.Name, ap.Description, ap.RedirectURIs}
 
-	body, err := s.RequestWithBucketID("PUT", EndpointApplication(appID), data, EndpointApplication(""))
+	body, err := s.RequestWithBucketID("PUT", EndpointApplication(appID), data, EndpointApplication(0))
 	if err != nil {
 		return
 	}
@@ -95,9 +95,9 @@ func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Applicat
 
 // ApplicationDelete deletes an existing Application
 //   appID : The ID of an Application
-func (s *Session) ApplicationDelete(appID string) (err error) {
+func (s *Session) ApplicationDelete(appID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointApplication(appID), nil, EndpointApplication(""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointApplication(appID), nil, EndpointApplication(0))
 	if err != nil {
 		return
 	}
@@ -114,9 +114,9 @@ func (s *Session) ApplicationDelete(appID string) (err error) {
 //   appID : The ID of an Application
 //
 // NOTE: func name may change, if I can think up something better.
-func (s *Session) ApplicationBotCreate(appID string) (st *User, err error) {
+func (s *Session) ApplicationBotCreate(appID int64) (st *User, err error) {
 
-	body, err := s.RequestWithBucketID("POST", EndpointApplicationsBot(appID), nil, EndpointApplicationsBot(""))
+	body, err := s.RequestWithBucketID("POST", EndpointApplicationsBot(appID), nil, EndpointApplicationsBot(0))
 	if err != nil {
 		return
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -1983,9 +1983,9 @@ func (s *Session) WebhookExecute(webhookID int64, token string, wait bool, data 
 // channelID : The channel ID.
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
-func (s *Session) MessageReactionAdd(channelID, messageID, emojiID int64) error {
+func (s *Session) MessageReactionAdd(channelID, messageID int64, emojiID string) error {
 
-	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, 0, 0, ""))
+	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, 0, "", ""))
 
 	return err
 }
@@ -1995,9 +1995,9 @@ func (s *Session) MessageReactionAdd(channelID, messageID, emojiID int64) error 
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
 // userID	 : The ID of the user to delete the reaction for.
-func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID int64) error {
+func (s *Session) MessageReactionRemove(channelID, messageID int64, emojiID string, userID int64) error {
 
-	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, StrID(userID)), nil, EndpointMessageReaction(channelID, 0, 0, ""))
+	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, StrID(userID)), nil, EndpointMessageReaction(channelID, 0, "", ""))
 
 	return err
 }
@@ -2006,9 +2006,9 @@ func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID in
 // channelID : The channel ID.
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
-func (s *Session) MessageReactionRemoveMe(channelID, messageID, emojiID int64) error {
+func (s *Session) MessageReactionRemoveMe(channelID, messageID int64, emojiID string) error {
 
-	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, 0, 0, ""))
+	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, 0, "", ""))
 
 	return err
 }
@@ -2028,7 +2028,7 @@ func (s *Session) MessageReactionsRemoveAll(channelID, messageID int64) error {
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
 // limit    : max number of users to return (max 100)
-func (s *Session) MessageReactions(channelID, messageID, emojiID int64, limit int) (st []*User, err error) {
+func (s *Session) MessageReactions(channelID, messageID int64, emojiID string, limit int) (st []*User, err error) {
 	uri := EndpointMessageReactions(channelID, messageID, emojiID)
 
 	v := url.Values{}
@@ -2041,7 +2041,7 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID int64, limit in
 		uri = fmt.Sprintf("%s?%s", uri, v.Encode())
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointMessageReaction(channelID, 0, 0, ""))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointMessageReaction(channelID, 0, "", ""))
 	if err != nil {
 		return
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -747,14 +747,14 @@ func (s *Session) GuildBanDelete(guildID, userID int64) (err error) {
 //  guildID  : The ID of a Guild.
 //  after    : The id of the member to return members after
 //  limit    : max number of members to return (max 1000)
-func (s *Session) GuildMembers(guildID int64, after string, limit int) (st []*Member, err error) {
+func (s *Session) GuildMembers(guildID int64, after int64, limit int) (st []*Member, err error) {
 
 	uri := EndpointGuildMembers(guildID)
 
 	v := url.Values{}
 
-	if after != "" {
-		v.Set("after", after)
+	if after != 0 {
+		v.Set("after", StrID(after))
 	}
 
 	if limit > 0 {

--- a/restapi.go
+++ b/restapi.go
@@ -1248,16 +1248,16 @@ func (s *Session) GuildEmbedEdit(guildID int64, enabled bool, channelID int64) (
 // beforeID    : If provided all log entries returned will be before the given ID.
 // actionType  : If provided the log will be filtered for the given Action Type.
 // limit       : The number messages that can be returned. (default 50, min 1, max 100)
-func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, limit int) (st *GuildAuditLog, err error) {
+func (s *Session) GuildAuditLog(guildID, userID, beforeID int64, actionType, limit int) (st *GuildAuditLog, err error) {
 
 	uri := EndpointGuildAuditLogs(guildID)
 
 	v := url.Values{}
-	if userID != "" {
-		v.Set("user_id", userID)
+	if userID != 0 {
+		v.Set("user_id", StrID(userID))
 	}
-	if beforeID != "" {
-		v.Set("before", beforeID)
+	if beforeID != 0 {
+		v.Set("before", StrID(beforeID))
 	}
 	if actionType > 0 {
 		v.Set("action_type", strconv.Itoa(actionType))
@@ -1944,12 +1944,6 @@ func (s *Session) WebhookEditWithToken(webhookID int64, token, name, avatar stri
 // WebhookDelete deletes a webhook for a given ID
 // webhookID: The ID of a webhook.
 func (s *Session) WebhookDelete(webhookID int64) (err error) {
-
-	body, err := s.RequestWithBucketID("DELETE", EndpointWebhook(webhookID), nil, EndpointWebhooks)
-	if err != nil {
-		return
-	}
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointWebhook(webhookID), nil, EndpointWebhooks)
 
 	return

--- a/restapi.go
+++ b/restapi.go
@@ -266,10 +266,22 @@ func (s *Session) Logout() (err error) {
 // ------------------------------------------------------------------------------------------------
 
 // User returns the user details of the given userID
-// userID    : A user ID or "@me" which is a shortcut of current user ID
-func (s *Session) User(userID string) (st *User, err error) {
+// userID    : A user ID
+func (s *Session) User(userID int64) (st *User, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointUser(userID), nil, EndpointUsers)
+	body, err := s.RequestWithBucketID("GET", EndpointUser(StrID(userID)), nil, EndpointUsers)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
+// UserMe returns the user details of the current user
+func (s *Session) UserMe() (st *User, err error) {
+
+	body, err := s.RequestWithBucketID("GET", EndpointUser("@me"), nil, EndpointUsers)
 	if err != nil {
 		return
 	}
@@ -280,7 +292,7 @@ func (s *Session) User(userID string) (st *User, err error) {
 
 // UserAvatar is deprecated. Please use UserAvatarDecode
 // userID    : A user ID or "@me" which is a shortcut of current user ID
-func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
+func (s *Session) UserAvatar(userID int64) (img image.Image, err error) {
 	u, err := s.User(userID)
 	if err != nil {
 		return
@@ -292,7 +304,7 @@ func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 // UserAvatarDecode returns an image.Image of a user's Avatar
 // user : The user which avatar should be retrieved
 func (s *Session) UserAvatarDecode(u *User) (img image.Image, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(u.ID, u.Avatar), nil, EndpointUserAvatar("", ""))
+	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(u.ID, u.Avatar), nil, EndpointUserAvatar(0, ""))
 	if err != nil {
 		return
 	}
@@ -374,10 +386,10 @@ func (s *Session) UserChannels() (st []*Channel, err error) {
 
 // UserChannelCreate creates a new User (Private) Channel with another User
 // recipientID : A user ID for the user to which this channel is opened with.
-func (s *Session) UserChannelCreate(recipientID string) (st *Channel, err error) {
+func (s *Session) UserChannelCreate(recipientID int64) (st *Channel, err error) {
 
 	data := struct {
-		RecipientID string `json:"recipient_id"`
+		RecipientID int64 `json:"recipient_id,string"`
 	}{recipientID}
 
 	body, err := s.RequestWithBucketID("POST", EndpointUserChannels("@me"), data, EndpointUserChannels(""))
@@ -393,18 +405,18 @@ func (s *Session) UserChannelCreate(recipientID string) (st *Channel, err error)
 // limit     : The number guilds that can be returned. (max 100)
 // beforeID  : If provided all guilds returned will be before given ID.
 // afterID   : If provided all guilds returned will be after given ID.
-func (s *Session) UserGuilds(limit int, beforeID, afterID string) (st []*UserGuild, err error) {
+func (s *Session) UserGuilds(limit int, beforeID, afterID int64) (st []*UserGuild, err error) {
 
 	v := url.Values{}
 
 	if limit > 0 {
 		v.Set("limit", strconv.Itoa(limit))
 	}
-	if afterID != "" {
-		v.Set("after", afterID)
+	if afterID != 0 {
+		v.Set("after", StrID(afterID))
 	}
-	if beforeID != "" {
-		v.Set("before", beforeID)
+	if beforeID != 0 {
+		v.Set("before", StrID(beforeID))
 	}
 
 	uri := EndpointUserGuilds("@me")
@@ -425,7 +437,7 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string) (st []*UserGui
 // UserGuildSettingsEdit Edits the users notification settings for a guild
 // guildID   : The ID of the guild to edit the settings on
 // settings  : The settings to update
-func (s *Session) UserGuildSettingsEdit(guildID string, settings *UserGuildSettingsEdit) (st *UserGuildSettings, err error) {
+func (s *Session) UserGuildSettingsEdit(guildID int64, settings *UserGuildSettingsEdit) (st *UserGuildSettings, err error) {
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointUserGuildSettings("@me", guildID), settings, EndpointUserGuildSettings("", guildID))
 	if err != nil {
@@ -442,7 +454,7 @@ func (s *Session) UserGuildSettingsEdit(guildID string, settings *UserGuildSetti
 //
 // NOTE: This function is now deprecated and will be removed in the future.
 // Please see the same function inside state.go
-func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions int, err error) {
+func (s *Session) UserChannelPermissions(userID, channelID int64) (apermissions int, err error) {
 	// Try to just get permissions from state.
 	apermissions, err = s.State.UserChannelPermissions(userID, channelID)
 	if err == nil {
@@ -559,7 +571,7 @@ func memberPermissions(guild *Guild, channel *Channel, member *Member) (apermiss
 
 // Guild returns a Guild structure of a specific Guild.
 // guildID   : The ID of a Guild
-func (s *Session) Guild(guildID string) (st *Guild, err error) {
+func (s *Session) Guild(guildID int64) (st *Guild, err error) {
 	if s.StateEnabled {
 		// Attempt to grab the guild from State first.
 		st, err = s.State.Guild(guildID)
@@ -597,7 +609,7 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 // GuildEdit edits a new Guild
 // guildID   : The ID of a Guild
 // g 		 : A GuildParams struct with the values Name, Region and VerificationLevel defined.
-func (s *Session) GuildEdit(guildID string, g GuildParams) (st *Guild, err error) {
+func (s *Session) GuildEdit(guildID int64, g GuildParams) (st *Guild, err error) {
 
 	// Bounds checking for VerificationLevel, interval: [0, 3]
 	if g.VerificationLevel != nil {
@@ -638,7 +650,7 @@ func (s *Session) GuildEdit(guildID string, g GuildParams) (st *Guild, err error
 
 // GuildDelete deletes a Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildDelete(guildID string) (st *Guild, err error) {
+func (s *Session) GuildDelete(guildID int64) (st *Guild, err error) {
 
 	body, err := s.RequestWithBucketID("DELETE", EndpointGuild(guildID), nil, EndpointGuild(guildID))
 	if err != nil {
@@ -651,7 +663,7 @@ func (s *Session) GuildDelete(guildID string) (st *Guild, err error) {
 
 // GuildLeave leaves a Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildLeave(guildID string) (err error) {
+func (s *Session) GuildLeave(guildID int64) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointUserGuild("@me", guildID), nil, EndpointUserGuild("", guildID))
 	return
@@ -660,7 +672,7 @@ func (s *Session) GuildLeave(guildID string) (err error) {
 // GuildBans returns an array of User structures for all bans of a
 // given guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildBans(guildID string) (st []*GuildBan, err error) {
+func (s *Session) GuildBans(guildID int64) (st []*GuildBan, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildBans(guildID), nil, EndpointGuildBans(guildID))
 	if err != nil {
@@ -676,7 +688,7 @@ func (s *Session) GuildBans(guildID string) (st []*GuildBan, err error) {
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
 // days      : The number of days of previous comments to delete.
-func (s *Session) GuildBanCreate(guildID, userID string, days int) (err error) {
+func (s *Session) GuildBanCreate(guildID, userID int64, days int) (err error) {
 	return s.GuildBanCreateWithReason(guildID, userID, "", days)
 }
 
@@ -685,7 +697,7 @@ func (s *Session) GuildBanCreate(guildID, userID string, days int) (err error) {
 // userID    : The ID of a User
 // reason    : The reason for this ban
 // days      : The number of days of previous comments to delete.
-func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days int) (err error) {
+func (s *Session) GuildBanCreateWithReason(guildID, userID int64, reason string, days int) (err error) {
 
 	uri := EndpointGuildBan(guildID, userID)
 
@@ -701,16 +713,16 @@ func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days 
 		uri += "?" + queryParams.Encode()
 	}
 
-	_, err = s.RequestWithBucketID("PUT", uri, nil, EndpointGuildBan(guildID, ""))
+	_, err = s.RequestWithBucketID("PUT", uri, nil, EndpointGuildBan(guildID, 0))
 	return
 }
 
 // GuildBanDelete removes the given user from the guild bans
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-func (s *Session) GuildBanDelete(guildID, userID string) (err error) {
+func (s *Session) GuildBanDelete(guildID, userID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, 0))
 	return
 }
 
@@ -718,7 +730,7 @@ func (s *Session) GuildBanDelete(guildID, userID string) (err error) {
 //  guildID  : The ID of a Guild.
 //  after    : The id of the member to return members after
 //  limit    : max number of members to return (max 1000)
-func (s *Session) GuildMembers(guildID string, after string, limit int) (st []*Member, err error) {
+func (s *Session) GuildMembers(guildID int64, after string, limit int) (st []*Member, err error) {
 
 	uri := EndpointGuildMembers(guildID)
 
@@ -748,9 +760,9 @@ func (s *Session) GuildMembers(guildID string, after string, limit int) (st []*M
 // GuildMember returns a member of a guild.
 //  guildID   : The ID of a Guild.
 //  userID    : The ID of a User
-func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
+func (s *Session) GuildMember(guildID, userID int64) (st *Member, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildMember(guildID, userID), nil, EndpointGuildMember(guildID, ""))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildMember(guildID, userID), nil, EndpointGuildMember(guildID, 0))
 	if err != nil {
 		return
 	}
@@ -762,7 +774,7 @@ func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
 // GuildMemberDelete removes the given user from the given guild.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-func (s *Session) GuildMemberDelete(guildID, userID string) (err error) {
+func (s *Session) GuildMemberDelete(guildID, userID int64) (err error) {
 
 	return s.GuildMemberDeleteWithReason(guildID, userID, "")
 }
@@ -771,14 +783,14 @@ func (s *Session) GuildMemberDelete(guildID, userID string) (err error) {
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
 // reason    : The reason for the kick
-func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (err error) {
+func (s *Session) GuildMemberDeleteWithReason(guildID, userID int64, reason string) (err error) {
 
 	uri := EndpointGuildMember(guildID, userID)
 	if reason != "" {
 		uri += "?reason=" + url.QueryEscape(reason)
 	}
 
-	_, err = s.RequestWithBucketID("DELETE", uri, nil, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", uri, nil, EndpointGuildMember(guildID, 0))
 	return
 }
 
@@ -786,13 +798,13 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // roles    : A list of role ID's to set on the member.
-func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err error) {
+func (s *Session) GuildMemberEdit(guildID, userID int64, roles []string) (err error) {
 
 	data := struct {
 		Roles []string `json:"roles"`
 	}{roles}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, 0))
 	if err != nil {
 		return
 	}
@@ -806,13 +818,13 @@ func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err e
 //  channelID : The ID of a channel to move user to, or null?
 // NOTE : I am not entirely set on the name of this function and it may change
 // prior to the final 1.0.0 release of Discordgo
-func (s *Session) GuildMemberMove(guildID, userID, channelID string) (err error) {
+func (s *Session) GuildMemberMove(guildID, userID, channelID int64) (err error) {
 
 	data := struct {
-		ChannelID string `json:"channel_id"`
+		ChannelID int64 `json:"channel_id,string"`
 	}{channelID}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, 0))
 	if err != nil {
 		return
 	}
@@ -822,19 +834,28 @@ func (s *Session) GuildMemberMove(guildID, userID, channelID string) (err error)
 
 // GuildMemberNickname updates the nickname of a guild member
 // guildID   : The ID of a guild
-// userID    : The ID of a user
 // userID    : The ID of a user or "@me" which is a shortcut of the current user ID
-func (s *Session) GuildMemberNickname(guildID, userID, nickname string) (err error) {
+// nickname  : The new nickname
+func (s *Session) GuildMemberNickname(guildID, userID int64, nickname string) (err error) {
 
 	data := struct {
 		Nick string `json:"nick"`
 	}{nickname}
 
-	if userID == "@me" {
-		userID += "/nick"
-	}
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, 0))
+	return
+}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+// GuildMemberNicknameMe updates the nickname the current user
+// guildID   : The ID of a guild
+// nickname  : The new nickname
+func (s *Session) GuildMemberNicknameMe(guildID int64, nickname string) (err error) {
+
+	data := struct {
+		Nick string `json:"nick"`
+	}{nickname}
+
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMemberMe(guildID)+"/nick", data, EndpointGuildMember(guildID, 0))
 	return
 }
 
@@ -842,9 +863,9 @@ func (s *Session) GuildMemberNickname(guildID, userID, nickname string) (err err
 //  guildID   : The ID of a Guild.
 //  userID    : The ID of a User.
 //  roleID 	  : The ID of a Role to be assigned to the user.
-func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string) (err error) {
+func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("PUT", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, 0, 0))
 
 	return
 }
@@ -853,9 +874,9 @@ func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string) (err error)
 //  guildID   : The ID of a Guild.
 //  userID    : The ID of a User.
 //  roleID 	  : The ID of a Role to be removed from the user.
-func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string) (err error) {
+func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, 0, 0))
 
 	return
 }
@@ -863,7 +884,7 @@ func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string) (err err
 // GuildChannels returns an array of Channel structures for all channels of a
 // given guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildChannels(guildID string) (st []*Channel, err error) {
+func (s *Session) GuildChannels(guildID int64) (st []*Channel, err error) {
 
 	body, err := s.request("GET", EndpointGuildChannels(guildID), "", nil, EndpointGuildChannels(guildID), 0)
 	if err != nil {
@@ -879,7 +900,7 @@ func (s *Session) GuildChannels(guildID string) (st []*Channel, err error) {
 // guildID   : The ID of a Guild.
 // name      : Name of the channel (2-100 chars length)
 // ctype     : Tpye of the channel (voice or text)
-func (s *Session) GuildChannelCreate(guildID, name, ctype string) (st *Channel, err error) {
+func (s *Session) GuildChannelCreate(guildID int64, name, ctype string) (st *Channel, err error) {
 
 	data := struct {
 		Name string `json:"name"`
@@ -898,7 +919,7 @@ func (s *Session) GuildChannelCreate(guildID, name, ctype string) (st *Channel, 
 // GuildChannelsReorder updates the order of channels in a guild
 // guildID   : The ID of a Guild.
 // channels  : Updated channels.
-func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel) (err error) {
+func (s *Session) GuildChannelsReorder(guildID int64, channels []*Channel) (err error) {
 
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildChannels(guildID), channels, EndpointGuildChannels(guildID))
 	return
@@ -906,7 +927,7 @@ func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel) (err
 
 // GuildInvites returns an array of Invite structures for the given guild
 // guildID   : The ID of a Guild.
-func (s *Session) GuildInvites(guildID string) (st []*Invite, err error) {
+func (s *Session) GuildInvites(guildID int64) (st []*Invite, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointGuildInvites(guildID), nil, EndpointGuildInivtes(guildID))
 	if err != nil {
 		return
@@ -918,7 +939,7 @@ func (s *Session) GuildInvites(guildID string) (st []*Invite, err error) {
 
 // GuildRoles returns all roles for a given guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
+func (s *Session) GuildRoles(guildID int64) (st []*Role, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID))
 	if err != nil {
@@ -932,7 +953,7 @@ func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
 
 // GuildRoleCreate returns a new Guild Role.
 // guildID: The ID of a Guild.
-func (s *Session) GuildRoleCreate(guildID string) (st *Role, err error) {
+func (s *Session) GuildRoleCreate(guildID int64) (st *Role, err error) {
 
 	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID))
 	if err != nil {
@@ -952,7 +973,7 @@ func (s *Session) GuildRoleCreate(guildID string) (st *Role, err error) {
 // hoist     : Whether to display the role's users separately.
 // perm      : The permissions for the role.
 // mention   : Whether this role is mentionable
-func (s *Session) GuildRoleEdit(guildID, roleID, name string, color int, hoist bool, perm int, mention bool) (st *Role, err error) {
+func (s *Session) GuildRoleEdit(guildID, roleID int64, name string, color int, hoist bool, perm int, mention bool) (st *Role, err error) {
 
 	// Prevent sending a color int that is too big.
 	if color > 0xFFFFFF {
@@ -967,7 +988,7 @@ func (s *Session) GuildRoleEdit(guildID, roleID, name string, color int, hoist b
 		Mentionable bool   `json:"mentionable"` // Whether this role is mentionable
 	}{name, color, hoist, perm, mention}
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRole(guildID, roleID), data, EndpointGuildRole(guildID, ""))
+	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRole(guildID, roleID), data, EndpointGuildRole(guildID, 0))
 	if err != nil {
 		return
 	}
@@ -980,7 +1001,7 @@ func (s *Session) GuildRoleEdit(guildID, roleID, name string, color int, hoist b
 // GuildRoleReorder reoders guild roles
 // guildID   : The ID of a Guild.
 // roles     : A list of ordered roles.
-func (s *Session) GuildRoleReorder(guildID string, roles []*Role) (st []*Role, err error) {
+func (s *Session) GuildRoleReorder(guildID int64, roles []*Role) (st []*Role, err error) {
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRoles(guildID), roles, EndpointGuildRoles(guildID))
 	if err != nil {
@@ -995,9 +1016,9 @@ func (s *Session) GuildRoleReorder(guildID string, roles []*Role) (st []*Role, e
 // GuildRoleDelete deletes an existing role.
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
-func (s *Session) GuildRoleDelete(guildID, roleID string) (err error) {
+func (s *Session) GuildRoleDelete(guildID, roleID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildRole(guildID, roleID), nil, EndpointGuildRole(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildRole(guildID, roleID), nil, EndpointGuildRole(guildID, 0))
 
 	return
 }
@@ -1006,7 +1027,7 @@ func (s *Session) GuildRoleDelete(guildID, roleID string) (err error) {
 // Requires 'KICK_MEMBER' permission.
 // guildID	: The ID of a Guild.
 // days		: The number of days to count prune for (1 or more).
-func (s *Session) GuildPruneCount(guildID string, days uint32) (count uint32, err error) {
+func (s *Session) GuildPruneCount(guildID int64, days uint32) (count uint32, err error) {
 	count = 0
 
 	if days <= 0 {
@@ -1035,7 +1056,7 @@ func (s *Session) GuildPruneCount(guildID string, days uint32) (count uint32, er
 // Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation.
 // guildID	: The ID of a Guild.
 // days		: The number of days to count prune for (1 or more).
-func (s *Session) GuildPrune(guildID string, days uint32) (count uint32, err error) {
+func (s *Session) GuildPrune(guildID int64, days uint32) (count uint32, err error) {
 
 	count = 0
 
@@ -1069,7 +1090,7 @@ func (s *Session) GuildPrune(guildID string, days uint32) (count uint32, err err
 
 // GuildIntegrations returns an array of Integrations for a guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildIntegrations(guildID string) (st []*GuildIntegration, err error) {
+func (s *Session) GuildIntegrations(guildID int64) (st []*GuildIntegration, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildIntegrations(guildID), nil, EndpointGuildIntegrations(guildID))
 	if err != nil {
@@ -1085,11 +1106,11 @@ func (s *Session) GuildIntegrations(guildID string) (st []*GuildIntegration, err
 // guildID          : The ID of a Guild.
 // integrationType  : The Integration type.
 // integrationID    : The ID of an integration.
-func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID string) (err error) {
+func (s *Session) GuildIntegrationCreate(guildID int64, integrationType string, integrationID int64) (err error) {
 
 	data := struct {
 		Type string `json:"type"`
-		ID   string `json:"id"`
+		ID   int64  `json:"id,string"`
 	}{integrationType, integrationID}
 
 	_, err = s.RequestWithBucketID("POST", EndpointGuildIntegrations(guildID), data, EndpointGuildIntegrations(guildID))
@@ -1103,7 +1124,7 @@ func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID
 // expireBehavior	      : The behavior when an integration subscription lapses (see the integration object documentation).
 // expireGracePeriod    : Period (in seconds) where the integration will ignore lapsed subscriptions.
 // enableEmoticons	    : Whether emoticons should be synced for this integration (twitch only currently).
-func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBehavior, expireGracePeriod int, enableEmoticons bool) (err error) {
+func (s *Session) GuildIntegrationEdit(guildID, integrationID int64, expireBehavior, expireGracePeriod int, enableEmoticons bool) (err error) {
 
 	data := struct {
 		ExpireBehavior    int  `json:"expire_behavior"`
@@ -1111,31 +1132,31 @@ func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBeha
 		EnableEmoticons   bool `json:"enable_emoticons"`
 	}{expireBehavior, expireGracePeriod, enableEmoticons}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildIntegration(guildID, integrationID), data, EndpointGuildIntegration(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildIntegration(guildID, integrationID), data, EndpointGuildIntegration(guildID, 0))
 	return
 }
 
 // GuildIntegrationDelete removes the given integration from the Guild.
 // guildID          : The ID of a Guild.
 // integrationID    : The ID of an integration.
-func (s *Session) GuildIntegrationDelete(guildID, integrationID string) (err error) {
+func (s *Session) GuildIntegrationDelete(guildID, integrationID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildIntegration(guildID, integrationID), nil, EndpointGuildIntegration(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildIntegration(guildID, integrationID), nil, EndpointGuildIntegration(guildID, 0))
 	return
 }
 
 // GuildIntegrationSync syncs an integration.
 // guildID          : The ID of a Guild.
 // integrationID    : The ID of an integration.
-func (s *Session) GuildIntegrationSync(guildID, integrationID string) (err error) {
+func (s *Session) GuildIntegrationSync(guildID, integrationID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("POST", EndpointGuildIntegrationSync(guildID, integrationID), nil, EndpointGuildIntegration(guildID, ""))
+	_, err = s.RequestWithBucketID("POST", EndpointGuildIntegrationSync(guildID, integrationID), nil, EndpointGuildIntegration(guildID, 0))
 	return
 }
 
 // GuildIcon returns an image.Image of a guild icon.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildIcon(guildID string) (img image.Image, err error) {
+func (s *Session) GuildIcon(guildID int64) (img image.Image, err error) {
 	g, err := s.Guild(guildID)
 	if err != nil {
 		return
@@ -1157,7 +1178,7 @@ func (s *Session) GuildIcon(guildID string) (img image.Image, err error) {
 
 // GuildSplash returns an image.Image of a guild splash image.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildSplash(guildID string) (img image.Image, err error) {
+func (s *Session) GuildSplash(guildID int64) (img image.Image, err error) {
 	g, err := s.Guild(guildID)
 	if err != nil {
 		return
@@ -1179,7 +1200,7 @@ func (s *Session) GuildSplash(guildID string) (img image.Image, err error) {
 
 // GuildEmbed returns the embed for a Guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
+func (s *Session) GuildEmbed(guildID int64) (st *GuildEmbed, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildEmbed(guildID), nil, EndpointGuildEmbed(guildID))
 	if err != nil {
@@ -1192,7 +1213,7 @@ func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
 
 // GuildEmbedEdit returns the embed for a Guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildEmbedEdit(guildID string, enabled bool, channelID string) (err error) {
+func (s *Session) GuildEmbedEdit(guildID int64, enabled bool, channelID int64) (err error) {
 
 	data := GuildEmbed{enabled, channelID}
 
@@ -1206,7 +1227,7 @@ func (s *Session) GuildEmbedEdit(guildID string, enabled bool, channelID string)
 
 // Channel returns a Channel strucutre of a specific Channel.
 // channelID  : The ID of the Channel you want returned.
-func (s *Session) Channel(channelID string) (st *Channel, err error) {
+func (s *Session) Channel(channelID int64) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointChannel(channelID), nil, EndpointChannel(channelID))
 	if err != nil {
 		return
@@ -1219,7 +1240,7 @@ func (s *Session) Channel(channelID string) (st *Channel, err error) {
 // ChannelEdit edits the given channel
 // channelID  : The ID of a Channel
 // name       : The new name to assign the channel.
-func (s *Session) ChannelEdit(channelID, name string) (st *Channel, err error) {
+func (s *Session) ChannelEdit(channelID int64, name string) (st *Channel, err error) {
 
 	data := struct {
 		Name string `json:"name"`
@@ -1236,7 +1257,7 @@ func (s *Session) ChannelEdit(channelID, name string) (st *Channel, err error) {
 
 // ChannelDelete deletes the given channel
 // channelID  : The ID of a Channel
-func (s *Session) ChannelDelete(channelID string) (st *Channel, err error) {
+func (s *Session) ChannelDelete(channelID int64) (st *Channel, err error) {
 
 	body, err := s.RequestWithBucketID("DELETE", EndpointChannel(channelID), nil, EndpointChannel(channelID))
 	if err != nil {
@@ -1250,7 +1271,7 @@ func (s *Session) ChannelDelete(channelID string) (st *Channel, err error) {
 // ChannelTyping broadcasts to all members that authenticated user is typing in
 // the given channel.
 // channelID  : The ID of a Channel
-func (s *Session) ChannelTyping(channelID string) (err error) {
+func (s *Session) ChannelTyping(channelID int64) (err error) {
 
 	_, err = s.RequestWithBucketID("POST", EndpointChannelTyping(channelID), nil, EndpointChannelTyping(channelID))
 	return
@@ -1263,7 +1284,7 @@ func (s *Session) ChannelTyping(channelID string) (err error) {
 // beforeID  : If provided all messages returned will be before given ID.
 // afterID   : If provided all messages returned will be after given ID.
 // aroundID  : If provided all messages returned will be around given ID.
-func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID, aroundID string) (st []*Message, err error) {
+func (s *Session) ChannelMessages(channelID int64, limit int, beforeID, afterID, aroundID string) (st []*Message, err error) {
 
 	uri := EndpointChannelMessages(channelID)
 
@@ -1296,9 +1317,9 @@ func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID
 // ChannelMessage gets a single message by ID from a given channel.
 // channeld  : The ID of a Channel
 // messageID : the ID of a Message
-func (s *Session) ChannelMessage(channelID, messageID string) (st *Message, err error) {
+func (s *Session) ChannelMessage(channelID, messageID int64) (st *Message, err error) {
 
-	response, err := s.RequestWithBucketID("GET", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""))
+	response, err := s.RequestWithBucketID("GET", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, 0))
 	if err != nil {
 		return
 	}
@@ -1311,9 +1332,9 @@ func (s *Session) ChannelMessage(channelID, messageID string) (st *Message, err 
 // channeld  : The ID of a Channel
 // messageID : the ID of a Message
 // lastToken : token returned by last ack
-func (s *Session) ChannelMessageAck(channelID, messageID, lastToken string) (st *Ack, err error) {
+func (s *Session) ChannelMessageAck(channelID, messageID int64, lastToken string) (st *Ack, err error) {
 
-	body, err := s.RequestWithBucketID("POST", EndpointChannelMessageAck(channelID, messageID), &Ack{Token: lastToken}, EndpointChannelMessageAck(channelID, ""))
+	body, err := s.RequestWithBucketID("POST", EndpointChannelMessageAck(channelID, messageID), &Ack{Token: lastToken}, EndpointChannelMessageAck(channelID, 0))
 	if err != nil {
 		return
 	}
@@ -1325,7 +1346,7 @@ func (s *Session) ChannelMessageAck(channelID, messageID, lastToken string) (st 
 // ChannelMessageSend sends a message to the given channel.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSend(channelID string, content string) (*Message, error) {
+func (s *Session) ChannelMessageSend(channelID int64, content string) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Content: content,
 	})
@@ -1336,7 +1357,7 @@ var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 // ChannelMessageSendComplex sends a message to the given channel.
 // channelID : The ID of a Channel.
 // data      : The message struct to send.
-func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend) (st *Message, err error) {
+func (s *Session) ChannelMessageSendComplex(channelID int64, data *MessageSend) (st *Message, err error) {
 	if data.Embed != nil && data.Embed.Type == "" {
 		data.Embed.Type = "rich"
 	}
@@ -1419,7 +1440,7 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 // ChannelMessageSendTTS sends a message to the given channel with Text to Speech.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSendTTS(channelID string, content string) (*Message, error) {
+func (s *Session) ChannelMessageSendTTS(channelID int64, content string) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Content: content,
 		Tts:     true,
@@ -1429,7 +1450,7 @@ func (s *Session) ChannelMessageSendTTS(channelID string, content string) (*Mess
 // ChannelMessageSendEmbed sends a message to the given channel with embedded data.
 // channelID : The ID of a Channel.
 // embed     : The embed data to send.
-func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbed(channelID int64, embed *MessageEmbed) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Embed: embed,
 	})
@@ -1440,7 +1461,7 @@ func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed)
 // channelID  : The ID of a Channel
 // messageID  : The ID of a Message
 // content    : The contents of the message
-func (s *Session) ChannelMessageEdit(channelID, messageID, content string) (*Message, error) {
+func (s *Session) ChannelMessageEdit(channelID, messageID int64, content string) (*Message, error) {
 	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetContent(content))
 }
 
@@ -1451,7 +1472,7 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err er
 		m.Embed.Type = "rich"
 	}
 
-	response, err := s.RequestWithBucketID("PATCH", EndpointChannelMessage(m.Channel, m.ID), m, EndpointChannelMessage(m.Channel, ""))
+	response, err := s.RequestWithBucketID("PATCH", EndpointChannelMessage(m.Channel, m.ID), m, EndpointChannelMessage(m.Channel, 0))
 	if err != nil {
 		return
 	}
@@ -1464,14 +1485,14 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err er
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
 // embed     : The embed data to send
-func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed) (*Message, error) {
+func (s *Session) ChannelMessageEditEmbed(channelID, messageID int64, embed *MessageEmbed) (*Message, error) {
 	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetEmbed(embed))
 }
 
 // ChannelMessageDelete deletes a message from the Channel.
-func (s *Session) ChannelMessageDelete(channelID, messageID string) (err error) {
+func (s *Session) ChannelMessageDelete(channelID, messageID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, 0))
 	return
 }
 
@@ -1479,8 +1500,8 @@ func (s *Session) ChannelMessageDelete(channelID, messageID string) (err error) 
 // If only one messageID is in the slice call channelMessageDelete funciton.
 // If the slice is empty do nothing.
 // channelID : The ID of the channel for the messages to delete.
-// messages  : The IDs of the messages to be deleted. A slice of string IDs. A maximum of 100 messages.
-func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string) (err error) {
+// messages  : The IDs of the messages to be deleted. A slice of message IDs. A maximum of 100 messages.
+func (s *Session) ChannelMessagesBulkDelete(channelID int64, messages []int64) (err error) {
 
 	if len(messages) == 0 {
 		return
@@ -1496,7 +1517,7 @@ func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string)
 	}
 
 	data := struct {
-		Messages []string `json:"messages"`
+		Messages IDSlice `json:"messages"`
 	}{messages}
 
 	_, err = s.RequestWithBucketID("POST", EndpointChannelMessagesBulkDelete(channelID), data, EndpointChannelMessagesBulkDelete(channelID))
@@ -1506,25 +1527,25 @@ func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string)
 // ChannelMessagePin pins a message within a given channel.
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
-func (s *Session) ChannelMessagePin(channelID, messageID string) (err error) {
+func (s *Session) ChannelMessagePin(channelID, messageID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("PUT", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, 0))
 	return
 }
 
 // ChannelMessageUnpin unpins a message within a given channel.
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
-func (s *Session) ChannelMessageUnpin(channelID, messageID string) (err error) {
+func (s *Session) ChannelMessageUnpin(channelID, messageID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, 0))
 	return
 }
 
 // ChannelMessagesPinned returns an array of Message structures for pinned messages
 // within a given channel
 // channelID : The ID of a Channel.
-func (s *Session) ChannelMessagesPinned(channelID string) (st []*Message, err error) {
+func (s *Session) ChannelMessagesPinned(channelID int64) (st []*Message, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointChannelMessagesPins(channelID), nil, EndpointChannelMessagesPins(channelID))
 
@@ -1540,7 +1561,7 @@ func (s *Session) ChannelMessagesPinned(channelID string) (st []*Message, err er
 // channelID : The ID of a Channel.
 // name: The name of the file.
 // io.Reader : A reader for the file contents.
-func (s *Session) ChannelFileSend(channelID, name string, r io.Reader) (*Message, error) {
+func (s *Session) ChannelFileSend(channelID int64, name string, r io.Reader) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}})
 }
 
@@ -1550,13 +1571,13 @@ func (s *Session) ChannelFileSend(channelID, name string, r io.Reader) (*Message
 // content: Optional Message content.
 // name: The name of the file.
 // io.Reader : A reader for the file contents.
-func (s *Session) ChannelFileSendWithMessage(channelID, content string, name string, r io.Reader) (*Message, error) {
+func (s *Session) ChannelFileSendWithMessage(channelID int64, content string, name string, r io.Reader) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}, Content: content})
 }
 
 // ChannelInvites returns an array of Invite structures for the given channel
 // channelID   : The ID of a Channel
-func (s *Session) ChannelInvites(channelID string) (st []*Invite, err error) {
+func (s *Session) ChannelInvites(channelID int64) (st []*Invite, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointChannelInvites(channelID), nil, EndpointChannelInvites(channelID))
 	if err != nil {
@@ -1571,7 +1592,7 @@ func (s *Session) ChannelInvites(channelID string) (st []*Invite, err error) {
 // channelID   : The ID of a Channel
 // i           : An Invite struct with the values MaxAge, MaxUses, Temporary,
 //               and XkcdPass defined.
-func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, err error) {
+func (s *Session) ChannelInviteCreate(channelID int64, i Invite) (st *Invite, err error) {
 
 	data := struct {
 		MaxAge    int    `json:"max_age"`
@@ -1592,24 +1613,24 @@ func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, e
 // ChannelPermissionSet creates a Permission Override for the given channel.
 // NOTE: This func name may changed.  Using Set instead of Create because
 // you can both create a new override or update an override with this function.
-func (s *Session) ChannelPermissionSet(channelID, targetID, targetType string, allow, deny int) (err error) {
+func (s *Session) ChannelPermissionSet(channelID, targetID int64, targetType string, allow, deny int) (err error) {
 
 	data := struct {
-		ID    string `json:"id"`
+		ID    int64  `json:"id,string"`
 		Type  string `json:"type"`
 		Allow int    `json:"allow"`
 		Deny  int    `json:"deny"`
 	}{targetID, targetType, allow, deny}
 
-	_, err = s.RequestWithBucketID("PUT", EndpointChannelPermission(channelID, targetID), data, EndpointChannelPermission(channelID, ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointChannelPermission(channelID, targetID), data, EndpointChannelPermission(channelID, 0))
 	return
 }
 
 // ChannelPermissionDelete deletes a specific permission override for the given channel.
 // NOTE: Name of this func may change.
-func (s *Session) ChannelPermissionDelete(channelID, targetID string) (err error) {
+func (s *Session) ChannelPermissionDelete(channelID, targetID int64) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointChannelPermission(channelID, targetID), nil, EndpointChannelPermission(channelID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointChannelPermission(channelID, targetID), nil, EndpointChannelPermission(channelID, 0))
 	return
 }
 
@@ -1744,7 +1765,7 @@ func (s *Session) GatewayBot() (st *GatewayBotResponse, err error) {
 // channelID: The ID of a Channel.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookCreate(channelID, name, avatar string) (st *Webhook, err error) {
+func (s *Session) WebhookCreate(channelID int64, name, avatar string) (st *Webhook, err error) {
 
 	data := struct {
 		Name   string `json:"name"`
@@ -1763,7 +1784,7 @@ func (s *Session) WebhookCreate(channelID, name, avatar string) (st *Webhook, er
 
 // ChannelWebhooks returns all webhooks for a given channel.
 // channelID: The ID of a channel.
-func (s *Session) ChannelWebhooks(channelID string) (st []*Webhook, err error) {
+func (s *Session) ChannelWebhooks(channelID int64) (st []*Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointChannelWebhooks(channelID), nil, EndpointChannelWebhooks(channelID))
 	if err != nil {
@@ -1777,7 +1798,7 @@ func (s *Session) ChannelWebhooks(channelID string) (st []*Webhook, err error) {
 
 // GuildWebhooks returns all webhooks for a given guild.
 // guildID: The ID of a Guild.
-func (s *Session) GuildWebhooks(guildID string) (st []*Webhook, err error) {
+func (s *Session) GuildWebhooks(guildID int64) (st []*Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildWebhooks(guildID), nil, EndpointGuildWebhooks(guildID))
 	if err != nil {
@@ -1791,7 +1812,7 @@ func (s *Session) GuildWebhooks(guildID string) (st []*Webhook, err error) {
 
 // Webhook returns a webhook for a given ID
 // webhookID: The ID of a webhook.
-func (s *Session) Webhook(webhookID string) (st *Webhook, err error) {
+func (s *Session) Webhook(webhookID int64) (st *Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointWebhook(webhookID), nil, EndpointWebhooks)
 	if err != nil {
@@ -1806,9 +1827,9 @@ func (s *Session) Webhook(webhookID string) (st *Webhook, err error) {
 // WebhookWithToken returns a webhook for a given ID
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
-func (s *Session) WebhookWithToken(webhookID, token string) (st *Webhook, err error) {
+func (s *Session) WebhookWithToken(webhookID int64, token string) (st *Webhook, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""))
+	body, err := s.RequestWithBucketID("GET", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken(0, ""))
 	if err != nil {
 		return
 	}
@@ -1822,7 +1843,7 @@ func (s *Session) WebhookWithToken(webhookID, token string) (st *Webhook, err er
 // webhookID: The ID of a webhook.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookEdit(webhookID, name, avatar string) (st *Role, err error) {
+func (s *Session) WebhookEdit(webhookID int64, name, avatar string) (st *Role, err error) {
 
 	data := struct {
 		Name   string `json:"name,omitempty"`
@@ -1844,14 +1865,14 @@ func (s *Session) WebhookEdit(webhookID, name, avatar string) (st *Role, err err
 // token    : The auth token for the webhook.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string) (st *Role, err error) {
+func (s *Session) WebhookEditWithToken(webhookID int64, token, name, avatar string) (st *Role, err error) {
 
 	data := struct {
 		Name   string `json:"name,omitempty"`
 		Avatar string `json:"avatar,omitempty"`
 	}{name, avatar}
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointWebhookToken(webhookID, token), data, EndpointWebhookToken("", ""))
+	body, err := s.RequestWithBucketID("PATCH", EndpointWebhookToken(webhookID, token), data, EndpointWebhookToken(0, ""))
 	if err != nil {
 		return
 	}
@@ -1863,7 +1884,7 @@ func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string) (s
 
 // WebhookDelete deletes a webhook for a given ID
 // webhookID: The ID of a webhook.
-func (s *Session) WebhookDelete(webhookID string) (st *Webhook, err error) {
+func (s *Session) WebhookDelete(webhookID int64) (st *Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("DELETE", EndpointWebhook(webhookID), nil, EndpointWebhooks)
 	if err != nil {
@@ -1878,9 +1899,9 @@ func (s *Session) WebhookDelete(webhookID string) (st *Webhook, err error) {
 // WebhookDeleteWithToken deletes a webhook for a given ID with an auth token.
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
-func (s *Session) WebhookDeleteWithToken(webhookID, token string) (st *Webhook, err error) {
+func (s *Session) WebhookDeleteWithToken(webhookID int64, token string) (st *Webhook, err error) {
 
-	body, err := s.RequestWithBucketID("DELETE", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""))
+	body, err := s.RequestWithBucketID("DELETE", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken(0, ""))
 	if err != nil {
 		return
 	}
@@ -1893,14 +1914,14 @@ func (s *Session) WebhookDeleteWithToken(webhookID, token string) (st *Webhook, 
 // WebhookExecute executes a webhook.
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook
-func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *WebhookParams) (err error) {
+func (s *Session) WebhookExecute(webhookID int64, token string, wait bool, data *WebhookParams) (err error) {
 	uri := EndpointWebhookToken(webhookID, token)
 
 	if wait {
 		uri += "?wait=true"
 	}
 
-	_, err = s.RequestWithBucketID("POST", uri, data, EndpointWebhookToken("", ""))
+	_, err = s.RequestWithBucketID("POST", uri, data, EndpointWebhookToken(0, ""))
 
 	return
 }
@@ -1909,9 +1930,9 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 // channelID : The channel ID.
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
-func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error {
+func (s *Session) MessageReactionAdd(channelID, messageID, emojiID int64) error {
 
-	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, "", "", ""))
+	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, 0, 0, ""))
 
 	return err
 }
@@ -1920,10 +1941,21 @@ func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error
 // channelID : The channel ID.
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
-// userID	 : @me or ID of the user to delete the reaction for.
-func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID string) error {
+// userID	 : The ID of the user to delete the reaction for.
+func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID int64) error {
 
-	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, userID), nil, EndpointMessageReaction(channelID, "", "", ""))
+	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, StrID(userID)), nil, EndpointMessageReaction(channelID, 0, 0, ""))
+
+	return err
+}
+
+// MessageReactionRemoveMe deletes an emoji reaction to a message the current user made.
+// channelID : The channel ID.
+// messageID : The message ID.
+// emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
+func (s *Session) MessageReactionRemoveMe(channelID, messageID, emojiID int64) error {
+
+	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, 0, 0, ""))
 
 	return err
 }
@@ -1931,7 +1963,7 @@ func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID st
 // MessageReactionsRemoveAll deletes all reactions from a message
 // channelID : The channel ID
 // messageID : The message ID.
-func (s *Session) MessageReactionsRemoveAll(channelID, messageID string) error {
+func (s *Session) MessageReactionsRemoveAll(channelID, messageID int64) error {
 
 	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactionsAll(channelID, messageID), nil, EndpointMessageReactionsAll(channelID, messageID))
 
@@ -1943,7 +1975,7 @@ func (s *Session) MessageReactionsRemoveAll(channelID, messageID string) error {
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
 // limit    : max number of users to return (max 100)
-func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit int) (st []*User, err error) {
+func (s *Session) MessageReactions(channelID, messageID, emojiID int64, limit int) (st []*User, err error) {
 	uri := EndpointMessageReactions(channelID, messageID, emojiID)
 
 	v := url.Values{}
@@ -1956,7 +1988,7 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 		uri = fmt.Sprintf("%s?%s", uri, v.Encode())
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointMessageReaction(channelID, "", "", ""))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointMessageReaction(channelID, 0, 0, ""))
 	if err != nil {
 		return
 	}
@@ -1970,12 +2002,12 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 // ------------------------------------------------------------------------------------------------
 
 // UserNoteSet sets the note for a specific user.
-func (s *Session) UserNoteSet(userID string, message string) (err error) {
+func (s *Session) UserNoteSet(userID int64, message string) (err error) {
 	data := struct {
 		Note string `json:"note"`
 	}{message}
 
-	_, err = s.RequestWithBucketID("PUT", EndpointUserNotes(userID), data, EndpointUserNotes(""))
+	_, err = s.RequestWithBucketID("PUT", EndpointUserNotes(userID), data, EndpointUserNotes(0))
 	return
 }
 
@@ -1996,7 +2028,7 @@ func (s *Session) RelationshipsGet() (r []*Relationship, err error) {
 
 // relationshipCreate creates a new relationship. (I.e. send or accept a friend request, block a user.)
 // relationshipType : 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
-func (s *Session) relationshipCreate(userID string, relationshipType int) (err error) {
+func (s *Session) relationshipCreate(userID int64, relationshipType int) (err error) {
 	data := struct {
 		Type int `json:"type"`
 	}{relationshipType}
@@ -2007,35 +2039,35 @@ func (s *Session) relationshipCreate(userID string, relationshipType int) (err e
 
 // RelationshipFriendRequestSend sends a friend request to a user.
 // userID: ID of the user.
-func (s *Session) RelationshipFriendRequestSend(userID string) (err error) {
+func (s *Session) RelationshipFriendRequestSend(userID int64) (err error) {
 	err = s.relationshipCreate(userID, 4)
 	return
 }
 
 // RelationshipFriendRequestAccept accepts a friend request from a user.
 // userID: ID of the user.
-func (s *Session) RelationshipFriendRequestAccept(userID string) (err error) {
+func (s *Session) RelationshipFriendRequestAccept(userID int64) (err error) {
 	err = s.relationshipCreate(userID, 1)
 	return
 }
 
 // RelationshipUserBlock blocks a user.
 // userID: ID of the user.
-func (s *Session) RelationshipUserBlock(userID string) (err error) {
+func (s *Session) RelationshipUserBlock(userID int64) (err error) {
 	err = s.relationshipCreate(userID, 2)
 	return
 }
 
 // RelationshipDelete removes the relationship with a user.
 // userID: ID of the user.
-func (s *Session) RelationshipDelete(userID string) (err error) {
+func (s *Session) RelationshipDelete(userID int64) (err error) {
 	_, err = s.RequestWithBucketID("DELETE", EndpointRelationship(userID), nil, EndpointRelationships())
 	return
 }
 
 // RelationshipsMutualGet returns an array of all the users both @me and the given user is friends with.
 // userID: ID of the user.
-func (s *Session) RelationshipsMutualGet(userID string) (mf []*User, err error) {
+func (s *Session) RelationshipsMutualGet(userID int64) (mf []*User, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointRelationshipsMutual(userID), nil, EndpointRelationshipsMutual(userID))
 	if err != nil {
 		return

--- a/restapi.go
+++ b/restapi.go
@@ -1345,7 +1345,7 @@ func (s *Session) ChannelTyping(channelID int64) (err error) {
 // beforeID  : If provided all messages returned will be before given ID.
 // afterID   : If provided all messages returned will be after given ID.
 // aroundID  : If provided all messages returned will be around given ID.
-func (s *Session) ChannelMessages(channelID int64, limit int, beforeID, afterID, aroundID string) (st []*Message, err error) {
+func (s *Session) ChannelMessages(channelID int64, limit int, beforeID, afterID, aroundID int64) (st []*Message, err error) {
 
 	uri := EndpointChannelMessages(channelID)
 
@@ -1353,14 +1353,14 @@ func (s *Session) ChannelMessages(channelID int64, limit int, beforeID, afterID,
 	if limit > 0 {
 		v.Set("limit", strconv.Itoa(limit))
 	}
-	if afterID != "" {
-		v.Set("after", afterID)
+	if afterID != 0 {
+		v.Set("after", StrID(afterID))
 	}
-	if beforeID != "" {
-		v.Set("before", beforeID)
+	if beforeID != 0 {
+		v.Set("before", StrID(beforeID))
 	}
-	if aroundID != "" {
-		v.Set("around", aroundID)
+	if aroundID != 0 {
+		v.Set("around", StrID(aroundID))
 	}
 	if len(v) > 0 {
 		uri = fmt.Sprintf("%s?%s", uri, v.Encode())

--- a/restapi_test.go
+++ b/restapi_test.go
@@ -227,7 +227,7 @@ func TestGuildMemberNicknameMe(t *testing.T) {
 		t.Skip("Skipping, dg not set.")
 	}
 
-	err := dg.GuildMemberNickname(envGuild, "@me/nick", "B1nzyRocks")
+	err := dg.GuildMemberNicknameMe(envGuild, "B1nzyRocks")
 	if err != nil {
 		t.Errorf("GuildNickname returned error: %+v", err)
 	}

--- a/restapi_test.go
+++ b/restapi_test.go
@@ -10,7 +10,7 @@ import (
 // TestChannelMessageSend tests the ChannelMessageSend() function. This should not return an error.
 func TestChannelMessageSend(t *testing.T) {
 
-	if envChannel == "" {
+	if envChannel == 0 {
 		t.Skip("Skipping, DG_CHANNEL not set.")
 	}
 
@@ -86,7 +86,7 @@ func TestUserChannelCreate(t *testing.T) {
 		t.Skip("Cannot TestUserChannelCreate, dg not set.")
 	}
 
-	if envAdmin == "" {
+	if envAdmin == 0 {
 		t.Skip("Skipped, DG_ADMIN not set.")
 	}
 
@@ -114,7 +114,7 @@ func TestUserGuilds(t *testing.T) {
 		t.Skip("Cannot TestUserGuilds, dg not set.")
 	}
 
-	_, err := dg.UserGuilds(10, "", "")
+	_, err := dg.UserGuilds(10, 0, 0)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -202,7 +202,7 @@ func TestVoiceRegions(t *testing.T) {
 }
 func TestGuildRoles(t *testing.T) {
 
-	if envGuild == "" {
+	if envGuild == 0 {
 		t.Skip("Skipping, DG_GUILD not set.")
 	}
 
@@ -217,9 +217,9 @@ func TestGuildRoles(t *testing.T) {
 
 }
 
-func TestGuildMemberNickname(t *testing.T) {
+func TestGuildMemberNicknameMe(t *testing.T) {
 
-	if envGuild == "" {
+	if envGuild == 0 {
 		t.Skip("Skipping, DG_GUILD not set.")
 	}
 
@@ -227,7 +227,7 @@ func TestGuildMemberNickname(t *testing.T) {
 		t.Skip("Skipping, dg not set.")
 	}
 
-	err := dg.GuildMemberNickname(envGuild, "@me/nick", "testnickname")
+	err := dg.GuildMemberNicknameMe(envGuild, "testnickname")
 	if err != nil {
 		t.Errorf("GuildNickname returned error: %+v", err)
 	}
@@ -236,7 +236,7 @@ func TestGuildMemberNickname(t *testing.T) {
 // TestChannelMessageSend2 tests the ChannelMessageSend() function. This should not return an error.
 func TestChannelMessageSend2(t *testing.T) {
 
-	if envChannel == "" {
+	if envChannel == 0 {
 		t.Skip("Skipping, DG_CHANNEL not set.")
 	}
 
@@ -253,7 +253,7 @@ func TestChannelMessageSend2(t *testing.T) {
 // TestGuildPruneCount tests GuildPruneCount() function. This should not return an error.
 func TestGuildPruneCount(t *testing.T) {
 
-	if envGuild == "" {
+	if envGuild == 0 {
 		t.Skip("Skipping, DG_GUILD not set.")
 	}
 
@@ -271,7 +271,7 @@ func TestGuildPruneCount(t *testing.T) {
 // TestGuildPrune tests GuildPrune() function. This should not return an error.
 func TestGuildPrune(t *testing.T) {
 
-	if envGuild == "" {
+	if envGuild == 0 {
 		t.Skip("Skipping, DG_GUILD not set.")
 	}
 

--- a/state.go
+++ b/state.go
@@ -40,9 +40,9 @@ type State struct {
 	TrackVoice      bool
 	TrackPresences  bool
 
-	guildMap   map[string]*Guild
-	channelMap map[string]*Channel
-	memberMap  map[string]map[string]*Member
+	guildMap   map[int64]*Guild
+	channelMap map[int64]*Channel
+	memberMap  map[int64]map[int64]*Member
 }
 
 // NewState creates an empty state.
@@ -58,14 +58,14 @@ func NewState() *State {
 		TrackRoles:     true,
 		TrackVoice:     true,
 		TrackPresences: true,
-		guildMap:       make(map[string]*Guild),
-		channelMap:     make(map[string]*Channel),
-		memberMap:      make(map[string]map[string]*Member),
+		guildMap:       make(map[int64]*Guild),
+		channelMap:     make(map[int64]*Channel),
+		memberMap:      make(map[int64]map[int64]*Member),
 	}
 }
 
 func (s *State) createMemberMap(guild *Guild) {
-	members := make(map[string]*Member)
+	members := make(map[int64]*Member)
 	for _, m := range guild.Members {
 		members[m.User.ID] = m
 	}
@@ -92,7 +92,7 @@ func (s *State) GuildAdd(guild *Guild) error {
 		s.createMemberMap(guild)
 	} else if _, ok := s.memberMap[guild.ID]; !ok {
 		// Even if we have no new member slice, we still initialize the member map for this guild if it doesn't exist
-		s.memberMap[guild.ID] = make(map[string]*Member)
+		s.memberMap[guild.ID] = make(map[int64]*Member)
 	}
 
 	if g, ok := s.guildMap[guild.ID]; ok {
@@ -156,7 +156,7 @@ func (s *State) GuildRemove(guild *Guild) error {
 // Useful for querying if @me is in a guild:
 //     _, err := discordgo.Session.State.Guild(guildID)
 //     isInGuild := err == nil
-func (s *State) Guild(guildID string) (*Guild, error) {
+func (s *State) Guild(guildID int64) (*Guild, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -173,7 +173,7 @@ func (s *State) Guild(guildID string) (*Guild, error) {
 
 // PresenceAdd adds a presence to the current world state, or
 // updates it if it already exists.
-func (s *State) PresenceAdd(guildID string, presence *Presence) error {
+func (s *State) PresenceAdd(guildID int64, presence *Presence) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -229,7 +229,7 @@ func (s *State) PresenceAdd(guildID string, presence *Presence) error {
 }
 
 // PresenceRemove removes a presence from the current world state.
-func (s *State) PresenceRemove(guildID string, presence *Presence) error {
+func (s *State) PresenceRemove(guildID int64, presence *Presence) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -253,7 +253,7 @@ func (s *State) PresenceRemove(guildID string, presence *Presence) error {
 }
 
 // Presence gets a presence by ID from a guild.
-func (s *State) Presence(guildID, userID string) (*Presence, error) {
+func (s *State) Presence(guildID, userID int64) (*Presence, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -341,7 +341,7 @@ func (s *State) MemberRemove(member *Member) error {
 }
 
 // Member gets a member by ID from a guild.
-func (s *State) Member(guildID, userID string) (*Member, error) {
+func (s *State) Member(guildID, userID int64) (*Member, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -364,7 +364,7 @@ func (s *State) Member(guildID, userID string) (*Member, error) {
 
 // RoleAdd adds a role to the current world state, or
 // updates it if it already exists.
-func (s *State) RoleAdd(guildID string, role *Role) error {
+func (s *State) RoleAdd(guildID int64, role *Role) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -389,7 +389,7 @@ func (s *State) RoleAdd(guildID string, role *Role) error {
 }
 
 // RoleRemove removes a role from current world state by ID.
-func (s *State) RoleRemove(guildID, roleID string) error {
+func (s *State) RoleRemove(guildID, roleID int64) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -413,7 +413,7 @@ func (s *State) RoleRemove(guildID, roleID string) error {
 }
 
 // Role gets a role by ID from a guild.
-func (s *State) Role(guildID, roleID string) (*Role, error) {
+func (s *State) Role(guildID, roleID int64) (*Role, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -521,18 +521,18 @@ func (s *State) ChannelRemove(channel *Channel) error {
 
 // GuildChannel gets a channel by ID from a guild.
 // This method is Deprecated, use Channel(channelID)
-func (s *State) GuildChannel(guildID, channelID string) (*Channel, error) {
+func (s *State) GuildChannel(guildID, channelID int64) (*Channel, error) {
 	return s.Channel(channelID)
 }
 
 // PrivateChannel gets a private channel by ID.
 // This method is Deprecated, use Channel(channelID)
-func (s *State) PrivateChannel(channelID string) (*Channel, error) {
+func (s *State) PrivateChannel(channelID int64) (*Channel, error) {
 	return s.Channel(channelID)
 }
 
 // Channel gets a channel by ID, it will look in all guilds an private channels.
-func (s *State) Channel(channelID string) (*Channel, error) {
+func (s *State) Channel(channelID int64) (*Channel, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -548,7 +548,7 @@ func (s *State) Channel(channelID string) (*Channel, error) {
 }
 
 // Emoji returns an emoji for a guild and emoji id.
-func (s *State) Emoji(guildID, emojiID string) (*Emoji, error) {
+func (s *State) Emoji(guildID, emojiID int64) (*Emoji, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -571,7 +571,7 @@ func (s *State) Emoji(guildID, emojiID string) (*Emoji, error) {
 }
 
 // EmojiAdd adds an emoji to the current world state.
-func (s *State) EmojiAdd(guildID string, emoji *Emoji) error {
+func (s *State) EmojiAdd(guildID int64, emoji *Emoji) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -596,7 +596,7 @@ func (s *State) EmojiAdd(guildID string, emoji *Emoji) error {
 }
 
 // EmojisAdd adds multiple emojis to the world state.
-func (s *State) EmojisAdd(guildID string, emojis []*Emoji) error {
+func (s *State) EmojisAdd(guildID int64, emojis []*Emoji) error {
 	for _, e := range emojis {
 		if err := s.EmojiAdd(guildID, e); err != nil {
 			return err
@@ -668,7 +668,7 @@ func (s *State) MessageRemove(message *Message) error {
 }
 
 // messageRemoveByID removes a message by channelID and messageID from the world state.
-func (s *State) messageRemoveByID(channelID, messageID string) error {
+func (s *State) messageRemoveByID(channelID, messageID int64) error {
 	c, err := s.Channel(channelID)
 	if err != nil {
 		return err
@@ -697,7 +697,7 @@ func (s *State) voiceStateUpdate(update *VoiceStateUpdate) error {
 	defer s.Unlock()
 
 	// Handle Leaving Channel
-	if update.ChannelID == "" {
+	if update.ChannelID == 0 {
 		for i, state := range guild.VoiceStates {
 			if state.UserID == update.UserID {
 				guild.VoiceStates = append(guild.VoiceStates[:i], guild.VoiceStates[i+1:]...)
@@ -719,7 +719,7 @@ func (s *State) voiceStateUpdate(update *VoiceStateUpdate) error {
 }
 
 // Message gets a message by channel and message ID.
-func (s *State) Message(channelID, messageID string) (*Message, error) {
+func (s *State) Message(channelID, messageID int64) (*Message, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -913,7 +913,7 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 // UserChannelPermissions returns the permission of a user in a channel.
 // userID    : The ID of the user to calculate permissions for.
 // channelID : The ID of the channel to calculate permission for.
-func (s *State) UserChannelPermissions(userID, channelID string) (apermissions int, err error) {
+func (s *State) UserChannelPermissions(userID, channelID int64) (apermissions int, err error) {
 	if s == nil {
 		return 0, ErrNilState
 	}
@@ -946,7 +946,7 @@ func (s *State) UserChannelPermissions(userID, channelID string) (apermissions i
 // 0 is returned in cases of error, which is the color of @everyone.
 // userID    : The ID of the user to calculate the color for.
 // channelID   : The ID of the channel to calculate the color for.
-func (s *State) UserColor(userID, channelID string) int {
+func (s *State) UserColor(userID, channelID int64) int {
 	if s == nil {
 		return 0
 	}

--- a/structs.go
+++ b/structs.go
@@ -463,12 +463,12 @@ type VoiceState struct {
 
 // A Presence stores the online, offline, or idle and game status of Guild members.
 type Presence struct {
-	User   *User    `json:"user"`
-	Status Status   `json:"status"`
-	Game   *Game    `json:"game"`
-	Nick   string   `json:"nick"`
-	Roles  []string `json:"roles"`
-	Since  *int     `json:"since"`
+	User   *User     `json:"user"`
+	Status Status    `json:"status"`
+	Game   *Game     `json:"game"`
+	Nick   string    `json:"nick"`
+	Roles  []IDSlice `json:"roles,string"`
+	Since  *int      `json:"since"`
 }
 
 // GameType is the type of "game" (see GameType* consts) in the Game struct

--- a/structs.go
+++ b/structs.go
@@ -463,12 +463,12 @@ type VoiceState struct {
 
 // A Presence stores the online, offline, or idle and game status of Guild members.
 type Presence struct {
-	User   *User     `json:"user"`
-	Status Status    `json:"status"`
-	Game   *Game     `json:"game"`
-	Nick   string    `json:"nick"`
-	Roles  []IDSlice `json:"roles,string"`
-	Since  *int      `json:"since"`
+	User   *User   `json:"user"`
+	Status Status  `json:"status"`
+	Game   *Game   `json:"game"`
+	Nick   string  `json:"nick"`
+	Roles  IDSlice `json:"roles,string"`
+	Since  *int    `json:"since"`
 }
 
 // GameType is the type of "game" (see GameType* consts) in the Game struct

--- a/structs.go
+++ b/structs.go
@@ -269,12 +269,12 @@ type Emoji struct {
 // APIName returns an correctly formatted API name for use in the MessageReactions endpoints.
 func (e *Emoji) APIName() string {
 	if e.ID != 0 && e.Name != "" {
-		return e.Name + ":" + strconv.FormatInt(e.ID, 10)
+		return e.Name + ":" + StrID(e.ID)
 	}
 	if e.Name != "" {
 		return e.Name
 	}
-	return strconv.FormatInt(e.ID, 10)
+	return StrID(e.ID)
 }
 
 // VerificationLevel type definition

--- a/structs.go
+++ b/structs.go
@@ -73,7 +73,7 @@ type Session struct {
 	UDPReady bool // NOTE: Deprecated
 
 	// Stores a mapping of guild id's to VoiceConnections
-	VoiceConnections map[string]*VoiceConnection
+	VoiceConnections map[int64]*VoiceConnection
 
 	// Managed state object, updated internally with events when
 	// StateEnabled is true.
@@ -160,12 +160,12 @@ const (
 
 // A Channel holds all data related to an individual Discord channel.
 type Channel struct {
-	ID                   string                 `json:"id"`
-	GuildID              string                 `json:"guild_id"`
+	ID                   int64                  `json:"id,string"`
+	GuildID              int64                  `json:"guild_id,string"`
 	Name                 string                 `json:"name"`
 	Topic                string                 `json:"topic"`
 	Type                 ChannelType            `json:"type"`
-	LastMessageID        string                 `json:"last_message_id"`
+	LastMessageID        int64                  `json:"last_message_id,string"`
 	NSFW                 bool                   `json:"nsfw"`
 	Position             int                    `json:"position"`
 	Bitrate              int                    `json:"bitrate"`
@@ -176,7 +176,7 @@ type Channel struct {
 
 // A PermissionOverwrite holds permission overwrite data for a Channel
 type PermissionOverwrite struct {
-	ID    string `json:"id"`
+	ID    int64  `json:"id,string"`
 	Type  string `json:"type"`
 	Deny  int    `json:"deny"`
 	Allow int    `json:"allow"`
@@ -184,22 +184,22 @@ type PermissionOverwrite struct {
 
 // Emoji struct holds data related to Emoji's
 type Emoji struct {
-	ID            string   `json:"id"`
-	Name          string   `json:"name"`
-	Roles         []string `json:"roles"`
-	Managed       bool     `json:"managed"`
-	RequireColons bool     `json:"require_colons"`
+	ID            int64   `json:"id,string"`
+	Name          string  `json:"name"`
+	Roles         IDSlice `json:"roles,string"`
+	Managed       bool    `json:"managed"`
+	RequireColons bool    `json:"require_colons"`
 }
 
 // APIName returns an correctly formatted API name for use in the MessageReactions endpoints.
 func (e *Emoji) APIName() string {
-	if e.ID != "" && e.Name != "" {
-		return e.Name + ":" + e.ID
+	if e.ID != 0 && e.Name != "" {
+		return e.Name + ":" + strconv.FormatInt(e.ID, 10)
 	}
 	if e.Name != "" {
 		return e.Name
 	}
-	return e.ID
+	return strconv.FormatInt(e.ID, 10)
 }
 
 // VerificationLevel type defination
@@ -216,13 +216,13 @@ const (
 // A Guild holds all data related to a specific Discord Guild.  Guilds are also
 // sometimes referred to as Servers in the Discord client.
 type Guild struct {
-	ID                          string            `json:"id"`
+	ID                          int64             `json:"id,string"`
 	Name                        string            `json:"name"`
 	Icon                        string            `json:"icon"`
 	Region                      string            `json:"region"`
-	AfkChannelID                string            `json:"afk_channel_id"`
-	EmbedChannelID              string            `json:"embed_channel_id"`
-	OwnerID                     string            `json:"owner_id"`
+	AfkChannelID                int64             `json:"afk_channel_id,string"`
+	EmbedChannelID              int64             `json:"embed_channel_id,string"`
+	OwnerID                     int64             `json:"owner_id,string"`
 	JoinedAt                    Timestamp         `json:"joined_at"`
 	Splash                      string            `json:"splash"`
 	AfkTimeout                  int               `json:"afk_timeout"`
@@ -242,7 +242,7 @@ type Guild struct {
 
 // A UserGuild holds a brief version of a Guild
 type UserGuild struct {
-	ID          string `json:"id"`
+	ID          int64  `json:"id,string"`
 	Name        string `json:"name"`
 	Icon        string `json:"icon"`
 	Owner       bool   `json:"owner"`
@@ -255,16 +255,16 @@ type GuildParams struct {
 	Region                      string             `json:"region,omitempty"`
 	VerificationLevel           *VerificationLevel `json:"verification_level,omitempty"`
 	DefaultMessageNotifications int                `json:"default_message_notifications,omitempty"` // TODO: Separate type?
-	AfkChannelID                string             `json:"afk_channel_id,omitempty"`
+	AfkChannelID                int64              `json:"afk_channel_id,omitempty,string"`
 	AfkTimeout                  int                `json:"afk_timeout,omitempty"`
 	Icon                        string             `json:"icon,omitempty"`
-	OwnerID                     string             `json:"owner_id,omitempty"`
+	OwnerID                     int64              `json:"owner_id,omitempty,string"`
 	Splash                      string             `json:"splash,omitempty"`
 }
 
 // A Role stores information about Discord guild member roles.
 type Role struct {
-	ID          string `json:"id"`
+	ID          int64  `json:"id,string"`
 	Name        string `json:"name"`
 	Managed     bool   `json:"managed"`
 	Mentionable bool   `json:"mentionable"`
@@ -291,10 +291,10 @@ func (r Roles) Swap(i, j int) {
 
 // A VoiceState stores the voice states of Guilds
 type VoiceState struct {
-	UserID    string `json:"user_id"`
+	UserID    int64  `json:"user_id,string"`
 	SessionID string `json:"session_id"`
-	ChannelID string `json:"channel_id"`
-	GuildID   string `json:"guild_id"`
+	ChannelID int64  `json:"channel_id,string"`
+	GuildID   int64  `json:"guild_id,string"`
 	Suppress  bool   `json:"suppress"`
 	SelfMute  bool   `json:"self_mute"`
 	SelfDeaf  bool   `json:"self_deaf"`
@@ -353,13 +353,13 @@ func (g *Game) UnmarshalJSON(bytes []byte) error {
 
 // A Member stores user information for Guild members.
 type Member struct {
-	GuildID  string   `json:"guild_id"`
-	JoinedAt string   `json:"joined_at"`
-	Nick     string   `json:"nick"`
-	Deaf     bool     `json:"deaf"`
-	Mute     bool     `json:"mute"`
-	User     *User    `json:"user"`
-	Roles    []string `json:"roles"`
+	GuildID  int64   `json:"guild_id,string"`
+	JoinedAt string  `json:"joined_at"`
+	Nick     string  `json:"nick"`
+	Deaf     bool    `json:"deaf"`
+	Mute     bool    `json:"mute"`
+	User     *User   `json:"user"`
+	Roles    IDSlice `json:"roles,string"`
 }
 
 // A Settings stores data for a specific users Discord client settings.
@@ -373,8 +373,8 @@ type Settings struct {
 	ConvertEmoticons       bool               `json:"convert_emoticons"`
 	Locale                 string             `json:"locale"`
 	Theme                  string             `json:"theme"`
-	GuildPositions         []string           `json:"guild_positions"`
-	RestrictedGuilds       []string           `json:"restricted_guilds"`
+	GuildPositions         IDSlice            `json:"guild_positions,string"`
+	RestrictedGuilds       IDSlice            `json:"restricted_guilds,string"`
 	FriendSourceFlags      *FriendSourceFlags `json:"friend_source_flags"`
 	Status                 Status             `json:"status"`
 	DetectPlatformAccounts bool               `json:"detect_platform_accounts"`
@@ -417,9 +417,9 @@ type TooManyRequests struct {
 
 // A ReadState stores data on the read state of channels.
 type ReadState struct {
-	MentionCount  int    `json:"mention_count"`
-	LastMessageID string `json:"last_message_id"`
-	ID            string `json:"id"`
+	MentionCount  int   `json:"mention_count"`
+	LastMessageID int64 `json:"last_message_id,string"`
+	ID            int64 `json:"id,string"`
 }
 
 // An Ack is used to ack messages
@@ -429,8 +429,8 @@ type Ack struct {
 
 // A GuildRole stores data for guild roles.
 type GuildRole struct {
-	Role    *Role  `json:"role"`
-	GuildID string `json:"guild_id"`
+	Role    *Role `json:"role"`
+	GuildID int64 `json:"guild_id,string"`
 }
 
 // A GuildBan stores data for a guild ban.
@@ -441,12 +441,12 @@ type GuildBan struct {
 
 // A GuildIntegration stores data for a guild integration.
 type GuildIntegration struct {
-	ID                string                   `json:"id"`
+	ID                int64                    `json:"id,string"`
 	Name              string                   `json:"name"`
 	Type              string                   `json:"type"`
 	Enabled           bool                     `json:"enabled"`
 	Syncing           bool                     `json:"syncing"`
-	RoleID            string                   `json:"role_id"`
+	RoleID            int64                    `json:"role_id,string"`
 	ExpireBehavior    int                      `json:"expire_behavior"`
 	ExpireGracePeriod int                      `json:"expire_grace_period"`
 	User              *User                    `json:"user"`
@@ -462,15 +462,15 @@ type GuildIntegrationAccount struct {
 
 // A GuildEmbed stores data for a guild embed.
 type GuildEmbed struct {
-	Enabled   bool   `json:"enabled"`
-	ChannelID string `json:"channel_id"`
+	Enabled   bool  `json:"enabled"`
+	ChannelID int64 `json:"channel_id,string"`
 }
 
 // A UserGuildSettingsChannelOverride stores data for a channel override for a users guild settings.
 type UserGuildSettingsChannelOverride struct {
-	Muted                bool   `json:"muted"`
-	MessageNotifications int    `json:"message_notifications"`
-	ChannelID            string `json:"channel_id"`
+	Muted                bool  `json:"muted"`
+	MessageNotifications int   `json:"message_notifications"`
+	ChannelID            int64 `json:"channel_id,string"`
 }
 
 // A UserGuildSettings stores data for a users guild settings.
@@ -479,7 +479,7 @@ type UserGuildSettings struct {
 	Muted                bool                                `json:"muted"`
 	MobilePush           bool                                `json:"mobile_push"`
 	MessageNotifications int                                 `json:"message_notifications"`
-	GuildID              string                              `json:"guild_id"`
+	GuildID              int64                               `json:"guild_id,string"`
 	ChannelOverrides     []*UserGuildSettingsChannelOverride `json:"channel_overrides"`
 }
 
@@ -500,9 +500,9 @@ type APIErrorMessage struct {
 
 // Webhook stores the data for a webhook.
 type Webhook struct {
-	ID        string `json:"id"`
-	GuildID   string `json:"guild_id"`
-	ChannelID string `json:"channel_id"`
+	ID        int64  `json:"id,string"`
+	GuildID   int64  `json:"guild_id,string"`
+	ChannelID int64  `json:"channel_id,string"`
 	User      *User  `json:"user"`
 	Name      string `json:"name"`
 	Avatar    string `json:"avatar"`
@@ -521,10 +521,10 @@ type WebhookParams struct {
 
 // MessageReaction stores the data for a message reaction.
 type MessageReaction struct {
-	UserID    string `json:"user_id"`
-	MessageID string `json:"message_id"`
-	Emoji     Emoji  `json:"emoji"`
-	ChannelID string `json:"channel_id"`
+	UserID    int64 `json:"user_id,string"`
+	MessageID int64 `json:"message_id,string"`
+	Emoji     Emoji `json:"emoji"`
+	ChannelID int64 `json:"channel_id,string"`
 }
 
 // GatewayBotResponse stores the data for the gateway/bot response

--- a/types.go
+++ b/types.go
@@ -96,6 +96,10 @@ func (ids IDSlice) MarshalJSON() ([]byte, error) {
 	//    18 characters currently, but 1 extra added for the future,
 	//    1 comma
 	//    2 quotes
+	if len(ids) < 1 {
+		return []byte("[]"), nil
+	}
+
 	outPut := make([]byte, 1, 2+(len(ids)*22))
 	outPut[0] = '['
 
@@ -109,6 +113,5 @@ func (ids IDSlice) MarshalJSON() ([]byte, error) {
 	}
 
 	outPut = append(outPut, '"', ']')
-	fmt.Println(string(outPut))
 	return outPut, nil
 }

--- a/user.go
+++ b/user.go
@@ -7,7 +7,7 @@ import (
 
 // A User stores all data for an individual Discord user.
 type User struct {
-	ID            string `json:"id"`
+	ID            int64  `json:"id,string"`
 	Email         string `json:"email"`
 	Username      string `json:"username"`
 	Avatar        string `json:"avatar"`
@@ -25,7 +25,7 @@ func (u *User) String() string {
 
 // Mention return a string which mentions the user
 func (u *User) Mention() string {
-	return fmt.Sprintf("<@%s>", u.ID)
+	return fmt.Sprintf("<@%d>", u.ID)
 }
 
 // AvatarURL returns a URL to the user's avatar.

--- a/voice.go
+++ b/voice.go
@@ -35,9 +35,9 @@ type VoiceConnection struct {
 	Debug        bool // If true, print extra logging -- DEPRECATED
 	LogLevel     int
 	Ready        bool // If true, voice is ready to send/receive audio
-	UserID       string
-	GuildID      string
-	ChannelID    string
+	UserID       int64
+	GuildID      int64
+	ChannelID    int64
 	deaf         bool
 	mute         bool
 	speaking     bool
@@ -116,7 +116,7 @@ func (v *VoiceConnection) Speaking(b bool) (err error) {
 
 // ChangeChannel sends Discord a request to change channels within a Guild
 // !!! NOTE !!! This function may be removed in favour of just using ChannelVoiceJoin
-func (v *VoiceConnection) ChangeChannel(channelID string, mute, deaf bool) (err error) {
+func (v *VoiceConnection) ChangeChannel(channelID int64, mute, deaf bool) (err error) {
 
 	v.log(LogInformational, "called")
 
@@ -311,8 +311,8 @@ func (v *VoiceConnection) open() (err error) {
 	}
 
 	type voiceHandshakeData struct {
-		ServerID  string `json:"server_id"`
-		UserID    string `json:"user_id"`
+		ServerID  int64  `json:"server_id,string"`
+		UserID    int64  `json:"user_id,string"`
 		SessionID string `json:"session_id"`
 		Token     string `json:"token"`
 	}

--- a/wsapi.go
+++ b/wsapi.go
@@ -75,7 +75,7 @@ func (s *Session) Open() (err error) {
 
 	if s.VoiceConnections == nil {
 		s.log(LogInformational, "creating new VoiceConnections map")
-		s.VoiceConnections = make(map[string]*VoiceConnection)
+		s.VoiceConnections = make(map[int64]*VoiceConnection)
 	}
 
 	// Get the gateway to use for the Websocket connection
@@ -312,7 +312,7 @@ func (s *Session) UpdateStatus(idle int, game string) (err error) {
 }
 
 type requestGuildMembersData struct {
-	GuildID string `json:"guild_id"`
+	GuildID int64  `json:"guild_id,string"`
 	Query   string `json:"query"`
 	Limit   int    `json:"limit"`
 }
@@ -327,7 +327,7 @@ type requestGuildMembersOp struct {
 // guildID  : The ID of the guild to request members of
 // query    : String that username starts with, leave empty to return all members
 // limit    : Max number of items to return, or 0 to request all members matched
-func (s *Session) RequestGuildMembers(guildID, query string, limit int) (err error) {
+func (s *Session) RequestGuildMembers(guildID int64, query string, limit int) (err error) {
 	s.log(LogInformational, "called")
 
 	s.RLock()
@@ -492,10 +492,10 @@ func (s *Session) onEvent(messageType int, message []byte) {
 // ------------------------------------------------------------------------------------------------
 
 type voiceChannelJoinData struct {
-	GuildID   *string `json:"guild_id"`
-	ChannelID *string `json:"channel_id"`
-	SelfMute  bool    `json:"self_mute"`
-	SelfDeaf  bool    `json:"self_deaf"`
+	GuildID   *int64 `json:"guild_id,string"`
+	ChannelID *int64 `json:"channel_id,string"`
+	SelfMute  bool   `json:"self_mute"`
+	SelfDeaf  bool   `json:"self_deaf"`
 }
 
 type voiceChannelJoinOp struct {
@@ -509,7 +509,7 @@ type voiceChannelJoinOp struct {
 //    cID     : Channel ID of the channel to join.
 //    mute    : If true, you will be set to muted upon joining.
 //    deaf    : If true, you will be set to deafened upon joining.
-func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *VoiceConnection, err error) {
+func (s *Session) ChannelVoiceJoin(gID, cID int64, mute, deaf bool) (voice *VoiceConnection, err error) {
 
 	s.log(LogInformational, "called")
 
@@ -556,7 +556,7 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 func (s *Session) onVoiceStateUpdate(st *VoiceStateUpdate) {
 
 	// If we don't have a connection for the channel, don't bother
-	if st.ChannelID == "" {
+	if st.ChannelID == 0 {
 		return
 	}
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -186,7 +186,7 @@ func (s *Session) Open() error {
 	// XXX: can this be moved to when opening a voice connection?
 	if s.VoiceConnections == nil {
 		s.log(LogInformational, "creating new VoiceConnections map")
-		s.VoiceConnections = make(map[string]*VoiceConnection)
+		s.VoiceConnections = make(map[int64]*VoiceConnection)
 	}
 
 	// Create listening chan outside of listen, as it needs to happen inside the


### PR DESCRIPTION
So this probably breaks 90% of the bots out there, and the gains are not major but i still feel like it needed to be done.
I expect this to not be merged in a while, if it's even merged at all because of the large breakage and small gains.

The main benefit i believe is less memory usage. A string id is 18 characters atm and go string headers are 2 integers, thats 34 bytes on a 64bit system, 26 bytes ovearhead per id.

There is some slightly more cpu used when decoding events however. 

I'm not done with this pr, i'm gonna use this branch in my fork and integrate my bot with it to do some real world testing and see what the real differences in performance, memory usage and usability actually are.

I will update this pr with the results of said tests.

### Notes:

 - All id's are represented as int64, using the `string` tag for decoding/encoding from/to json strings
 - This `string` tag did not work for slices :( so i had to make a new type, IDSlice.
 - For the api calls that has @me as a possibility as the id, i created a seperate function for.