### PR TITLE
Fix for #437

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -20,7 +20,7 @@ var (
 
 	EndpointDiscord  = "https://discordapp.com/"
 	EndpointAPI      = EndpointDiscord + "api/"
-	EndpointGuilds   = EndpointAPI + "guilds/"
+	EndpointGuilds   = EndpointAPI + "guilds"
 	EndpointChannels = EndpointAPI + "channels/"
 	EndpointUsers    = EndpointAPI + "users/"
 	EndpointGateway  = EndpointAPI + "gateway"


### PR DESCRIPTION
When using [Session.CreateGuild](https://github.com/bwmarrin/discordgo/blob/0993a94b4e1c3291bed2047f583f34792269355c/restapi.go#L579-L594), currently a 404 is returned as [EndpointGuilds](https://github.com/bwmarrin/discordgo/blob/master/endpoints.go#L23) posts to "guilds/" rather than "guilds", the latter of which is correct according to the Discord API reference. I'm not sure if this is a recent change as the API doesn't show a changelog before v6, but I reproed the issue on my end and this fix seems to work fine.

Credit goes to @Wubsy, who brought up the issue  (#437) in the Discord chat :)