### PR TITLE
Add members from GuildMembersChunk to state

### DIFF
--- a/state.go
+++ b/state.go
@@ -816,6 +816,13 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		if s.TrackMembers {
 			err = s.MemberRemove(t.Member)
 		}
+	case *GuildMembersChunk:
+		if s.TrackMembers {
+			for i := range t.Members {
+				t.Members[i].GuildID = t.GuildID
+				err = s.MemberAdd(t.Members[i])
+			}
+		}
 	case *GuildRoleCreate:
 		if s.TrackRoles {
 			err = s.RoleAdd(t.GuildID, t.Role)


### PR DESCRIPTION
Adds members from the GuildMembersChunk event to state.

Results in Members being in both, guild.Members + the private members-map compared to just the guild.Members slice when doing it "manually" in your application which can cause issues.