### PR TITLE
added clarification when initializing discordgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Construct a new Discord client which can be used to access the variety of
 Discord API functions and to set callback functions for Discord events.
 
 ```go
-discord, err := discordgo.New("authentication token")
+discord, err := discordgo.New("Bot " + "authentication token")
 ```
 
 See Documentation and Examples below for more detailed information.


### PR DESCRIPTION
from the code I ran on my system with the latest changes this seems to be the syntax for the authentication tokens. I'm guessing it was just never updated.
Let me know if this is incorrect. 
Thanks!