### PR TITLE
Changed Member.JoinedAt to type Timestamp

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -597,7 +597,7 @@ type Member struct {
 	GuildID string `json:"guild_id"`
 
 	// The time at which the member joined the guild, in ISO8601.
-	JoinedAt string `json:"joined_at"`
+	JoinedAt Timestamp `json:"joined_at"`
 
 	// The nickname of the member, if they have one.
 	Nick string `json:"nick"`


### PR DESCRIPTION
It was previously just string, but has been updated to be consistent with the other structs.