### PR TITLE
Reduce data sent to the DAPI in GuildChannelsReorder

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -935,7 +935,17 @@ func (s *Session) GuildChannelCreate(guildID, name string, ctype ChannelType) (s
 // channels  : Updated channels.
 func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel) (err error) {
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildChannels(guildID), channels, EndpointGuildChannels(guildID))
+	data := make([]struct {
+		ID       string `json:"id"`
+		Position int    `json:"position"`
+	}, len(channels))
+
+	for i, c := range channels {
+		data[i].ID = c.ID
+		data[i].Position = c.Position
+	}
+
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildChannels(guildID), data, EndpointGuildChannels(guildID))
 	return
 }
 


### PR DESCRIPTION
This function currently has an issue where it sends too much data, causing Discord to reject the request as it believes you're trying to amend several fields by sending all of them.
This change resolves that by creating a simplified version of the Channel struct that only sends the data required for reordering.