### PR TITLE
Add Audit Log Reason Support (#386)

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -645,6 +645,11 @@ type GatewayBotResponse struct {
 	Shards int    `json:"shards"`
 }
 
+// OptionalRequestHeaders is a struct for applied headers when making requests
+type OptionalRequestHeaders struct {
+	AuditLogReason	string	
+}
+
 // Constants for the different bit offsets of text channel permissions
 const (
 	PermissionReadMessages = 1 << (iota + 10)


### PR DESCRIPTION
This pull request adds audit log reason support.

The new `OptionalRequestHeaders` struct can be extended to cover future headers that may want to be needed in the future.

Also added versions of functions so that they take a reason argument.