### PR TITLE
Add proper response type for GuildBans docs

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -675,7 +675,7 @@ func (s *Session) GuildLeave(guildID string) (err error) {
 	return
 }
 
-// GuildBans returns an array of User structures for all bans of a
+// GuildBans returns an array of GuildBan structures for all bans of a
 // given guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildBans(guildID string) (st []*GuildBan, err error) {


### PR DESCRIPTION
The previous documentation stated that the response type was an array of User structures, when the function return an array of GuildBan structures.