### PR TITLE
Added .MessageFormat() to emoji struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -281,8 +281,8 @@ type Emoji struct {
 	Animated      bool     `json:"animated"`
 }
 
-// ChatName returns a correctly formatted Emoji for use in Message content and embeds
-func (e *Emoji) ChatName() string {
+// MessageFormat returns a correctly formatted Emoji for use in Message content and embeds
+func (e *Emoji) MessageFormat() string {
 	if e.ID != "" && e.Name != "" {
 		if e.Animated {
 			return "<a:" + e.APIName() + ">"

--- a/structs.go
+++ b/structs.go
@@ -281,6 +281,19 @@ type Emoji struct {
 	Animated      bool     `json:"animated"`
 }
 
+// ChatName returns a correctly formatted Emoji for use in Message content and embeds
+func (e *Emoji) ChatName() string {
+	if e.ID != "" && e.Name != "" {
+		if e.Animated {
+			return "<a:" + e.APIName() + ">"
+		} else {
+			return "<:" + e.APIName() + ">"
+		}
+	}
+
+	return e.APIName()
+}
+
 // APIName returns an correctly formatted API name for use in the MessageReactions endpoints.
 func (e *Emoji) APIName() string {
 	if e.ID != "" && e.Name != "" {

--- a/structs.go
+++ b/structs.go
@@ -286,9 +286,9 @@ func (e *Emoji) MessageFormat() string {
 	if e.ID != "" && e.Name != "" {
 		if e.Animated {
 			return "<a:" + e.APIName() + ">"
-		} else {
-			return "<:" + e.APIName() + ">"
 		}
+
+		return "<:" + e.APIName() + ">"
 	}
 
 	return e.APIName()


### PR DESCRIPTION
.APIName currently covers all REST url cases, but with the introduction of animated Emoji the chat usage of Emoji has become slightly less obvious as well, despite bots being able to use them.

This new func makes usage of custom emoji (including animated ones) easier.