### PR TITLE
Changed State.MemberAdd to set fields individually

### DIFF
--- a/state.go
+++ b/state.go
@@ -299,7 +299,12 @@ func (s *State) MemberAdd(member *Member) error {
 		members[member.User.ID] = member
 		guild.Members = append(guild.Members, member)
 	} else {
-		*m = *member // Update the actual data, which will also update the member pointer in the slice
+		// We are about to replace `m` in the state with `member`, but first we need to
+		// make sure we preserve any fields that the `member` doesn't contain from `m`.
+		if member.JoinedAt == "" {
+			member.JoinedAt = m.JoinedAt
+		}
+		*m = *member
 	}
 
 	return nil


### PR DESCRIPTION
This fixes #532. Though it's not mentioned on the Discord docs, it seems `Member.JoinedAt` isn't sent in member updates (it *is* sent in member chunks), which caused the value to be overwritten to an empty value after member updates. This pull request changes `State.MemberAdd` to handle each field individually, similarly to other function in the State that have similar dilemmas, checking for an empty `JoinedAt` field.