### PR TITLE
Allow size parameter to be omitted in User.AvatarURL

### DIFF
--- a/user.go
+++ b/user.go
@@ -29,7 +29,9 @@ func (u *User) Mention() string {
 }
 
 // AvatarURL returns a URL to the user's avatar.
-//		size:     The size of the user's avatar as a power of two
+//    size:    The size of the user's avatar as a power of two
+//             if size is an empty string, no size parameter will
+//             be added to the URL.
 func (u *User) AvatarURL(size string) string {
 	var URL string
 	if strings.HasPrefix(u.Avatar, "a_") {
@@ -37,6 +39,9 @@ func (u *User) AvatarURL(size string) string {
 	} else {
 		URL = EndpointUserAvatar(u.ID, u.Avatar)
 	}
-
-	return URL + "?size=" + size
+	
+	if size != "" {
+		return URL + "?size=" + size	
+	}
+	return URL
 }


### PR DESCRIPTION
Allows you to leave the size parameter as an empty string