### PR TITLE
Change uint to float64 for TimeStamps

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -337,8 +337,8 @@ type Game struct {
 
 // A TimeStamps struct contains start and end times used in the rich presence "playing .." Game
 type TimeStamps struct {
-	EndTimestamp   uint `json:"end,omitempty"`
-	StartTimestamp uint `json:"start,omitempty"`
+	EndTimestamp   float64 `json:"end,omitempty"`
+	StartTimestamp float64 `json:"start,omitempty"`
 }
 
 // An Assets struct contains assets and labels used in the rich presence "playing .." Game


### PR DESCRIPTION
Hey,

currently the develop branch will throw the following error when parsing a PRESENCE_UPDATE containing a Game object:
`2017/10/30 14:52:48 [DG0] wsapi.go:477:onEvent() error unmarshalling PRESENCE_UPDATE event, json: cannot unmarshal number 1509371565406.0 into Go struct field TimeStamps.start of type uint`

This change will fix the error by changing the `TimeStamps.start` and `TimeStamps.end` values from an uint to a float64.

