### PR TITLE
Add GuildID to Multiple Structs

### DIFF
--- a/events.go
+++ b/events.go
@@ -70,6 +70,7 @@ type ChannelDelete struct {
 type ChannelPinsUpdate struct {
 	LastPinTimestamp string `json:"last_pin_timestamp"`
 	ChannelID        string `json:"channel_id"`
+	GuildID          string `json:"guild_id,omitempty"`
 }
 
 // GuildCreate is the data for a GuildCreate event.
@@ -212,6 +213,7 @@ type RelationshipRemove struct {
 type TypingStart struct {
 	UserID    string `json:"user_id"`
 	ChannelID string `json:"channel_id"`
+	GuildID   string `json:"guild_id,omitempty"`
 	Timestamp int    `json:"timestamp"`
 }
 
@@ -250,4 +252,5 @@ type VoiceStateUpdate struct {
 type MessageDeleteBulk struct {
 	Messages  []string `json:"ids"`
 	ChannelID string   `json:"channel_id"`
+	GuildID   string   `json:"guild_id"`
 }

--- a/message.go
+++ b/message.go
@@ -38,6 +38,9 @@ type Message struct {
 	// The ID of the channel in which the message was sent.
 	ChannelID string `json:"channel_id"`
 
+	// The ID of the guild in which the message was sent.
+	GuildID string `json:"guild_id,omitempty"`
+
 	// The content of the message.
 	Content string `json:"content"`
 

--- a/structs.go
+++ b/structs.go
@@ -813,6 +813,7 @@ type MessageReaction struct {
 	MessageID string `json:"message_id"`
 	Emoji     Emoji  `json:"emoji"`
 	ChannelID string `json:"channel_id"`
+	GuildID   string `json:"guild_id,omitempty"`
 }
 
 // GatewayBotResponse stores the data for the gateway/bot response


### PR DESCRIPTION
Discord has introduced the `guild_id` property into various guild related events and this PR aims to support them.