### PR TITLE
fix: remove _trace from helloOp

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -261,7 +261,6 @@ type heartbeatOp struct {
 
 type helloOp struct {
 	HeartbeatInterval time.Duration `json:"heartbeat_interval"`
-	Trace             []string      `json:"_trace"`
 }
 
 // FailedHeartbeatAcks is the Number of heartbeat intervals to wait until forcing a connection restart.


### PR DESCRIPTION
As per discordapp/discord-api-docs#967, _trace in OP10 HELLO is no
longer an array of strings, but rather an undefined glob of data that
presently contains a mixed bag of strings and objects.

type helloOp does not seem to be exposed outside of the library, so this
is not a breaking change; furthermore, the Trace field of helloOp was
not used anywhere within the library. It seems like it would be safer to
just remove the field outright, rather than accept it as an interface{}
and waste cycles unmarshaling data that is never used.

This is a critically breaking bug, as if the upstream change is merged,
bots using DiscordGo prior to this patch will be unable to connect; an
error would occur when trying to unmarshal the new data glob into a
[]string, causing (*Session).Open() to prematurely return.