### PR TITLE
Feat(MessageReactions): afterID and beforeID

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -2108,14 +2108,22 @@ func (s *Session) MessageReactionsRemoveAll(channelID, messageID string) error {
 // channelID : The channel ID.
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
-// limit    : max number of users to return (max 100)
-func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit int) (st []*User, err error) {
+// limit     : The number of users that can be returned (max 100).
+// afterID   : If provided all users returned will be after given ID.
+// beforeID  : If provided all users returned will be before given ID.
+func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit int, beforeID, afterID string) (st []*User, err error) {
 	uri := EndpointMessageReactions(channelID, messageID, emojiID)
 
 	v := url.Values{}
 
 	if limit > 0 {
 		v.Set("limit", strconv.Itoa(limit))
+	}
+	if afterID != "" {
+		v.Set("after", afterID)
+	}
+	if beforeID != "" {
+		v.Set("before", beforeID)
 	}
 
 	if len(v) > 0 {


### PR DESCRIPTION
API support for the afterID and beforeID of reactions.