### PR TITLE
check for empty gID/cID

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -649,6 +649,17 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 
 	// Send the request to Discord that we want to join the voice channel
 	data := voiceChannelJoinOp{4, voiceChannelJoinData{&gID, &cID, mute, deaf}}
+	
+	// If a empty string is sent the session will temporarily disconnect, unless it's null(nil)
+	if cID == "" {
+		data.Data.ChannelID = nil
+	}
+	
+	// If the gID is empty the session will temporarily dissconnect, returning prevents this.  
+	if gID == "" {
+		return
+	}
+	
 	s.wsMutex.Lock()
 	err = s.wsConn.WriteJSON(data)
 	s.wsMutex.Unlock()

--- a/wsapi.go
+++ b/wsapi.go
@@ -655,7 +655,7 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 		data.Data.ChannelID = nil
 	}
 	
-	// If the gID is empty the session will temporarily dissconnect, returning prevents this.  
+	// If the gID is empty the session will temporarily disconnect, returning prevents this.  
 	if gID == "" {
 		return
 	}


### PR DESCRIPTION
Sending a empty string causes the session to disconnect for then reconnect a few seconds later. Sending a null/nil string pointer fixes this and gives the expected result of just disconnecting from the voice channel.

Also added a check for gID as there's no point to send with no guild ID and it will just temporarily disconnect the session.
