### PR TITLE
Remove code duplication in ChannelVoiceJoin

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -615,11 +615,7 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 	voice.session = s
 	voice.Unlock()
 
-	// Send the request to Discord that we want to join the voice channel
-	data := voiceChannelJoinOp{4, voiceChannelJoinData{&gID, &cID, mute, deaf}}
-	s.wsMutex.Lock()
-	err = s.wsConn.WriteJSON(data)
-	s.wsMutex.Unlock()
+	err = s.ChannelVoiceJoinManual(gID, cID, mute, deaf)
 	if err != nil {
 		return
 	}
@@ -652,10 +648,6 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 	s.wsMutex.Lock()
 	err = s.wsConn.WriteJSON(data)
 	s.wsMutex.Unlock()
-	if err != nil {
-		return
-	}
-
 	return
 }
 


### PR DESCRIPTION
This PR remove the code duplication between ChannelVoiceJoin and ChannelVoiceJoinManual
The only drawback is that it get signaled twice in the log.
Shoud I put this part in a little private function called by both functions ?