### PR TITLE
added SnowflakeTimestamp utility function

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,0 +1,17 @@
+package discordgo
+
+import (
+	"strconv"
+	"time"
+)
+
+// SnowflakeTimestamp returns the creation time of a Snowflake ID relative to the creation of Discord.
+func SnowflakeTimestamp(ID string) (t time.Time, err error) {
+	i, err := strconv.ParseInt(ID, 10, 64)
+	if err != nil {
+		return
+	}
+	timestamp := (i >> 22) + 1420070400000
+	t = time.Unix(timestamp/1000, 0)
+	return
+}


### PR DESCRIPTION
Returns the creation date of a Snowflake relative to discord. I created a `util.go` file for this function. My next choice would have been putting it in `discord.go`