### PR TITLE
Remove ChannelEdit rate_limit_per_user omit-empty

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -264,7 +264,7 @@ type ChannelEdit struct {
 	UserLimit            int                    `json:"user_limit,omitempty"`
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
 	ParentID             string                 `json:"parent_id,omitempty"`
-	RateLimitPerUser     int                    `json:"rate_limit_per_user,omitempty"`
+	RateLimitPerUser     int                    `json:"rate_limit_per_user"`
 }
 
 // A PermissionOverwrite holds permission overwrite data for a Channel


### PR DESCRIPTION
I realised setting the `rate_limit_per_user` field of the ChannelEdit struct to omitempty will make it impossible to reset the value. This PR fixes this.

#586 