### PR TITLE
Add custom dialer option

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -50,7 +50,7 @@ func New(args ...interface{}) (s *Session, err error) {
 	// Create an empty Session interface.
 	s = &Session{
 		State:                  NewState(),
-		ratelimiter:            NewRatelimiter(),
+		Ratelimiter:            NewRatelimiter(),
 		StateEnabled:           true,
 		Compress:               true,
 		ShouldReconnectOnError: true,

--- a/discord.go
+++ b/discord.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION of DiscordGo, follows Semantic Versioning. (http://semver.org/)
-const VERSION = "0.17.0-dev"
+const VERSION = "0.17.0"
 
 // ErrMFA will be risen by New when the user has 2FA.
 var ErrMFA = errors.New("account has 2FA enabled")

--- a/endpoints.go
+++ b/endpoints.go
@@ -122,8 +122,6 @@ var (
 	EndpointRelationship        = func(uID string) string { return EndpointRelationships() + "/" + uID }
 	EndpointRelationshipsMutual = func(uID string) string { return EndpointUsers + uID + "/relationships" }
 
-	EndpointGuildCreate = EndpointAPI + "guild"
-
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invite/" + iID }
 
 	EndpointIntegrationsJoin = func(iID string) string { return EndpointAPI + "integrations/" + iID + "/join" }

--- a/endpoints.go
+++ b/endpoints.go
@@ -97,7 +97,7 @@ var (
 	EndpointChannelMessages           = func(cID string) string { return EndpointChannels + cID + "/messages" }
 	EndpointChannelMessage            = func(cID, mID string) string { return EndpointChannels + cID + "/messages/" + mID }
 	EndpointChannelMessageAck         = func(cID, mID string) string { return EndpointChannels + cID + "/messages/" + mID + "/ack" }
-	EndpointChannelMessagesBulkDelete = func(cID string) string { return EndpointChannel(cID) + "/messages/bulk_delete" }
+	EndpointChannelMessagesBulkDelete = func(cID string) string { return EndpointChannel(cID) + "/messages/bulk-delete" }
 	EndpointChannelMessagesPins       = func(cID string) string { return EndpointChannel(cID) + "/pins" }
 	EndpointChannelMessagePin         = func(cID, mID string) string { return EndpointChannel(cID) + "/pins/" + mID }
 

--- a/endpoints.go
+++ b/endpoints.go
@@ -121,6 +121,8 @@ var (
 	EndpointRelationship        = func(uID string) string { return EndpointRelationships() + "/" + uID }
 	EndpointRelationshipsMutual = func(uID string) string { return EndpointUsers + uID + "/relationships" }
 
+	EndpointGuildCreate = EndpointAPI + "guilds"
+
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invite/" + iID }
 
 	EndpointIntegrationsJoin = func(iID string) string { return EndpointAPI + "integrations/" + iID + "/join" }

--- a/endpoints.go
+++ b/endpoints.go
@@ -71,7 +71,6 @@ var (
 	EndpointUserNotes          = func(uID string) string { return EndpointUsers + "@me/notes/" + uID }
 
 	EndpointGuild                = func(gID string) string { return EndpointGuilds + gID }
-	EndpointGuildInivtes         = func(gID string) string { return EndpointGuilds + gID + "/invites" }
 	EndpointGuildChannels        = func(gID string) string { return EndpointGuilds + gID + "/channels" }
 	EndpointGuildMembers         = func(gID string) string { return EndpointGuilds + gID + "/members" }
 	EndpointGuildMember          = func(gID, uID string) string { return EndpointGuilds + gID + "/members/" + uID }

--- a/logging.go
+++ b/logging.go
@@ -23,7 +23,7 @@ const (
 	LogError int = iota
 
 	// LogWarning level is used for very abnormal events and errors that are
-	// also returend to a calling function.
+	// also returned to a calling function.
 	LogWarning
 
 	// LogInformational level is used for normal non-error activity

--- a/logging.go
+++ b/logging.go
@@ -47,7 +47,7 @@ func msglog(msgL, caller int, format string, a ...interface{}) {
 
 	if Logger != nil {
 		Logger(msgL, caller, format, a)
-	} else { 
+	} else {
 
 		pc, file, line, _ := runtime.Caller(caller)
 

--- a/logging.go
+++ b/logging.go
@@ -34,6 +34,9 @@ const (
 	LogDebug
 )
 
+// Logger can be used to replace the standard logging for discordgo
+var Logger func(msgL, caller int, format string, a ...interface{})
+
 // msglog provides package wide logging consistancy for discordgo
 // the format, a...  portion this command follows that of fmt.Printf
 //   msgL   : LogLevel of the message
@@ -42,18 +45,23 @@ const (
 //   a ...  : comma seperated list of values to pass
 func msglog(msgL, caller int, format string, a ...interface{}) {
 
-	pc, file, line, _ := runtime.Caller(caller)
+	if Logger != nil {
+		Logger(msgL, caller, format, a)
+	} else { 
 
-	files := strings.Split(file, "/")
-	file = files[len(files)-1]
+		pc, file, line, _ := runtime.Caller(caller)
 
-	name := runtime.FuncForPC(pc).Name()
-	fns := strings.Split(name, ".")
-	name = fns[len(fns)-1]
+		files := strings.Split(file, "/")
+		file = files[len(files)-1]
 
-	msg := fmt.Sprintf(format, a...)
+		name := runtime.FuncForPC(pc).Name()
+		fns := strings.Split(name, ".")
+		name = fns[len(fns)-1]
 
-	log.Printf("[DG%d] %s:%d:%s() %s\n", msgL, file, line, name, msg)
+		msg := fmt.Sprintf(format, a...)
+
+		log.Printf("[DG%d] %s:%d:%s() %s\n", msgL, file, line, name, msg)
+	}
 }
 
 // helper function that wraps msglog for the Session struct

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -41,8 +41,8 @@ func NewRatelimiter() *RateLimiter {
 	}
 }
 
-// getBucket retrieves or creates a bucket
-func (r *RateLimiter) getBucket(key string) *Bucket {
+// GetBucket retrieves or creates a bucket
+func (r *RateLimiter) GetBucket(key string) *Bucket {
 	r.Lock()
 	defer r.Unlock()
 
@@ -51,7 +51,7 @@ func (r *RateLimiter) getBucket(key string) *Bucket {
 	}
 
 	b := &Bucket{
-		remaining: 1,
+		Remaining: 1,
 		Key:       key,
 		global:    r.global,
 	}
@@ -67,28 +67,36 @@ func (r *RateLimiter) getBucket(key string) *Bucket {
 	r.buckets[key] = b
 	return b
 }
-
-// LockBucket Locks until a request can be made
-func (r *RateLimiter) LockBucket(bucketID string) *Bucket {
-
-	b := r.getBucket(bucketID)
-
-	b.Lock()
-
+func (r *RateLimiter) GetWaitTime(b *Bucket, minRemaining int) time.Duration {
 	// If we ran out of calls and the reset time is still ahead of us
 	// then we need to take it easy and relax a little
-	if b.remaining < 1 && b.reset.After(time.Now()) {
-		time.Sleep(b.reset.Sub(time.Now()))
-
+	if b.Remaining < minRemaining && b.reset.After(time.Now()) {
+		return b.reset.Sub(time.Now())
 	}
 
 	// Check for global ratelimits
 	sleepTo := time.Unix(0, atomic.LoadInt64(r.global))
 	if now := time.Now(); now.Before(sleepTo) {
-		time.Sleep(sleepTo.Sub(now))
+		return sleepTo.Sub(now)
 	}
 
-	b.remaining--
+	return 0
+}
+
+// LockBucket Locks until a request can be made
+func (r *RateLimiter) LockBucket(bucketID string) *Bucket {
+	return r.LockBucketObject(r.GetBucket(bucketID))
+}
+
+// LockBucketObject Locks an already resolved bucket until a request can be made
+func (r *RateLimiter) LockBucketObject(b *Bucket) *Bucket {
+	b.Lock()
+
+	if wait := r.GetWaitTime(b, 1); wait > 0 {
+		time.Sleep(wait)
+	}
+
+	b.Remaining--
 	return b
 }
 
@@ -96,13 +104,14 @@ func (r *RateLimiter) LockBucket(bucketID string) *Bucket {
 type Bucket struct {
 	sync.Mutex
 	Key       string
-	remaining int
+	Remaining int
 	limit     int
 	reset     time.Time
 	global    *int64
 
 	lastReset       time.Time
 	customRateLimit *customRateLimit
+	Userdata        interface{}
 }
 
 // Release unlocks the bucket and reads the headers to update the buckets ratelimit info
@@ -113,10 +122,10 @@ func (b *Bucket) Release(headers http.Header) error {
 	// Check if the bucket uses a custom ratelimiter
 	if rl := b.customRateLimit; rl != nil {
 		if time.Now().Sub(b.lastReset) >= rl.reset {
-			b.remaining = rl.requests - 1
+			b.Remaining = rl.requests - 1
 			b.lastReset = time.Now()
 		}
-		if b.remaining < 1 {
+		if b.Remaining < 1 {
 			b.reset = time.Now().Add(rl.reset)
 		}
 		return nil
@@ -176,7 +185,7 @@ func (b *Bucket) Release(headers http.Header) error {
 		if err != nil {
 			return err
 		}
-		b.remaining = int(parsedRemaining)
+		b.Remaining = int(parsedRemaining)
 	}
 
 	return nil

--- a/restapi.go
+++ b/restapi.go
@@ -907,7 +907,7 @@ func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel) (err
 // GuildInvites returns an array of Invite structures for the given guild
 // guildID   : The ID of a Guild.
 func (s *Session) GuildInvites(guildID string) (st []*Invite, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointGuildInvites(guildID), nil, EndpointGuildInivtes(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildInvites(guildID), nil, EndpointGuildInvites(guildID))
 	if err != nil {
 		return
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -587,7 +587,7 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 		Name string `json:"name"`
 	}{name}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuilds, data, EndpointGuilds)
+	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate)
 	if err != nil {
 		return
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -585,7 +585,7 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 		Name string `json:"name"`
 	}{name}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate)
+	body, err := s.RequestWithBucketID("POST", EndpointGuilds, data, EndpointGuilds)
 	if err != nil {
 		return
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -65,9 +65,11 @@ func (s *Session) request(method, urlStr, contentType string, b []byte, bucketID
 	if bucketID == "" {
 		bucketID = strings.SplitN(urlStr, "?", 2)[0]
 	}
+	return s.RequestWithLockedBucket(method, urlStr, contentType, b, s.Ratelimiter.LockBucket(bucketID), sequence)
+}
 
-	bucket := s.ratelimiter.LockBucket(bucketID)
-
+// RequestWithLockedBucket makes a request using a bucket that's already been locked
+func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b []byte, bucket *Bucket, sequence int) (response []byte, err error) {
 	if s.Debug {
 		log.Printf("API REQUEST %8s :: %s\n", method, urlStr)
 		log.Printf("API REQUEST  PAYLOAD :: [%s]\n", string(b))
@@ -139,7 +141,7 @@ func (s *Session) request(method, urlStr, contentType string, b []byte, bucketID
 		if sequence < s.MaxRestRetries {
 
 			s.log(LogInformational, "%s Failed (%s), Retrying...", urlStr, resp.Status)
-			response, err = s.request(method, urlStr, contentType, b, bucketID, sequence+1)
+			response, err = s.RequestWithLockedBucket(method, urlStr, contentType, b, s.Ratelimiter.LockBucketObject(bucket), sequence+1)
 		} else {
 			err = fmt.Errorf("Exceeded Max retries HTTP %s, %s", resp.Status, response)
 		}
@@ -158,7 +160,7 @@ func (s *Session) request(method, urlStr, contentType string, b []byte, bucketID
 		// we can make the above smarter
 		// this method can cause longer delays than required
 
-		response, err = s.request(method, urlStr, contentType, b, bucketID, sequence)
+		response, err = s.RequestWithLockedBucket(method, urlStr, contentType, b, s.Ratelimiter.LockBucketObject(bucket), sequence)
 
 	default: // Error condition
 		err = newRestError(req, resp, response)

--- a/state.go
+++ b/state.go
@@ -816,6 +816,13 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		if s.TrackMembers {
 			err = s.MemberRemove(t.Member)
 		}
+	case *GuildMembersChunk:
+		if s.TrackMembers {
+			for i := range t.Members {
+				t.Members[i].GuildID = t.GuildID
+				err = s.MemberAdd(t.Members[i])
+			}
+		}
 	case *GuildRoleCreate:
 		if s.TrackRoles {
 			err = s.RoleAdd(t.GuildID, t.Role)

--- a/structs.go
+++ b/structs.go
@@ -108,6 +108,12 @@ type Session struct {
 
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
+
+	// websocket dialer
+	Dialer *websocket.Dialer
+
+	// voice websocket dialer
+	VoiceDialer *websocket.Dialer
 }
 
 // A VoiceRegion stores data for a specific voice region server.

--- a/structs.go
+++ b/structs.go
@@ -12,9 +12,7 @@
 package discordgo
 
 import (
-	"encoding/json"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
@@ -315,43 +313,19 @@ type Presence struct {
 	Since  *int     `json:"since"`
 }
 
+// A game type
+type GameType int
+
+const (
+	GameTypeGame GameType = iota
+	GameTypeStreaming
+)
+
 // A Game struct holds the name of the "playing .." game for a user
 type Game struct {
-	Name string `json:"name"`
-	Type int    `json:"type"`
-	URL  string `json:"url,omitempty"`
-}
-
-// UnmarshalJSON unmarshals json to Game struct
-func (g *Game) UnmarshalJSON(bytes []byte) error {
-	temp := &struct {
-		Name json.Number     `json:"name"`
-		Type json.RawMessage `json:"type"`
-		URL  string          `json:"url"`
-	}{}
-	err := json.Unmarshal(bytes, temp)
-	if err != nil {
-		return err
-	}
-	g.URL = temp.URL
-	g.Name = temp.Name.String()
-
-	if temp.Type != nil {
-		err = json.Unmarshal(temp.Type, &g.Type)
-		if err == nil {
-			return nil
-		}
-
-		s := ""
-		err = json.Unmarshal(temp.Type, &s)
-		if err == nil {
-			g.Type, err = strconv.Atoi(s)
-		}
-
-		return err
-	}
-
-	return nil
+	Name string   `json:"name"`
+	Type GameType `json:"type"`
+	URL  string   `json:"url,omitempty"`
 }
 
 // A Member stores user information for Guild members.

--- a/structs.go
+++ b/structs.go
@@ -323,9 +323,30 @@ const (
 
 // A Game struct holds the name of the "playing .." game for a user
 type Game struct {
-	Name string   `json:"name"`
-	Type GameType `json:"type"`
-	URL  string   `json:"url,omitempty"`
+	Name          string     `json:"name"`
+	Type          GameType   `json:"type"`
+	URL           string     `json:"url,omitempty"`
+	Details       string     `json:"details,omitempty"`
+	State         string     `json:"state,omitempty"`
+	TimeStamps    TimeStamps `json:"timestamps,omitempty"`
+	Assets        Assets     `json:"assets,omitempty"`
+	ApplicationID string     `json:"application_id,omitempty"`
+	Instance      int8       `json:"instance,omitempty"`
+	// TODO: Party and Secrets (unknown structure)
+}
+
+// A TimeStamps struct contains start and end times used in the rich presence "playing .." Game
+type TimeStamps struct {
+	EndTimestamp   uint `json:"end,omitempty"`
+	StartTimestamp uint `json:"start,omitempty"`
+}
+
+// An Assets struct contains assets and labels used in the rich presence "playing .." Game
+type Assets struct {
+	LargeImageID string `json:"large_image,omitempty"`
+	SmallImageID string `json:"small_image,omitempty"`
+	LargeText    string `json:"large_text,omitempty"`
+	SmallText    string `json:"small_text,omitempty"`
 }
 
 // A Member stores user information for Guild members.

--- a/structs.go
+++ b/structs.go
@@ -83,6 +83,9 @@ type Session struct {
 	// Stores the last HeartbeatAck that was recieved (in UTC)
 	LastHeartbeatAck time.Time
 
+	// used to deal with rate limits
+	Ratelimiter *RateLimiter
+
 	// Event handlers
 	handlersMu   sync.RWMutex
 	handlers     map[string][]*eventHandlerInstance
@@ -93,9 +96,6 @@ type Session struct {
 
 	// When nil, the session is not listening.
 	listening chan interface{}
-
-	// used to deal with rate limits
-	ratelimiter *RateLimiter
 
 	// sequence tracks the current gateway api websocket sequence number
 	sequence *int64

--- a/structs.go
+++ b/structs.go
@@ -174,6 +174,7 @@ type Channel struct {
 	Recipients           []*User                `json:"recipients"`
 	Messages             []*Message             `json:"-"`
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites"`
+	ParentID             string                 `json:"parent_id"`
 }
 
 // A PermissionOverwrite holds permission overwrite data for a Channel

--- a/structs.go
+++ b/structs.go
@@ -110,9 +110,12 @@ type Session struct {
 	wsMutex sync.Mutex
 
 	// websocket dialer
+	// if not defined, it falls back to the global websocket dialer
 	Dialer *websocket.Dialer
 
 	// voice websocket dialer
+	// if not defined, it falls back to the normal websocket dialer.
+	// if the normal websocket dialer isn't defined either, it falls back to the global one
 	VoiceDialer *websocket.Dialer
 }
 

--- a/voice.go
+++ b/voice.go
@@ -301,7 +301,15 @@ func (v *VoiceConnection) open() (err error) {
 	// Connect to VoiceConnection Websocket
 	vg := fmt.Sprintf("wss://%s", strings.TrimSuffix(v.endpoint, ":80"))
 	v.log(LogInformational, "connecting to voice endpoint %s", vg)
-	v.wsConn, _, err = websocket.DefaultDialer.Dial(vg, nil)
+	dialer := v.session.VoiceDialer
+	if dialer == nil {
+		if v.session.Dialer != nil {
+			dialer = v.session.Dialer
+		} else {
+			dialer = websocket.DefaultDialer
+		}
+	}
+	v.wsConn, _, err = dialer.Dial(vg, nil)
 	if err != nil {
 		v.log(LogWarning, "error connecting to voice endpoint %s, %s", vg, err)
 		v.log(LogDebug, "voice struct: %#v\n", v)

--- a/voice.go
+++ b/voice.go
@@ -13,7 +13,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"sync"
@@ -104,7 +103,7 @@ func (v *VoiceConnection) Speaking(b bool) (err error) {
 	defer v.Unlock()
 	if err != nil {
 		v.speaking = false
-		log.Println("Speaking() write json error:", err)
+		v.log(LogError, "Speaking() write json error:", err)
 		return
 	}
 
@@ -181,7 +180,7 @@ func (v *VoiceConnection) Close() {
 		v.log(LogInformational, "closing udp")
 		err := v.udpConn.Close()
 		if err != nil {
-			log.Println("error closing udp connection: ", err)
+			v.log(LogError, "error closing udp connection: ", err)
 		}
 		v.udpConn = nil
 	}

--- a/wsapi.go
+++ b/wsapi.go
@@ -93,7 +93,11 @@ func (s *Session) Open() (err error) {
 	header.Add("accept-encoding", "zlib")
 
 	s.log(LogInformational, "connecting to gateway %s", s.gateway)
-	s.wsConn, _, err = websocket.DefaultDialer.Dial(s.gateway, header)
+	dialer := s.Dialer
+	if dialer == nil {
+		dialer = websocket.DefaultDialer
+	}
+	s.wsConn, _, err = dialer.Dial(s.gateway, header)
 	if err != nil {
 		s.log(LogWarning, "error connecting to gateway %s, %s", s.gateway, err)
 		s.gateway = "" // clear cached gateway

--- a/wsapi.go
+++ b/wsapi.go
@@ -285,9 +285,9 @@ func (s *Session) UpdateStreamingStatus(idle int, game string, url string) (err 
 	}
 
 	if game != "" {
-		gameType := 0
+		gameType := GameTypeGame
 		if url != "" {
-			gameType = 1
+			gameType = GameTypeStreaming
 		}
 		usd.Game = &Game{
 			Name: game,

--- a/wsapi.go
+++ b/wsapi.go
@@ -249,7 +249,7 @@ func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}
 	}
 }
 
-type updateStatusData struct {
+type UpdateStatusData struct {
 	IdleSince *int   `json:"since"`
 	Game      *Game  `json:"game"`
 	AFK       bool   `json:"afk"`
@@ -258,7 +258,7 @@ type updateStatusData struct {
 
 type updateStatusOp struct {
 	Op   int              `json:"op"`
-	Data updateStatusData `json:"d"`
+	Data UpdateStatusData `json:"d"`
 }
 
 // UpdateStreamingStatus is used to update the user's streaming status.
@@ -270,13 +270,7 @@ func (s *Session) UpdateStreamingStatus(idle int, game string, url string) (err 
 
 	s.log(LogInformational, "called")
 
-	s.RLock()
-	defer s.RUnlock()
-	if s.wsConn == nil {
-		return ErrWSNotFound
-	}
-
-	usd := updateStatusData{
+	usd := UpdateStatusData{
 		Status: "online",
 	}
 
@@ -294,6 +288,18 @@ func (s *Session) UpdateStreamingStatus(idle int, game string, url string) (err 
 			Type: gameType,
 			URL:  url,
 		}
+	}
+
+	return s.UpdateStatusComplex(usd)
+}
+
+// UpdateStatusComplex allows for sending the raw status update data untouched by discordgo.
+func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
+
+	s.RLock()
+	defer s.RUnlock()
+	if s.wsConn == nil {
+		return ErrWSNotFound
 	}
 
 	s.wsMutex.Lock()


### PR DESCRIPTION
This change allows the dialer to be replaced with a custom version.
You can replace the general websocket dialer and if you want, you can use a different dialer for voice connections.

As an example, you could enable SOCKS5 proxying for voice requests with the following code and `x/net/proxy`:
```go
	socksDialer, err := proxy.SOCKS5("tcp", "localhost:31337", nil, &net.Dialer{})
	if err != nil {
		fmt.Println("Error creating socks proxy", err)
		return
	}

	session.VoiceDialer = &websocket.Dialer{
		NetDial: socksDialer.Dial,
	}
```