### PR TITLE
Added copy of previous Message state to MessageUpdate

### DIFF
--- a/events.go
+++ b/events.go
@@ -162,6 +162,8 @@ type MessageCreate struct {
 // MessageUpdate is the data for a MessageUpdate event.
 type MessageUpdate struct {
 	*Message
+	// BeforeUpdate will be nil if the Message was not previously cached in the state cache.
+	BeforeUpdate *Message `json:"-"`
 }
 
 // MessageDelete is the data for a MessageDelete event.

--- a/state.go
+++ b/state.go
@@ -863,6 +863,12 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	case *MessageUpdate:
 		if s.MaxMessageCount != 0 {
+			old, err := s.Message(t.ChannelID, t.ID)
+			if err == nil {
+				oldCopy := *old
+				t.BeforeUpdate = &oldCopy
+			}
+
 			err = s.MessageAdd(t.Message)
 		}
 	case *MessageDelete:

--- a/state.go
+++ b/state.go
@@ -863,7 +863,8 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	case *MessageUpdate:
 		if s.MaxMessageCount != 0 {
-			old, err := s.Message(t.ChannelID, t.ID)
+			var old *Message
+			old, err = s.Message(t.ChannelID, t.ID)
 			if err == nil {
 				oldCopy := *old
 				t.BeforeUpdate = &oldCopy


### PR DESCRIPTION
It is currently impossible to obtain a copy of the previous message content when receiving `MessageUpdate`, as the changes are always written to state before the message is sent to the event handler, even when SyncEvents is used.

This PR fixes that by introducing a (shallow) copy of the Message object, allowing comparison of the old and the new message.