### PR TITLE
Fix for #437 (#2)

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -122,6 +122,8 @@ var (
 	EndpointRelationship        = func(uID string) string { return EndpointRelationships() + "/" + uID }
 	EndpointRelationshipsMutual = func(uID string) string { return EndpointUsers + uID + "/relationships" }
 
+	EndpointGuildCreate = EndpointAPI + "guild"
+
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invite/" + iID }
 
 	EndpointIntegrationsJoin = func(iID string) string { return EndpointAPI + "integrations/" + iID + "/join" }

--- a/restapi.go
+++ b/restapi.go
@@ -585,7 +585,7 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 		Name string `json:"name"`
 	}{name}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuilds, data, EndpointGuilds)
+	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
When using `Session.CreateGuild`, currently a 404 is returned as `EndpointGuilds` posts to `guilds/` rather than `guilds`, the latter of which is correct according to the Discord API reference. I'm not sure if this is a recent change as the API doesn't show a changelog before v6, but I reproed the issue on my end and this fix seems to work fine.

I originally changed EndpointGuilds to "guild", but didn't really consider that it would break other things (duh), so in this commit I added a new variable, `EndpointGuildCreate`, and used that inside `Session.CreateGuild` instead of `EndpointGuilds`. I threw it down in the more miscellaneous section of the endpoints, as the block with `EndpointGuilds` seemed too general for this variable, while the block with the rest of the guild endpoints was all function definitions. This version passes `restapi_test.go` fine.

Once again, credit goes to @Wubsy, who brought up the issue (#437) in the Discord chat :)