### PR TITLE
adds InviteWithCounts

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1717,6 +1717,19 @@ func (s *Session) Invite(inviteID string) (st *Invite, err error) {
 	return
 }
 
+// InviteWithCounts returns an Invite structure of the given invite including approximate member counts
+// inviteID : The invite code
+func (s *Session) InviteWithCounts(inviteID string) (st *Invite, err error) {
+
+	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID)+"?with_counts=true", nil, EndpointInvite(""))
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
 // InviteDelete deletes an existing invite
 // inviteID   : the code of an invite
 func (s *Session) InviteDelete(inviteID string) (st *Invite, err error) {

--- a/structs.go
+++ b/structs.go
@@ -177,6 +177,10 @@ type Invite struct {
 	Revoked   bool      `json:"revoked"`
 	Temporary bool      `json:"temporary"`
 	Unique    bool      `json:"unique"`
+
+	// will only be filled when using InviteWithCounts
+	ApproximatePresenceCount int `json:"approximate_presence_count"`
+	ApproximateMemberCount   int `json:"approximate_member_count"`
 }
 
 // ChannelType is the type of a Channel


### PR DESCRIPTION
This PR implements the optional URL parameter `with_counts` of the Get Invite Request. It returns approximate member counts with the invite object (even for invites of servers the requesting account is not a part of).

It is documented here https://discordapp.com/developers/docs/resources/invite#get-invite