### PR TITLE
Fix TimeStamps unmarshalling (#474)

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -12,6 +12,7 @@
 package discordgo
 
 import (
+	"encoding/json"
 	"net/http"
 	"sync"
 	"time"
@@ -338,8 +339,23 @@ type Game struct {
 
 // A TimeStamps struct contains start and end times used in the rich presence "playing .." Game
 type TimeStamps struct {
-	EndTimestamp   uint `json:"end,omitempty"`
-	StartTimestamp uint `json:"start,omitempty"`
+	EndTimestamp   int64 `json:"end,omitempty"`
+	StartTimestamp int64 `json:"start,omitempty"`
+}
+
+// UnmarshalJSON unmarshals JSON into TimeStamps struct
+func (t *TimeStamps) UnmarshalJSON(b []byte) error {
+	temp := struct {
+		End   float64 `json:"end,omitempty"`
+		Start float64 `json:"start,omitempty"`
+	}{}
+	err := json.Unmarshal(b, &temp)
+	if err != nil {
+		return err
+	}
+	t.EndTimestamp = int64(temp.End)
+	t.StartTimestamp = int64(temp.Start)
+	return nil
 }
 
 // An Assets struct contains assets and labels used in the rich presence "playing .." Game


### PR DESCRIPTION
TimeStamps used in rich presence currently cause the following error:
`[DG0] wsapi.go:477:onEvent() error unmarshalling PRESENCE_UPDATE event, json: cannot unmarshal number 1510183304574.0 into Go struct field TimeStamps.start of type uint`

This change fixes the issue by implementing UnmarshalJSON on TimeStamps and changing startTimestamp and endTimestamp from uint (which may be too small on some platforms) to int64.