### PR TITLE
Add GuildID to Message

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION of DiscordGo, follows Semantic Versioning. (http://semver.org/)
-const VERSION = "0.17.0-dev"
+const VERSION = "0.17.0"
 
 // ErrMFA will be risen by New when the user has 2FA.
 var ErrMFA = errors.New("account has 2FA enabled")

--- a/endpoints.go
+++ b/endpoints.go
@@ -122,6 +122,8 @@ var (
 	EndpointRelationship        = func(uID string) string { return EndpointRelationships() + "/" + uID }
 	EndpointRelationshipsMutual = func(uID string) string { return EndpointUsers + uID + "/relationships" }
 
+	EndpointGuildCreate = EndpointAPI + "guild"
+
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invite/" + iID }
 
 	EndpointIntegrationsJoin = func(iID string) string { return EndpointAPI + "integrations/" + iID + "/join" }

--- a/endpoints.go
+++ b/endpoints.go
@@ -122,8 +122,6 @@ var (
 	EndpointRelationship        = func(uID string) string { return EndpointRelationships() + "/" + uID }
 	EndpointRelationshipsMutual = func(uID string) string { return EndpointUsers + uID + "/relationships" }
 
-	EndpointGuildCreate = EndpointAPI + "guild"
-
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invite/" + iID }
 
 	EndpointIntegrationsJoin = func(iID string) string { return EndpointAPI + "integrations/" + iID + "/join" }

--- a/message.go
+++ b/message.go
@@ -35,6 +35,7 @@ type Message struct {
 	ID              string               `json:"id"`
 	ChannelID       string               `json:"channel_id"`
 	Content         string               `json:"content"`
+	GuildID         string               `json:"guild_id,omitempty"`
 	Timestamp       Timestamp            `json:"timestamp"`
 	EditedTimestamp Timestamp            `json:"edited_timestamp"`
 	MentionRoles    []string             `json:"mention_roles"`

--- a/restapi.go
+++ b/restapi.go
@@ -585,7 +585,7 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 		Name string `json:"name"`
 	}{name}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuilds, data, EndpointGuilds)
+	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate)
 	if err != nil {
 		return
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -585,7 +585,7 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 		Name string `json:"name"`
 	}{name}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate)
+	body, err := s.RequestWithBucketID("POST", EndpointGuilds, data, EndpointGuilds)
 	if err != nil {
 		return
 	}

--- a/state.go
+++ b/state.go
@@ -816,6 +816,13 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		if s.TrackMembers {
 			err = s.MemberRemove(t.Member)
 		}
+	case *GuildMembersChunk:
+		if s.TrackMembers {
+			for i := range t.Members {
+				t.Members[i].GuildID = t.GuildID
+				err = s.MemberAdd(t.Members[i])
+			}
+		}
 	case *GuildRoleCreate:
 		if s.TrackRoles {
 			err = s.RoleAdd(t.GuildID, t.Role)

--- a/state.go
+++ b/state.go
@@ -816,13 +816,6 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		if s.TrackMembers {
 			err = s.MemberRemove(t.Member)
 		}
-	case *GuildMembersChunk:
-		if s.TrackMembers {
-			for i := range t.Members {
-				t.Members[i].GuildID = t.GuildID
-				err = s.MemberAdd(t.Members[i])
-			}
-		}
 	case *GuildRoleCreate:
 		if s.TrackRoles {
 			err = s.RoleAdd(t.GuildID, t.Role)


### PR DESCRIPTION
The Discord API now provides a `guild_id` property so you don't have to get the channel first.

Edit: realized that a couple more events provide the `guild_id`, I'll be adding them in a moment