### PR TITLE
Fixed travis test failing for older versions of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ go:
 install:
     - go get github.com/bwmarrin/discordgo
     - go get -v .
-    - go get -v github.com/golang/lint/golint
+    - go get -v golang.org/x/lint/golint || true
 script:
     - diff <(gofmt -d .) <(echo -n)
     - go vet -x ./...
-    - golint -set_exit_status ./...
+    - golint -set_exit_status ./... || true
     - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
 go:
-    - 1.7.x
-    - 1.8.x
     - 1.9.x
+    - 1.10.x
+    - 1.11.x
 install:
     - go get github.com/bwmarrin/discordgo
     - go get -v .
-    - go get -v golang.org/x/lint/golint || true
+    - go get -v golang.org/x/lint/golint
 script:
     - diff <(gofmt -d .) <(echo -n)
     - go vet -x ./...
-    - golint -set_exit_status ./... || true
+    - golint -set_exit_status ./...
     - go test -v -race ./...


### PR DESCRIPTION
Older versions of go were making tests fail due to golint.
Post v1.6 of go, golint changed to an official repo.

Error before change:
```
golang.org/x/tools/go/internal/gcimporter
../../../golang.org/x/tools/go/internal/gcimporter/bexport.go:212: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
The command "go get -v golang.org/x/lint/golint" failed and exited with 2 during .
```
pre v1.9, this method was not present. 
References:
- https://github.com/golang/go/issues/28291#issuecomment-431568120
- https://github.com/golang/tools/pull/52#issuecomment-432082363