### PR TITLE
adds default avatar generation to AvatarURL method

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -63,8 +63,9 @@ var (
 	EndpointUser               = func(uID string) string { return EndpointUsers + uID }
 	EndpointUserAvatar         = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".png" }
 	EndpointUserAvatarAnimated = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".gif" }
-	EndpointDefaultUserAvatar  = func(uDiscriminator int) string {
-		return EndpointCDN + "embed/avatars/" + strconv.Itoa(uDiscriminator%5) + ".png"
+	EndpointDefaultUserAvatar  = func(uDiscriminator string) string {
+		uDiscriminatorInt, _ := strconv.Atoi(uDiscriminator)
+		return EndpointCDN + "embed/avatars/" + strconv.Itoa(uDiscriminatorInt%5) + ".png"
 	}
 	EndpointUserSettings      = func(uID string) string { return EndpointUsers + uID + "/settings" }
 	EndpointUserGuilds        = func(uID string) string { return EndpointUsers + uID + "/guilds" }

--- a/endpoints.go
+++ b/endpoints.go
@@ -11,6 +11,8 @@
 
 package discordgo
 
+import "strconv"
+
 // APIVersion is the Discord API version used for the REST and Websocket API.
 var APIVersion = "6"
 
@@ -61,14 +63,17 @@ var (
 	EndpointUser               = func(uID string) string { return EndpointUsers + uID }
 	EndpointUserAvatar         = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".png" }
 	EndpointUserAvatarAnimated = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".gif" }
-	EndpointUserSettings       = func(uID string) string { return EndpointUsers + uID + "/settings" }
-	EndpointUserGuilds         = func(uID string) string { return EndpointUsers + uID + "/guilds" }
-	EndpointUserGuild          = func(uID, gID string) string { return EndpointUsers + uID + "/guilds/" + gID }
-	EndpointUserGuildSettings  = func(uID, gID string) string { return EndpointUsers + uID + "/guilds/" + gID + "/settings" }
-	EndpointUserChannels       = func(uID string) string { return EndpointUsers + uID + "/channels" }
-	EndpointUserDevices        = func(uID string) string { return EndpointUsers + uID + "/devices" }
-	EndpointUserConnections    = func(uID string) string { return EndpointUsers + uID + "/connections" }
-	EndpointUserNotes          = func(uID string) string { return EndpointUsers + "@me/notes/" + uID }
+	EndpointDefaultUserAvatar  = func(uDiscriminator int) string {
+		return EndpointCDN + "embed/avatars/" + strconv.Itoa(uDiscriminator%5) + ".png"
+	}
+	EndpointUserSettings      = func(uID string) string { return EndpointUsers + uID + "/settings" }
+	EndpointUserGuilds        = func(uID string) string { return EndpointUsers + uID + "/guilds" }
+	EndpointUserGuild         = func(uID, gID string) string { return EndpointUsers + uID + "/guilds/" + gID }
+	EndpointUserGuildSettings = func(uID, gID string) string { return EndpointUsers + uID + "/guilds/" + gID + "/settings" }
+	EndpointUserChannels      = func(uID string) string { return EndpointUsers + uID + "/channels" }
+	EndpointUserDevices       = func(uID string) string { return EndpointUsers + uID + "/devices" }
+	EndpointUserConnections   = func(uID string) string { return EndpointUsers + uID + "/connections" }
+	EndpointUserNotes         = func(uID string) string { return EndpointUsers + "@me/notes/" + uID }
 
 	EndpointGuild                = func(gID string) string { return EndpointGuilds + gID }
 	EndpointGuildChannels        = func(gID string) string { return EndpointGuilds + gID + "/channels" }

--- a/user.go
+++ b/user.go
@@ -2,7 +2,6 @@ package discordgo
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -36,8 +35,7 @@ func (u *User) Mention() string {
 func (u *User) AvatarURL(size string) string {
 	var URL string
 	if u.Avatar == "" {
-		discriminatorInt, _ := strconv.Atoi(u.Discriminator)
-		URL = EndpointDefaultUserAvatar(discriminatorInt)
+		URL = EndpointDefaultUserAvatar(u.Discriminator)
 	} else if strings.HasPrefix(u.Avatar, "a_") {
 		URL = EndpointUserAvatarAnimated(u.ID, u.Avatar)
 	} else {

--- a/user.go
+++ b/user.go
@@ -2,6 +2,7 @@ package discordgo
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -34,7 +35,10 @@ func (u *User) Mention() string {
 //             be added to the URL.
 func (u *User) AvatarURL(size string) string {
 	var URL string
-	if strings.HasPrefix(u.Avatar, "a_") {
+	if u.Avatar == "" {
+		discriminatorInt, _ := strconv.Atoi(u.Discriminator)
+		URL = EndpointDefaultUserAvatar(discriminatorInt)
+	} else if strings.HasPrefix(u.Avatar, "a_") {
 		URL = EndpointUserAvatarAnimated(u.ID, u.Avatar)
 	} else {
 		URL = EndpointUserAvatar(u.ID, u.Avatar)


### PR DESCRIPTION
AvatarURL will return a link to the default avatars instead of an invalid link if the user has no avatar set.

As described here: https://discordapp.com/developers/docs/reference#image-formatting-cdn-endpoints