### PR TITLE
Changing GuildParams.*VerificationLevel to non-pointer

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -618,12 +618,9 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 func (s *Session) GuildEdit(guildID string, g GuildParams) (st *Guild, err error) {
 
 	// Bounds checking for VerificationLevel, interval: [0, 3]
-	if g.VerificationLevel != nil {
-		val := *g.VerificationLevel
-		if val < 0 || val > 3 {
-			err = ErrVerificationLevelBounds
-			return
-		}
+	if g.VerificationLevel < 0 || g.VerificationLevel > 3 {
+		err = ErrVerificationLevelBounds
+		return
 	}
 
 	//Bounds checking for regions

--- a/structs.go
+++ b/structs.go
@@ -458,7 +458,7 @@ type UserGuild struct {
 type GuildParams struct {
 	Name                        string             `json:"name,omitempty"`
 	Region                      string             `json:"region,omitempty"`
-	VerificationLevel           VerificationLevel `json:"verification_level,omitempty"`
+	VerificationLevel           VerificationLevel  `json:"verification_level,omitempty"`
 	DefaultMessageNotifications int                `json:"default_message_notifications,omitempty"` // TODO: Separate type?
 	AfkChannelID                string             `json:"afk_channel_id,omitempty"`
 	AfkTimeout                  int                `json:"afk_timeout,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -458,7 +458,7 @@ type UserGuild struct {
 type GuildParams struct {
 	Name                        string             `json:"name,omitempty"`
 	Region                      string             `json:"region,omitempty"`
-	VerificationLevel           *VerificationLevel `json:"verification_level,omitempty"`
+	VerificationLevel           VerificationLevel `json:"verification_level,omitempty"`
 	DefaultMessageNotifications int                `json:"default_message_notifications,omitempty"` // TODO: Separate type?
 	AfkChannelID                string             `json:"afk_channel_id,omitempty"`
 	AfkTimeout                  int                `json:"afk_timeout,omitempty"`


### PR DESCRIPTION
Seeing as VerificationLevel is a type alias for an integer, and the precedent of its use doesn't use a reference - I figure we should bring this all in line