### PR TITLE
Drop the default websocket close handler

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -85,6 +85,10 @@ func (s *Session) Open() error {
 		s.wsConn = nil // Just to be safe.
 		return err
 	}
+	
+	s.wsConn.SetCloseHandler(func(code int, text string) error {
+		return nil
+	})
 
 	defer func() {
 		// because of this, all code below must set err to the error


### PR DESCRIPTION
The default websocket close handler sends back the close code it received ([see here](https://github.com/gorilla/websocket/blob/23059f29570f0e13fca80ef6aea0f04c11daaa4d/conn.go#L1063-L1070)) .
In some cases, Discord seems to receive that close code. The problem is, if we get a 1000 close code and reply back with a 1000 close code, it'll invalidate our session, and we will not be able to resume it.
Not sending any close code, should do the trick.