### PR TITLE
feature: add last_pin_timestamp to Channel struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -217,6 +217,10 @@ type Channel struct {
 	// guaranteed to be an ID of a valid message.
 	LastMessageID string `json:"last_message_id"`
 
+	// The timestamp of the last pinned message in the channel.
+	// Empty if the channel has no pinned messages.
+	LastPinTimestamp Timestamp `json:"last_pin_timestamp"`
+
 	// Whether the channel is marked as NSFW.
 	NSFW bool `json:"nsfw"`
 


### PR DESCRIPTION
This resolves #547.

Adds a "LastPinTimestamp" field to the Channel structure, which reflects
the `last_pin_timestamp` field on the Discord API. This field is
indicative of whether or not the channel has any pinned messages, and
can save an API request from being sent if there are none.

FWIW, The API doesn't seem to return a 404 anymore when there are no
pinned messages; it returns a 200 with `[]`.