### PR TITLE
Add Member.Mention

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -602,6 +602,11 @@ type Member struct {
 	Roles []string `json:"roles"`
 }
 
+// Mention creates a member mention
+func (m *Member) Mention() string {
+	return "<@!" + m.User.ID + ">"
+}
+
 // A Settings stores data for a specific users Discord client settings.
 type Settings struct {
 	RenderEmbeds           bool               `json:"render_embeds"`


### PR DESCRIPTION
Associated issue: 
https://github.com/bwmarrin/discordgo/issues/518

I'm not sure if it matters if the member nickname is empty.