### PR TITLE
Fix role mention replacement

### DIFF
--- a/message.go
+++ b/message.go
@@ -237,7 +237,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 			continue
 		}
 
-		content = strings.Replace(content, "<&"+role.ID+">", "@"+role.Name, -1)
+		content = strings.Replace(content, "<@&"+role.ID+">", "@"+role.Name, -1)
 	}
 
 	content = patternChannels.ReplaceAllStringFunc(content, func(mention string) string {

--- a/message_test.go
+++ b/message_test.go
@@ -30,7 +30,7 @@ func TestContentWithMoreMentionsReplaced(t *testing.T) {
 		ID:      "channel",
 	})
 	m := &Message{
-		Content:      "<&role> <@!user> <@user> <#channel>",
+		Content:      "<@&role> <@!user> <@user> <#channel>",
 		ChannelID:    "channel",
 		MentionRoles: []string{"role"},
 		Mentions:     []*User{user},


### PR DESCRIPTION
Roles are mentioned with `<@&number>` instead of `<&number>`
