### PR TITLE
Expose all Emojis and allow a member dump

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1310,6 +1310,22 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 	return
 }
 
+// GuildEmojis returns an array of Emoji structures for all emojis of a
+// given guild.
+// guildID : The ID of a Guild.
+// name    : The Name of the Emoji.
+// image   : The base64 encoded emoji image, has to be smaller than 256KB.
+// roles   : The roles for which this emoji will be whitelisted, can be nil.
+func (s *Session) GuildEmojis(guildID string) (emojis []*Emoji, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointGuildEmojis(guildID), nil, EndpointGuildEmojis(guildID))
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &emojis)
+	return
+}
+
 // GuildEmojiCreate creates a new emoji
 // guildID : The ID of a Guild.
 // name    : The Name of the Emoji.

--- a/state.go
+++ b/state.go
@@ -349,6 +349,26 @@ func (s *State) MemberRemove(member *Member) error {
 	return ErrStateNotFound
 }
 
+// Members returns a deep copy of all members in all guilds
+func (s *State) Members() map[string]map[string]Member {
+	s.RLock()
+	defer s.RUnlock()
+
+	memberMap := make(map[string]map[string]Member)
+
+	for guildID, memberList := range s.memberMap {
+		a := make(map[string]Member)
+
+		for memberID, member := range memberList {
+			a[memberID] = *member
+		}
+
+		memberMap[guildID] = a
+	}
+
+	return memberMap
+}
+
 // Member gets a member by ID from a guild.
 func (s *State) Member(guildID, userID string) (*Member, error) {
 	if s == nil {


### PR DESCRIPTION
I've added two methods that allow users to

* Get a list of all emojis added to the Guild
* Get a deep copy of the memberMap used in State