### PR TITLE
Several typo fixes.

### DIFF
--- a/event.go
+++ b/event.go
@@ -6,7 +6,7 @@ type EventHandler interface {
 	Type() string
 
 	// Handle is called whenever an event of Type() happens.
-	// It is the recievers responsibility to type assert that the interface
+	// It is the receivers responsibility to type assert that the interface
 	// is the expected struct.
 	Handle(*Session, interface{})
 }

--- a/examples/appmaker/main.go
+++ b/examples/appmaker/main.go
@@ -79,7 +79,7 @@ func main() {
 	ap.Name = Name
 	ap, err = dg.ApplicationCreate(ap)
 	if err != nil {
-		fmt.Println("error creating new applicaiton,", err)
+		fmt.Println("error creating new application,", err)
 		return
 	}
 

--- a/logging.go
+++ b/logging.go
@@ -42,7 +42,7 @@ var Logger func(msgL, caller int, format string, a ...interface{})
 //   msgL   : LogLevel of the message
 //   caller : 1 + the number of callers away from the message source
 //   format : Printf style message format
-//   a ...  : comma seperated list of values to pass
+//   a ...  : comma separated list of values to pass
 func msglog(msgL, caller int, format string, a ...interface{}) {
 
 	if Logger != nil {

--- a/restapi.go
+++ b/restapi.go
@@ -1206,7 +1206,7 @@ func (s *Session) GuildEmbedEdit(guildID string, enabled bool, channelID string)
 // Functions specific to Discord Channels
 // ------------------------------------------------------------------------------------------------
 
-// Channel returns a Channel strucutre of a specific Channel.
+// Channel returns a Channel structure of a specific Channel.
 // channelID  : The ID of the Channel you want returned.
 func (s *Session) Channel(channelID string) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointChannel(channelID), nil, EndpointChannel(channelID))

--- a/restapi.go
+++ b/restapi.go
@@ -1478,7 +1478,7 @@ func (s *Session) ChannelMessageDelete(channelID, messageID string) (err error) 
 }
 
 // ChannelMessagesBulkDelete bulk deletes the messages from the channel for the provided messageIDs.
-// If only one messageID is in the slice call channelMessageDelete funciton.
+// If only one messageID is in the slice call channelMessageDelete function.
 // If the slice is empty do nothing.
 // channelID : The ID of the channel for the messages to delete.
 // messages  : The IDs of the messages to be deleted. A slice of string IDs. A maximum of 100 messages.

--- a/structs.go
+++ b/structs.go
@@ -203,7 +203,7 @@ func (e *Emoji) APIName() string {
 	return e.ID
 }
 
-// VerificationLevel type defination
+// VerificationLevel type definition
 type VerificationLevel int
 
 // Constants for VerificationLevel levels from 0 to 3 inclusive
@@ -395,7 +395,7 @@ type Settings struct {
 	DeveloperMode          bool               `json:"developer_mode"`
 }
 
-// Status type defination
+// Status type definition
 type Status string
 
 // Constants for Status with the different current available status

--- a/voice.go
+++ b/voice.go
@@ -68,7 +68,7 @@ type VoiceConnection struct {
 	voiceSpeakingUpdateHandlers []VoiceSpeakingUpdateHandler
 }
 
-// VoiceSpeakingUpdateHandler type provides a function defination for the
+// VoiceSpeakingUpdateHandler type provides a function definition for the
 // VoiceSpeakingUpdate event
 type VoiceSpeakingUpdateHandler func(vc *VoiceConnection, vs *VoiceSpeakingUpdate)
 
@@ -246,7 +246,7 @@ type voiceOP2 struct {
 }
 
 // WaitUntilConnected waits for the Voice Connection to
-// become ready, if it does not become ready it retuns an err
+// become ready, if it does not become ready it returns an err
 func (v *VoiceConnection) waitUntilConnected() error {
 
 	v.log(LogInformational, "called")
@@ -857,7 +857,7 @@ func (v *VoiceConnection) reconnect() {
 		}
 
 		if v.session.DataReady == false || v.session.wsConn == nil {
-			v.log(LogInformational, "cannot reconenct to channel %s with unready session", v.ChannelID)
+			v.log(LogInformational, "cannot reconnect to channel %s with unready session", v.ChannelID)
 			continue
 		}
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -673,7 +673,7 @@ func (s *Session) onVoiceServerUpdate(st *VoiceServerUpdate) {
 	voice.GuildID = st.GuildID
 	voice.Unlock()
 
-	// Open a conenction to the voice server
+	// Open a connection to the voice server
 	err := voice.open()
 	if err != nil {
 		s.log(LogError, "onVoiceServerUpdate voice.open, %s", err)


### PR DESCRIPTION
Not sure how these remained unfixed for so long, they were all here in plain text with the line numbers: https://goreportcard.com/report/github.com/bwmarrin/discordgo#misspell.