### PR TITLE
Update guild object

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -288,12 +288,13 @@ func (e *Emoji) APIName() string {
 // VerificationLevel type definition
 type VerificationLevel int
 
-// Constants for VerificationLevel levels from 0 to 3 inclusive
+// Constants for VerificationLevel levels from 0 to 4 inclusive
 const (
 	VerificationLevelNone VerificationLevel = iota
 	VerificationLevelLow
 	VerificationLevelMedium
 	VerificationLevelHigh
+	VerificationLevelVeryHigh
 )
 
 // ExplicitContentFilterLevel type definition

--- a/structs.go
+++ b/structs.go
@@ -316,6 +316,15 @@ const (
 	MfaLevelElevated
 )
 
+// DefaultMessageNotificationLevel type definition
+type DefaultMessageNotificationLevel int
+
+// Constants for DefaultMessageNotificationLevel levels from 0 to 1 inclusive
+const (
+	DefaultMessageNotificationLevelAllMessages DefaultMessageNotificationLevel = iota
+	DefaultMessageNotificationLevelOnlyMentions
+)
+
 // A Guild holds all data related to a specific Discord Guild.  Guilds are also
 // sometimes referred to as Servers in the Discord client.
 type Guild struct {
@@ -369,8 +378,7 @@ type Guild struct {
 	Large bool `json:"large"`
 
 	// The default message notification setting for the guild.
-	// 0 == all messages, 1 == mentions only.
-	DefaultMessageNotifications int `json:"default_message_notifications"`
+	DefaultMessageNotifications DefaultMessageNotificationLevel `json:"default_message_notifications"`
 
 	// A list of roles in the guild.
 	Roles []*Role `json:"roles"`
@@ -433,15 +441,15 @@ type UserGuild struct {
 
 // A GuildParams stores all the data needed to update discord guild settings
 type GuildParams struct {
-	Name                        string             `json:"name,omitempty"`
-	Region                      string             `json:"region,omitempty"`
-	VerificationLevel           *VerificationLevel `json:"verification_level,omitempty"`
-	DefaultMessageNotifications int                `json:"default_message_notifications,omitempty"` // TODO: Separate type?
-	AfkChannelID                string             `json:"afk_channel_id,omitempty"`
-	AfkTimeout                  int                `json:"afk_timeout,omitempty"`
-	Icon                        string             `json:"icon,omitempty"`
-	OwnerID                     string             `json:"owner_id,omitempty"`
-	Splash                      string             `json:"splash,omitempty"`
+	Name                        string                           `json:"name,omitempty"`
+	Region                      string                           `json:"region,omitempty"`
+	VerificationLevel           *VerificationLevel               `json:"verification_level,omitempty"`
+	DefaultMessageNotifications *DefaultMessageNotificationLevel `json:"default_message_notifications,omitempty"`
+	AfkChannelID                string                           `json:"afk_channel_id"`
+	AfkTimeout                  int                              `json:"afk_timeout"`
+	Icon                        string                           `json:"icon,omitempty"`
+	OwnerID                     string                           `json:"owner_id,omitempty"`
+	Splash                      string                           `json:"splash,omitempty"`
 }
 
 // A Role stores information about Discord guild member roles.

--- a/structs.go
+++ b/structs.go
@@ -450,6 +450,7 @@ type GuildParams struct {
 	Icon                        string                           `json:"icon,omitempty"`
 	OwnerID                     string                           `json:"owner_id,omitempty"`
 	Splash                      string                           `json:"splash,omitempty"`
+	ExplicitContentFilter       *ExplicitContentFilterLevel      `json:"explicit_content_filter,omitempty"`
 }
 
 // A Role stores information about Discord guild member roles.


### PR DESCRIPTION
I made a few changes to the `Guild` struct and `GuildParams` struct to stay up to date with the API.

I put them all in one PR to prevent merge conflicts. Please tell me if I should do it differently.

Some might break backwards compatibility. Please tell me if I should use a different approach.

Changes:
- add VerificationLevel Very High (4)
- add DefaultMessageNotificationLevel
  - use it in Guild Struct
  - use it in GuildParams (for modifying Guilds)
  - ⚠️ This might break backwards compatibility. 
- add ExplicitContentFilterLevel to GuildParams (for modifying Guilds)
- removed `omitempty` for `AfkChannelID` and `AfkTimeout` to be able to reset it.
  - ⚠️ This might break backwards compatibility. 
  - ⚠️ I forgot to put that in a separate commit. (it's in 09ff136f06ff22fb7b7ca34d6d7185aa7bf5f186)