### PR TITLE
Adds the unique field to the invite struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -144,6 +144,7 @@ type Invite struct {
 	MaxUses   int       `json:"max_uses"`
 	Revoked   bool      `json:"revoked"`
 	Temporary bool      `json:"temporary"`
+	Unique    bool      `json:"unique"`
 }
 
 // ChannelType is the type of a Channel


### PR DESCRIPTION
The unique field can be used to prevent invite reusing.

https://discordapp.com/developers/docs/resources/channel#create-channel-invite
https://discordapp.com/developers/docs/resources/invite#invite-object
