### PR TITLE
Added Asset and ApplicationAssets

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -141,8 +141,9 @@ var (
 	EndpointEmoji         = func(eID string) string { return EndpointAPI + "emojis/" + eID + ".png" }
 	EndpointEmojiAnimated = func(eID string) string { return EndpointAPI + "emojis/" + eID + ".gif" }
 
-	EndpointOauth2          = EndpointAPI + "oauth2/"
-	EndpointApplications    = EndpointOauth2 + "applications"
-	EndpointApplication     = func(aID string) string { return EndpointApplications + "/" + aID }
-	EndpointApplicationsBot = func(aID string) string { return EndpointApplications + "/" + aID + "/bot" }
+	EndpointOauth2            = EndpointAPI + "oauth2/"
+	EndpointApplications      = EndpointOauth2 + "applications"
+	EndpointApplication       = func(aID string) string { return EndpointApplications + "/" + aID }
+	EndpointApplicationsBot   = func(aID string) string { return EndpointApplications + "/" + aID + "/bot" }
+	EndpointApplicationAssets = func(aID string) string { return EndpointApplications + "/" + aID + "/assets" }
 )

--- a/oauth2.go
+++ b/oauth2.go
@@ -105,6 +105,25 @@ func (s *Session) ApplicationDelete(appID string) (err error) {
 	return
 }
 
+// Asset struct stores values for an asset of an application
+type Asset struct {
+	Type int    `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ApplicationAssets returns an application's assets
+func (s *Session) ApplicationAssets(appID string) (ass []*Asset, err error) {
+
+	body, err := s.RequestWithBucketID("GET", EndpointApplicationAssets(appID), nil, EndpointApplicationAssets(""))
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &ass)
+	return
+}
+
 // ------------------------------------------------------------------------------------------------
 // Code specific to Discord OAuth2 Application Bots
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The `/assets` endpoint is used in `https://discordapp.com/developers/applications/$APP_ID/rich-presence/assets` for Rich Presence assets.