### PR TITLE
Update handlers to receive an interface for the Session

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -49,7 +49,7 @@ func New(args ...interface{}) (s *Session, err error) {
 
 	// Create an empty Session interface.
 	s = &Session{
-		State:                  NewState(),
+		state:                  NewState(),
 		Ratelimiter:            NewRatelimiter(),
 		StateEnabled:           true,
 		Compress:               true,

--- a/discord_test.go
+++ b/discord_test.go
@@ -137,17 +137,17 @@ func TestOpenClose(t *testing.T) {
 func TestAddHandler(t *testing.T) {
 
 	testHandlerCalled := int32(0)
-	testHandler := func(s *Session, m *MessageCreate) {
+	testHandler := func(s Sessioner, m *MessageCreate) {
 		atomic.AddInt32(&testHandlerCalled, 1)
 	}
 
 	interfaceHandlerCalled := int32(0)
-	interfaceHandler := func(s *Session, i interface{}) {
+	interfaceHandler := func(s Sessioner, i interface{}) {
 		atomic.AddInt32(&interfaceHandlerCalled, 1)
 	}
 
 	bogusHandlerCalled := int32(0)
-	bogusHandler := func(s *Session, se *Session) {
+	bogusHandler := func(s Sessioner, se *Session) {
 		atomic.AddInt32(&bogusHandlerCalled, 1)
 	}
 
@@ -181,7 +181,7 @@ func TestAddHandler(t *testing.T) {
 func TestRemoveHandler(t *testing.T) {
 
 	testHandlerCalled := int32(0)
-	testHandler := func(s *Session, m *MessageCreate) {
+	testHandler := func(s Sessioner, m *MessageCreate) {
 		atomic.AddInt32(&testHandlerCalled, 1)
 	}
 

--- a/event.go
+++ b/event.go
@@ -8,7 +8,7 @@ type EventHandler interface {
 	// Handle is called whenever an event of Type() happens.
 	// It is the receivers responsibility to type assert that the interface
 	// is the expected struct.
-	Handle(*Session, interface{})
+	Handle(Sessioner, interface{})
 }
 
 // EventInterfaceProvider is an interface for providing empty interfaces for
@@ -27,7 +27,7 @@ type EventInterfaceProvider interface {
 const interfaceEventType = "__INTERFACE__"
 
 // interfaceEventHandler is an event handler for interface{} events.
-type interfaceEventHandler func(*Session, interface{})
+type interfaceEventHandler func(Sessioner, interface{})
 
 // Type returns the event type for interface{} events.
 func (eh interfaceEventHandler) Type() string {
@@ -35,7 +35,7 @@ func (eh interfaceEventHandler) Type() string {
 }
 
 // Handle is the handler for an interface{} event.
-func (eh interfaceEventHandler) Handle(s *Session, i interface{}) {
+func (eh interfaceEventHandler) Handle(s Sessioner, i interface{}) {
 	eh(s, i)
 }
 
@@ -233,7 +233,7 @@ func (s *Session) onInterface(i interface{}) {
 	case *VoiceStateUpdate:
 		go s.onVoiceStateUpdate(t)
 	}
-	err := s.State.OnInterface(s, i)
+	err := s.state.OnInterface(s, i)
 	if err != nil {
 		s.log(LogDebug, "error dispatching internal event, %s", err)
 	}

--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -54,7 +54,7 @@ const (
 )
 
 // channelCreateEventHandler is an event handler for ChannelCreate events.
-type channelCreateEventHandler func(*Session, *ChannelCreate)
+type channelCreateEventHandler func(Sessioner, *ChannelCreate)
 
 // Type returns the event type for ChannelCreate events.
 func (eh channelCreateEventHandler) Type() string {
@@ -67,14 +67,14 @@ func (eh channelCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelCreate events.
-func (eh channelCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelCreateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*ChannelCreate); ok {
 		eh(s, t)
 	}
 }
 
 // channelDeleteEventHandler is an event handler for ChannelDelete events.
-type channelDeleteEventHandler func(*Session, *ChannelDelete)
+type channelDeleteEventHandler func(Sessioner, *ChannelDelete)
 
 // Type returns the event type for ChannelDelete events.
 func (eh channelDeleteEventHandler) Type() string {
@@ -87,14 +87,14 @@ func (eh channelDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelDelete events.
-func (eh channelDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelDeleteEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*ChannelDelete); ok {
 		eh(s, t)
 	}
 }
 
 // channelPinsUpdateEventHandler is an event handler for ChannelPinsUpdate events.
-type channelPinsUpdateEventHandler func(*Session, *ChannelPinsUpdate)
+type channelPinsUpdateEventHandler func(Sessioner, *ChannelPinsUpdate)
 
 // Type returns the event type for ChannelPinsUpdate events.
 func (eh channelPinsUpdateEventHandler) Type() string {
@@ -107,14 +107,14 @@ func (eh channelPinsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelPinsUpdate events.
-func (eh channelPinsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelPinsUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*ChannelPinsUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // channelUpdateEventHandler is an event handler for ChannelUpdate events.
-type channelUpdateEventHandler func(*Session, *ChannelUpdate)
+type channelUpdateEventHandler func(Sessioner, *ChannelUpdate)
 
 // Type returns the event type for ChannelUpdate events.
 func (eh channelUpdateEventHandler) Type() string {
@@ -127,14 +127,14 @@ func (eh channelUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for ChannelUpdate events.
-func (eh channelUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh channelUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*ChannelUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // connectEventHandler is an event handler for Connect events.
-type connectEventHandler func(*Session, *Connect)
+type connectEventHandler func(Sessioner, *Connect)
 
 // Type returns the event type for Connect events.
 func (eh connectEventHandler) Type() string {
@@ -142,14 +142,14 @@ func (eh connectEventHandler) Type() string {
 }
 
 // Handle is the handler for Connect events.
-func (eh connectEventHandler) Handle(s *Session, i interface{}) {
+func (eh connectEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*Connect); ok {
 		eh(s, t)
 	}
 }
 
 // disconnectEventHandler is an event handler for Disconnect events.
-type disconnectEventHandler func(*Session, *Disconnect)
+type disconnectEventHandler func(Sessioner, *Disconnect)
 
 // Type returns the event type for Disconnect events.
 func (eh disconnectEventHandler) Type() string {
@@ -157,14 +157,14 @@ func (eh disconnectEventHandler) Type() string {
 }
 
 // Handle is the handler for Disconnect events.
-func (eh disconnectEventHandler) Handle(s *Session, i interface{}) {
+func (eh disconnectEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*Disconnect); ok {
 		eh(s, t)
 	}
 }
 
 // eventEventHandler is an event handler for Event events.
-type eventEventHandler func(*Session, *Event)
+type eventEventHandler func(Sessioner, *Event)
 
 // Type returns the event type for Event events.
 func (eh eventEventHandler) Type() string {
@@ -172,14 +172,14 @@ func (eh eventEventHandler) Type() string {
 }
 
 // Handle is the handler for Event events.
-func (eh eventEventHandler) Handle(s *Session, i interface{}) {
+func (eh eventEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*Event); ok {
 		eh(s, t)
 	}
 }
 
 // guildBanAddEventHandler is an event handler for GuildBanAdd events.
-type guildBanAddEventHandler func(*Session, *GuildBanAdd)
+type guildBanAddEventHandler func(Sessioner, *GuildBanAdd)
 
 // Type returns the event type for GuildBanAdd events.
 func (eh guildBanAddEventHandler) Type() string {
@@ -192,14 +192,14 @@ func (eh guildBanAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildBanAdd events.
-func (eh guildBanAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildBanAddEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildBanAdd); ok {
 		eh(s, t)
 	}
 }
 
 // guildBanRemoveEventHandler is an event handler for GuildBanRemove events.
-type guildBanRemoveEventHandler func(*Session, *GuildBanRemove)
+type guildBanRemoveEventHandler func(Sessioner, *GuildBanRemove)
 
 // Type returns the event type for GuildBanRemove events.
 func (eh guildBanRemoveEventHandler) Type() string {
@@ -212,14 +212,14 @@ func (eh guildBanRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildBanRemove events.
-func (eh guildBanRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildBanRemoveEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildBanRemove); ok {
 		eh(s, t)
 	}
 }
 
 // guildCreateEventHandler is an event handler for GuildCreate events.
-type guildCreateEventHandler func(*Session, *GuildCreate)
+type guildCreateEventHandler func(Sessioner, *GuildCreate)
 
 // Type returns the event type for GuildCreate events.
 func (eh guildCreateEventHandler) Type() string {
@@ -232,14 +232,14 @@ func (eh guildCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildCreate events.
-func (eh guildCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildCreateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildCreate); ok {
 		eh(s, t)
 	}
 }
 
 // guildDeleteEventHandler is an event handler for GuildDelete events.
-type guildDeleteEventHandler func(*Session, *GuildDelete)
+type guildDeleteEventHandler func(Sessioner, *GuildDelete)
 
 // Type returns the event type for GuildDelete events.
 func (eh guildDeleteEventHandler) Type() string {
@@ -252,14 +252,14 @@ func (eh guildDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildDelete events.
-func (eh guildDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildDeleteEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildDelete); ok {
 		eh(s, t)
 	}
 }
 
 // guildEmojisUpdateEventHandler is an event handler for GuildEmojisUpdate events.
-type guildEmojisUpdateEventHandler func(*Session, *GuildEmojisUpdate)
+type guildEmojisUpdateEventHandler func(Sessioner, *GuildEmojisUpdate)
 
 // Type returns the event type for GuildEmojisUpdate events.
 func (eh guildEmojisUpdateEventHandler) Type() string {
@@ -272,14 +272,14 @@ func (eh guildEmojisUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildEmojisUpdate events.
-func (eh guildEmojisUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildEmojisUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildEmojisUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // guildIntegrationsUpdateEventHandler is an event handler for GuildIntegrationsUpdate events.
-type guildIntegrationsUpdateEventHandler func(*Session, *GuildIntegrationsUpdate)
+type guildIntegrationsUpdateEventHandler func(Sessioner, *GuildIntegrationsUpdate)
 
 // Type returns the event type for GuildIntegrationsUpdate events.
 func (eh guildIntegrationsUpdateEventHandler) Type() string {
@@ -292,14 +292,14 @@ func (eh guildIntegrationsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildIntegrationsUpdate events.
-func (eh guildIntegrationsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildIntegrationsUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildIntegrationsUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // guildMemberAddEventHandler is an event handler for GuildMemberAdd events.
-type guildMemberAddEventHandler func(*Session, *GuildMemberAdd)
+type guildMemberAddEventHandler func(Sessioner, *GuildMemberAdd)
 
 // Type returns the event type for GuildMemberAdd events.
 func (eh guildMemberAddEventHandler) Type() string {
@@ -312,14 +312,14 @@ func (eh guildMemberAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMemberAdd events.
-func (eh guildMemberAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMemberAddEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildMemberAdd); ok {
 		eh(s, t)
 	}
 }
 
 // guildMemberRemoveEventHandler is an event handler for GuildMemberRemove events.
-type guildMemberRemoveEventHandler func(*Session, *GuildMemberRemove)
+type guildMemberRemoveEventHandler func(Sessioner, *GuildMemberRemove)
 
 // Type returns the event type for GuildMemberRemove events.
 func (eh guildMemberRemoveEventHandler) Type() string {
@@ -332,14 +332,14 @@ func (eh guildMemberRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMemberRemove events.
-func (eh guildMemberRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMemberRemoveEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildMemberRemove); ok {
 		eh(s, t)
 	}
 }
 
 // guildMemberUpdateEventHandler is an event handler for GuildMemberUpdate events.
-type guildMemberUpdateEventHandler func(*Session, *GuildMemberUpdate)
+type guildMemberUpdateEventHandler func(Sessioner, *GuildMemberUpdate)
 
 // Type returns the event type for GuildMemberUpdate events.
 func (eh guildMemberUpdateEventHandler) Type() string {
@@ -352,14 +352,14 @@ func (eh guildMemberUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMemberUpdate events.
-func (eh guildMemberUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMemberUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildMemberUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // guildMembersChunkEventHandler is an event handler for GuildMembersChunk events.
-type guildMembersChunkEventHandler func(*Session, *GuildMembersChunk)
+type guildMembersChunkEventHandler func(Sessioner, *GuildMembersChunk)
 
 // Type returns the event type for GuildMembersChunk events.
 func (eh guildMembersChunkEventHandler) Type() string {
@@ -372,14 +372,14 @@ func (eh guildMembersChunkEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildMembersChunk events.
-func (eh guildMembersChunkEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildMembersChunkEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildMembersChunk); ok {
 		eh(s, t)
 	}
 }
 
 // guildRoleCreateEventHandler is an event handler for GuildRoleCreate events.
-type guildRoleCreateEventHandler func(*Session, *GuildRoleCreate)
+type guildRoleCreateEventHandler func(Sessioner, *GuildRoleCreate)
 
 // Type returns the event type for GuildRoleCreate events.
 func (eh guildRoleCreateEventHandler) Type() string {
@@ -392,14 +392,14 @@ func (eh guildRoleCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildRoleCreate events.
-func (eh guildRoleCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildRoleCreateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildRoleCreate); ok {
 		eh(s, t)
 	}
 }
 
 // guildRoleDeleteEventHandler is an event handler for GuildRoleDelete events.
-type guildRoleDeleteEventHandler func(*Session, *GuildRoleDelete)
+type guildRoleDeleteEventHandler func(Sessioner, *GuildRoleDelete)
 
 // Type returns the event type for GuildRoleDelete events.
 func (eh guildRoleDeleteEventHandler) Type() string {
@@ -412,14 +412,14 @@ func (eh guildRoleDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildRoleDelete events.
-func (eh guildRoleDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildRoleDeleteEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildRoleDelete); ok {
 		eh(s, t)
 	}
 }
 
 // guildRoleUpdateEventHandler is an event handler for GuildRoleUpdate events.
-type guildRoleUpdateEventHandler func(*Session, *GuildRoleUpdate)
+type guildRoleUpdateEventHandler func(Sessioner, *GuildRoleUpdate)
 
 // Type returns the event type for GuildRoleUpdate events.
 func (eh guildRoleUpdateEventHandler) Type() string {
@@ -432,14 +432,14 @@ func (eh guildRoleUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildRoleUpdate events.
-func (eh guildRoleUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildRoleUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildRoleUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // guildUpdateEventHandler is an event handler for GuildUpdate events.
-type guildUpdateEventHandler func(*Session, *GuildUpdate)
+type guildUpdateEventHandler func(Sessioner, *GuildUpdate)
 
 // Type returns the event type for GuildUpdate events.
 func (eh guildUpdateEventHandler) Type() string {
@@ -452,14 +452,14 @@ func (eh guildUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for GuildUpdate events.
-func (eh guildUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh guildUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*GuildUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // messageAckEventHandler is an event handler for MessageAck events.
-type messageAckEventHandler func(*Session, *MessageAck)
+type messageAckEventHandler func(Sessioner, *MessageAck)
 
 // Type returns the event type for MessageAck events.
 func (eh messageAckEventHandler) Type() string {
@@ -472,14 +472,14 @@ func (eh messageAckEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageAck events.
-func (eh messageAckEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageAckEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageAck); ok {
 		eh(s, t)
 	}
 }
 
 // messageCreateEventHandler is an event handler for MessageCreate events.
-type messageCreateEventHandler func(*Session, *MessageCreate)
+type messageCreateEventHandler func(Sessioner, *MessageCreate)
 
 // Type returns the event type for MessageCreate events.
 func (eh messageCreateEventHandler) Type() string {
@@ -492,14 +492,14 @@ func (eh messageCreateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageCreate events.
-func (eh messageCreateEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageCreateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageCreate); ok {
 		eh(s, t)
 	}
 }
 
 // messageDeleteEventHandler is an event handler for MessageDelete events.
-type messageDeleteEventHandler func(*Session, *MessageDelete)
+type messageDeleteEventHandler func(Sessioner, *MessageDelete)
 
 // Type returns the event type for MessageDelete events.
 func (eh messageDeleteEventHandler) Type() string {
@@ -512,14 +512,14 @@ func (eh messageDeleteEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageDelete events.
-func (eh messageDeleteEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageDeleteEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageDelete); ok {
 		eh(s, t)
 	}
 }
 
 // messageDeleteBulkEventHandler is an event handler for MessageDeleteBulk events.
-type messageDeleteBulkEventHandler func(*Session, *MessageDeleteBulk)
+type messageDeleteBulkEventHandler func(Sessioner, *MessageDeleteBulk)
 
 // Type returns the event type for MessageDeleteBulk events.
 func (eh messageDeleteBulkEventHandler) Type() string {
@@ -532,14 +532,14 @@ func (eh messageDeleteBulkEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageDeleteBulk events.
-func (eh messageDeleteBulkEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageDeleteBulkEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageDeleteBulk); ok {
 		eh(s, t)
 	}
 }
 
 // messageReactionAddEventHandler is an event handler for MessageReactionAdd events.
-type messageReactionAddEventHandler func(*Session, *MessageReactionAdd)
+type messageReactionAddEventHandler func(Sessioner, *MessageReactionAdd)
 
 // Type returns the event type for MessageReactionAdd events.
 func (eh messageReactionAddEventHandler) Type() string {
@@ -552,14 +552,14 @@ func (eh messageReactionAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageReactionAdd events.
-func (eh messageReactionAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageReactionAddEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageReactionAdd); ok {
 		eh(s, t)
 	}
 }
 
 // messageReactionRemoveEventHandler is an event handler for MessageReactionRemove events.
-type messageReactionRemoveEventHandler func(*Session, *MessageReactionRemove)
+type messageReactionRemoveEventHandler func(Sessioner, *MessageReactionRemove)
 
 // Type returns the event type for MessageReactionRemove events.
 func (eh messageReactionRemoveEventHandler) Type() string {
@@ -572,14 +572,14 @@ func (eh messageReactionRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageReactionRemove events.
-func (eh messageReactionRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageReactionRemoveEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageReactionRemove); ok {
 		eh(s, t)
 	}
 }
 
 // messageReactionRemoveAllEventHandler is an event handler for MessageReactionRemoveAll events.
-type messageReactionRemoveAllEventHandler func(*Session, *MessageReactionRemoveAll)
+type messageReactionRemoveAllEventHandler func(Sessioner, *MessageReactionRemoveAll)
 
 // Type returns the event type for MessageReactionRemoveAll events.
 func (eh messageReactionRemoveAllEventHandler) Type() string {
@@ -592,14 +592,14 @@ func (eh messageReactionRemoveAllEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageReactionRemoveAll events.
-func (eh messageReactionRemoveAllEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageReactionRemoveAllEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageReactionRemoveAll); ok {
 		eh(s, t)
 	}
 }
 
 // messageUpdateEventHandler is an event handler for MessageUpdate events.
-type messageUpdateEventHandler func(*Session, *MessageUpdate)
+type messageUpdateEventHandler func(Sessioner, *MessageUpdate)
 
 // Type returns the event type for MessageUpdate events.
 func (eh messageUpdateEventHandler) Type() string {
@@ -612,14 +612,14 @@ func (eh messageUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for MessageUpdate events.
-func (eh messageUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh messageUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*MessageUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // presenceUpdateEventHandler is an event handler for PresenceUpdate events.
-type presenceUpdateEventHandler func(*Session, *PresenceUpdate)
+type presenceUpdateEventHandler func(Sessioner, *PresenceUpdate)
 
 // Type returns the event type for PresenceUpdate events.
 func (eh presenceUpdateEventHandler) Type() string {
@@ -632,14 +632,14 @@ func (eh presenceUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for PresenceUpdate events.
-func (eh presenceUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh presenceUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*PresenceUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // presencesReplaceEventHandler is an event handler for PresencesReplace events.
-type presencesReplaceEventHandler func(*Session, *PresencesReplace)
+type presencesReplaceEventHandler func(Sessioner, *PresencesReplace)
 
 // Type returns the event type for PresencesReplace events.
 func (eh presencesReplaceEventHandler) Type() string {
@@ -652,14 +652,14 @@ func (eh presencesReplaceEventHandler) New() interface{} {
 }
 
 // Handle is the handler for PresencesReplace events.
-func (eh presencesReplaceEventHandler) Handle(s *Session, i interface{}) {
+func (eh presencesReplaceEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*PresencesReplace); ok {
 		eh(s, t)
 	}
 }
 
 // rateLimitEventHandler is an event handler for RateLimit events.
-type rateLimitEventHandler func(*Session, *RateLimit)
+type rateLimitEventHandler func(Sessioner, *RateLimit)
 
 // Type returns the event type for RateLimit events.
 func (eh rateLimitEventHandler) Type() string {
@@ -667,14 +667,14 @@ func (eh rateLimitEventHandler) Type() string {
 }
 
 // Handle is the handler for RateLimit events.
-func (eh rateLimitEventHandler) Handle(s *Session, i interface{}) {
+func (eh rateLimitEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*RateLimit); ok {
 		eh(s, t)
 	}
 }
 
 // readyEventHandler is an event handler for Ready events.
-type readyEventHandler func(*Session, *Ready)
+type readyEventHandler func(Sessioner, *Ready)
 
 // Type returns the event type for Ready events.
 func (eh readyEventHandler) Type() string {
@@ -687,14 +687,14 @@ func (eh readyEventHandler) New() interface{} {
 }
 
 // Handle is the handler for Ready events.
-func (eh readyEventHandler) Handle(s *Session, i interface{}) {
+func (eh readyEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*Ready); ok {
 		eh(s, t)
 	}
 }
 
 // relationshipAddEventHandler is an event handler for RelationshipAdd events.
-type relationshipAddEventHandler func(*Session, *RelationshipAdd)
+type relationshipAddEventHandler func(Sessioner, *RelationshipAdd)
 
 // Type returns the event type for RelationshipAdd events.
 func (eh relationshipAddEventHandler) Type() string {
@@ -707,14 +707,14 @@ func (eh relationshipAddEventHandler) New() interface{} {
 }
 
 // Handle is the handler for RelationshipAdd events.
-func (eh relationshipAddEventHandler) Handle(s *Session, i interface{}) {
+func (eh relationshipAddEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*RelationshipAdd); ok {
 		eh(s, t)
 	}
 }
 
 // relationshipRemoveEventHandler is an event handler for RelationshipRemove events.
-type relationshipRemoveEventHandler func(*Session, *RelationshipRemove)
+type relationshipRemoveEventHandler func(Sessioner, *RelationshipRemove)
 
 // Type returns the event type for RelationshipRemove events.
 func (eh relationshipRemoveEventHandler) Type() string {
@@ -727,14 +727,14 @@ func (eh relationshipRemoveEventHandler) New() interface{} {
 }
 
 // Handle is the handler for RelationshipRemove events.
-func (eh relationshipRemoveEventHandler) Handle(s *Session, i interface{}) {
+func (eh relationshipRemoveEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*RelationshipRemove); ok {
 		eh(s, t)
 	}
 }
 
 // resumedEventHandler is an event handler for Resumed events.
-type resumedEventHandler func(*Session, *Resumed)
+type resumedEventHandler func(Sessioner, *Resumed)
 
 // Type returns the event type for Resumed events.
 func (eh resumedEventHandler) Type() string {
@@ -747,14 +747,14 @@ func (eh resumedEventHandler) New() interface{} {
 }
 
 // Handle is the handler for Resumed events.
-func (eh resumedEventHandler) Handle(s *Session, i interface{}) {
+func (eh resumedEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*Resumed); ok {
 		eh(s, t)
 	}
 }
 
 // typingStartEventHandler is an event handler for TypingStart events.
-type typingStartEventHandler func(*Session, *TypingStart)
+type typingStartEventHandler func(Sessioner, *TypingStart)
 
 // Type returns the event type for TypingStart events.
 func (eh typingStartEventHandler) Type() string {
@@ -767,14 +767,14 @@ func (eh typingStartEventHandler) New() interface{} {
 }
 
 // Handle is the handler for TypingStart events.
-func (eh typingStartEventHandler) Handle(s *Session, i interface{}) {
+func (eh typingStartEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*TypingStart); ok {
 		eh(s, t)
 	}
 }
 
 // userGuildSettingsUpdateEventHandler is an event handler for UserGuildSettingsUpdate events.
-type userGuildSettingsUpdateEventHandler func(*Session, *UserGuildSettingsUpdate)
+type userGuildSettingsUpdateEventHandler func(Sessioner, *UserGuildSettingsUpdate)
 
 // Type returns the event type for UserGuildSettingsUpdate events.
 func (eh userGuildSettingsUpdateEventHandler) Type() string {
@@ -787,14 +787,14 @@ func (eh userGuildSettingsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserGuildSettingsUpdate events.
-func (eh userGuildSettingsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userGuildSettingsUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*UserGuildSettingsUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // userNoteUpdateEventHandler is an event handler for UserNoteUpdate events.
-type userNoteUpdateEventHandler func(*Session, *UserNoteUpdate)
+type userNoteUpdateEventHandler func(Sessioner, *UserNoteUpdate)
 
 // Type returns the event type for UserNoteUpdate events.
 func (eh userNoteUpdateEventHandler) Type() string {
@@ -807,14 +807,14 @@ func (eh userNoteUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserNoteUpdate events.
-func (eh userNoteUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userNoteUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*UserNoteUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // userSettingsUpdateEventHandler is an event handler for UserSettingsUpdate events.
-type userSettingsUpdateEventHandler func(*Session, *UserSettingsUpdate)
+type userSettingsUpdateEventHandler func(Sessioner, *UserSettingsUpdate)
 
 // Type returns the event type for UserSettingsUpdate events.
 func (eh userSettingsUpdateEventHandler) Type() string {
@@ -827,14 +827,14 @@ func (eh userSettingsUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserSettingsUpdate events.
-func (eh userSettingsUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userSettingsUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*UserSettingsUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // userUpdateEventHandler is an event handler for UserUpdate events.
-type userUpdateEventHandler func(*Session, *UserUpdate)
+type userUpdateEventHandler func(Sessioner, *UserUpdate)
 
 // Type returns the event type for UserUpdate events.
 func (eh userUpdateEventHandler) Type() string {
@@ -847,14 +847,14 @@ func (eh userUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for UserUpdate events.
-func (eh userUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh userUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*UserUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // voiceServerUpdateEventHandler is an event handler for VoiceServerUpdate events.
-type voiceServerUpdateEventHandler func(*Session, *VoiceServerUpdate)
+type voiceServerUpdateEventHandler func(Sessioner, *VoiceServerUpdate)
 
 // Type returns the event type for VoiceServerUpdate events.
 func (eh voiceServerUpdateEventHandler) Type() string {
@@ -867,14 +867,14 @@ func (eh voiceServerUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for VoiceServerUpdate events.
-func (eh voiceServerUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh voiceServerUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*VoiceServerUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // voiceStateUpdateEventHandler is an event handler for VoiceStateUpdate events.
-type voiceStateUpdateEventHandler func(*Session, *VoiceStateUpdate)
+type voiceStateUpdateEventHandler func(Sessioner, *VoiceStateUpdate)
 
 // Type returns the event type for VoiceStateUpdate events.
 func (eh voiceStateUpdateEventHandler) Type() string {
@@ -887,14 +887,14 @@ func (eh voiceStateUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for VoiceStateUpdate events.
-func (eh voiceStateUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh voiceStateUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*VoiceStateUpdate); ok {
 		eh(s, t)
 	}
 }
 
 // webhooksUpdateEventHandler is an event handler for WebhooksUpdate events.
-type webhooksUpdateEventHandler func(*Session, *WebhooksUpdate)
+type webhooksUpdateEventHandler func(Sessioner, *WebhooksUpdate)
 
 // Type returns the event type for WebhooksUpdate events.
 func (eh webhooksUpdateEventHandler) Type() string {
@@ -907,7 +907,7 @@ func (eh webhooksUpdateEventHandler) New() interface{} {
 }
 
 // Handle is the handler for WebhooksUpdate events.
-func (eh webhooksUpdateEventHandler) Handle(s *Session, i interface{}) {
+func (eh webhooksUpdateEventHandler) Handle(s Sessioner, i interface{}) {
 	if t, ok := i.(*WebhooksUpdate); ok {
 		eh(s, t)
 	}
@@ -915,95 +915,95 @@ func (eh webhooksUpdateEventHandler) Handle(s *Session, i interface{}) {
 
 func handlerForInterface(handler interface{}) EventHandler {
 	switch v := handler.(type) {
-	case func(*Session, interface{}):
+	case func(Sessioner, interface{}):
 		return interfaceEventHandler(v)
-	case func(*Session, *ChannelCreate):
+	case func(Sessioner, *ChannelCreate):
 		return channelCreateEventHandler(v)
-	case func(*Session, *ChannelDelete):
+	case func(Sessioner, *ChannelDelete):
 		return channelDeleteEventHandler(v)
-	case func(*Session, *ChannelPinsUpdate):
+	case func(Sessioner, *ChannelPinsUpdate):
 		return channelPinsUpdateEventHandler(v)
-	case func(*Session, *ChannelUpdate):
+	case func(Sessioner, *ChannelUpdate):
 		return channelUpdateEventHandler(v)
-	case func(*Session, *Connect):
+	case func(Sessioner, *Connect):
 		return connectEventHandler(v)
-	case func(*Session, *Disconnect):
+	case func(Sessioner, *Disconnect):
 		return disconnectEventHandler(v)
-	case func(*Session, *Event):
+	case func(Sessioner, *Event):
 		return eventEventHandler(v)
-	case func(*Session, *GuildBanAdd):
+	case func(Sessioner, *GuildBanAdd):
 		return guildBanAddEventHandler(v)
-	case func(*Session, *GuildBanRemove):
+	case func(Sessioner, *GuildBanRemove):
 		return guildBanRemoveEventHandler(v)
-	case func(*Session, *GuildCreate):
+	case func(Sessioner, *GuildCreate):
 		return guildCreateEventHandler(v)
-	case func(*Session, *GuildDelete):
+	case func(Sessioner, *GuildDelete):
 		return guildDeleteEventHandler(v)
-	case func(*Session, *GuildEmojisUpdate):
+	case func(Sessioner, *GuildEmojisUpdate):
 		return guildEmojisUpdateEventHandler(v)
-	case func(*Session, *GuildIntegrationsUpdate):
+	case func(Sessioner, *GuildIntegrationsUpdate):
 		return guildIntegrationsUpdateEventHandler(v)
-	case func(*Session, *GuildMemberAdd):
+	case func(Sessioner, *GuildMemberAdd):
 		return guildMemberAddEventHandler(v)
-	case func(*Session, *GuildMemberRemove):
+	case func(Sessioner, *GuildMemberRemove):
 		return guildMemberRemoveEventHandler(v)
-	case func(*Session, *GuildMemberUpdate):
+	case func(Sessioner, *GuildMemberUpdate):
 		return guildMemberUpdateEventHandler(v)
-	case func(*Session, *GuildMembersChunk):
+	case func(Sessioner, *GuildMembersChunk):
 		return guildMembersChunkEventHandler(v)
-	case func(*Session, *GuildRoleCreate):
+	case func(Sessioner, *GuildRoleCreate):
 		return guildRoleCreateEventHandler(v)
-	case func(*Session, *GuildRoleDelete):
+	case func(Sessioner, *GuildRoleDelete):
 		return guildRoleDeleteEventHandler(v)
-	case func(*Session, *GuildRoleUpdate):
+	case func(Sessioner, *GuildRoleUpdate):
 		return guildRoleUpdateEventHandler(v)
-	case func(*Session, *GuildUpdate):
+	case func(Sessioner, *GuildUpdate):
 		return guildUpdateEventHandler(v)
-	case func(*Session, *MessageAck):
+	case func(Sessioner, *MessageAck):
 		return messageAckEventHandler(v)
-	case func(*Session, *MessageCreate):
+	case func(Sessioner, *MessageCreate):
 		return messageCreateEventHandler(v)
-	case func(*Session, *MessageDelete):
+	case func(Sessioner, *MessageDelete):
 		return messageDeleteEventHandler(v)
-	case func(*Session, *MessageDeleteBulk):
+	case func(Sessioner, *MessageDeleteBulk):
 		return messageDeleteBulkEventHandler(v)
-	case func(*Session, *MessageReactionAdd):
+	case func(Sessioner, *MessageReactionAdd):
 		return messageReactionAddEventHandler(v)
-	case func(*Session, *MessageReactionRemove):
+	case func(Sessioner, *MessageReactionRemove):
 		return messageReactionRemoveEventHandler(v)
-	case func(*Session, *MessageReactionRemoveAll):
+	case func(Sessioner, *MessageReactionRemoveAll):
 		return messageReactionRemoveAllEventHandler(v)
-	case func(*Session, *MessageUpdate):
+	case func(Sessioner, *MessageUpdate):
 		return messageUpdateEventHandler(v)
-	case func(*Session, *PresenceUpdate):
+	case func(Sessioner, *PresenceUpdate):
 		return presenceUpdateEventHandler(v)
-	case func(*Session, *PresencesReplace):
+	case func(Sessioner, *PresencesReplace):
 		return presencesReplaceEventHandler(v)
-	case func(*Session, *RateLimit):
+	case func(Sessioner, *RateLimit):
 		return rateLimitEventHandler(v)
-	case func(*Session, *Ready):
+	case func(Sessioner, *Ready):
 		return readyEventHandler(v)
-	case func(*Session, *RelationshipAdd):
+	case func(Sessioner, *RelationshipAdd):
 		return relationshipAddEventHandler(v)
-	case func(*Session, *RelationshipRemove):
+	case func(Sessioner, *RelationshipRemove):
 		return relationshipRemoveEventHandler(v)
-	case func(*Session, *Resumed):
+	case func(Sessioner, *Resumed):
 		return resumedEventHandler(v)
-	case func(*Session, *TypingStart):
+	case func(Sessioner, *TypingStart):
 		return typingStartEventHandler(v)
-	case func(*Session, *UserGuildSettingsUpdate):
+	case func(Sessioner, *UserGuildSettingsUpdate):
 		return userGuildSettingsUpdateEventHandler(v)
-	case func(*Session, *UserNoteUpdate):
+	case func(Sessioner, *UserNoteUpdate):
 		return userNoteUpdateEventHandler(v)
-	case func(*Session, *UserSettingsUpdate):
+	case func(Sessioner, *UserSettingsUpdate):
 		return userSettingsUpdateEventHandler(v)
-	case func(*Session, *UserUpdate):
+	case func(Sessioner, *UserUpdate):
 		return userUpdateEventHandler(v)
-	case func(*Session, *VoiceServerUpdate):
+	case func(Sessioner, *VoiceServerUpdate):
 		return voiceServerUpdateEventHandler(v)
-	case func(*Session, *VoiceStateUpdate):
+	case func(Sessioner, *VoiceStateUpdate):
 		return voiceStateUpdateEventHandler(v)
-	case func(*Session, *WebhooksUpdate):
+	case func(Sessioner, *WebhooksUpdate):
 		return webhooksUpdateEventHandler(v)
 	}
 

--- a/examples/airhorn/main.go
+++ b/examples/airhorn/main.go
@@ -71,7 +71,7 @@ func main() {
 
 // This function will be called (due to AddHandler above) when the bot receives
 // the "ready" event from Discord.
-func ready(s *discordgo.Session, event *discordgo.Ready) {
+func ready(s discordgo.Sessioner, event *discordgo.Ready) {
 
 	// Set the playing status.
 	s.UpdateStatus(0, "!airhorn")
@@ -79,11 +79,11 @@ func ready(s *discordgo.Session, event *discordgo.Ready) {
 
 // This function will be called (due to AddHandler above) every time a new
 // message is created on any channel that the autenticated bot has access to.
-func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
+func messageCreate(s discordgo.Sessioner, m *discordgo.MessageCreate) {
 
 	// Ignore all messages created by the bot itself
 	// This isn't required in this specific example but it's a good practice.
-	if m.Author.ID == s.State.User.ID {
+	if m.Author.ID == s.State().User.ID {
 		return
 	}
 
@@ -91,14 +91,14 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	if strings.HasPrefix(m.Content, "!airhorn") {
 
 		// Find the channel that the message came from.
-		c, err := s.State.Channel(m.ChannelID)
+		c, err := s.State().Channel(m.ChannelID)
 		if err != nil {
 			// Could not find channel.
 			return
 		}
 
 		// Find the guild for that channel.
-		g, err := s.State.Guild(c.GuildID)
+		g, err := s.State().Guild(c.GuildID)
 		if err != nil {
 			// Could not find guild.
 			return
@@ -120,7 +120,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 // This function will be called (due to AddHandler above) every time a new
 // guild is joined.
-func guildCreate(s *discordgo.Session, event *discordgo.GuildCreate) {
+func guildCreate(s discordgo.Sessioner, event *discordgo.GuildCreate) {
 
 	if event.Guild.Unavailable {
 		return
@@ -179,7 +179,7 @@ func loadSound() error {
 }
 
 // playSound plays the current buffer to the provided channel.
-func playSound(s *discordgo.Session, guildID, channelID string) (err error) {
+func playSound(s discordgo.Sessioner, guildID, channelID string) (err error) {
 
 	// Join the provided voice channel.
 	vc, err := s.ChannelVoiceJoin(guildID, channelID, false, true)

--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -52,11 +52,11 @@ func main() {
 
 // This function will be called (due to AddHandler above) every time a new
 // message is created on any channel that the autenticated bot has access to.
-func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
+func messageCreate(s discordgo.Sessioner, m *discordgo.MessageCreate) {
 
 	// Ignore all messages created by the bot itself
 	// This isn't required in this specific example but it's a good practice.
-	if m.Author.ID == s.State.User.ID {
+	if m.Author.ID == s.State().User.ID {
 		return
 	}
 	// If the message is "ping" reply with "Pong!"

--- a/message.go
+++ b/message.go
@@ -251,7 +251,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 		return
 	}
 
-	channel, err := s.State.Channel(m.ChannelID)
+	channel, err := s.state.Channel(m.ChannelID)
 	if err != nil {
 		content = m.ContentWithMentionsReplaced()
 		return
@@ -260,7 +260,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 	for _, user := range m.Mentions {
 		nick := user.Username
 
-		member, err := s.State.Member(channel.GuildID, user.ID)
+		member, err := s.state.Member(channel.GuildID, user.ID)
 		if err == nil && member.Nick != "" {
 			nick = member.Nick
 		}
@@ -271,7 +271,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 		).Replace(content)
 	}
 	for _, roleID := range m.MentionRoles {
-		role, err := s.State.Role(channel.GuildID, roleID)
+		role, err := s.state.Role(channel.GuildID, roleID)
 		if err != nil || !role.Mentionable {
 			continue
 		}
@@ -280,7 +280,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 	}
 
 	content = patternChannels.ReplaceAllStringFunc(content, func(mention string) string {
-		channel, err := s.State.Channel(mention[2 : len(mention)-1])
+		channel, err := s.state.Channel(mention[2 : len(mention)-1])
 		if err != nil || channel.Type == ChannelTypeGuildVoice {
 			return mention
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -5,25 +5,25 @@ import (
 )
 
 func TestContentWithMoreMentionsReplaced(t *testing.T) {
-	s := &Session{StateEnabled: true, State: NewState()}
+	s := &Session{StateEnabled: true, state: NewState()}
 
 	user := &User{
 		ID:       "user",
 		Username: "User Name",
 	}
 
-	s.State.GuildAdd(&Guild{ID: "guild"})
-	s.State.RoleAdd("guild", &Role{
+	s.state.GuildAdd(&Guild{ID: "guild"})
+	s.state.RoleAdd("guild", &Role{
 		ID:          "role",
 		Name:        "Role Name",
 		Mentionable: true,
 	})
-	s.State.MemberAdd(&Member{
+	s.state.MemberAdd(&Member{
 		User:    user,
 		Nick:    "User Nick",
 		GuildID: "guild",
 	})
-	s.State.ChannelAdd(&Channel{
+	s.state.ChannelAdd(&Channel{
 		Name:    "Channel Name",
 		GuildID: "guild",
 		ID:      "channel",

--- a/restapi.go
+++ b/restapi.go
@@ -462,13 +462,13 @@ func (s *Session) UserGuildSettingsEdit(guildID string, settings *UserGuildSetti
 // Please see the same function inside state.go
 func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions int, err error) {
 	// Try to just get permissions from state.
-	apermissions, err = s.State.UserChannelPermissions(userID, channelID)
+	apermissions, err = s.state.UserChannelPermissions(userID, channelID)
 	if err == nil {
 		return
 	}
 
 	// Otherwise try get as much data from state as possible, falling back to the network.
-	channel, err := s.State.Channel(channelID)
+	channel, err := s.state.Channel(channelID)
 	if err != nil || channel == nil {
 		channel, err = s.Channel(channelID)
 		if err != nil {
@@ -476,7 +476,7 @@ func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions
 		}
 	}
 
-	guild, err := s.State.Guild(channel.GuildID)
+	guild, err := s.state.Guild(channel.GuildID)
 	if err != nil || guild == nil {
 		guild, err = s.Guild(channel.GuildID)
 		if err != nil {
@@ -489,7 +489,7 @@ func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions
 		return
 	}
 
-	member, err := s.State.Member(guild.ID, userID)
+	member, err := s.state.Member(guild.ID, userID)
 	if err != nil || member == nil {
 		member, err = s.GuildMember(guild.ID, userID)
 		if err != nil {
@@ -580,7 +580,7 @@ func memberPermissions(guild *Guild, channel *Channel, member *Member) (apermiss
 func (s *Session) Guild(guildID string) (st *Guild, err error) {
 	if s.StateEnabled {
 		// Attempt to grab the guild from State first.
-		st, err = s.State.Guild(guildID)
+		st, err = s.state.Guild(guildID)
 		if err == nil && !st.Unavailable {
 			return
 		}

--- a/state.go
+++ b/state.go
@@ -19,7 +19,7 @@ import (
 )
 
 // ErrNilState is returned when the state is nil.
-var ErrNilState = errors.New("state not instantiated, please use discordgo.New() or assign Session.State")
+var ErrNilState = errors.New("state not instantiated, please use discordgo.New()")
 
 // ErrStateNotFound is returned when the state cache
 // requested is not found
@@ -158,7 +158,7 @@ func (s *State) GuildRemove(guild *Guild) error {
 
 // Guild gets a guild by ID.
 // Useful for querying if @me is in a guild:
-//     _, err := discordgo.Session.State.Guild(guildID)
+//     _, err := discordgo.Session.State().Guild(guildID)
 //     isInGuild := err == nil
 func (s *State) Guild(guildID string) (*Guild, error) {
 	if s == nil {

--- a/structs.go
+++ b/structs.go
@@ -77,7 +77,7 @@ type Session struct {
 
 	// Managed state object, updated internally with events when
 	// StateEnabled is true.
-	State *State
+	state *State
 
 	// The http client used for REST requests
 	Client *http.Client
@@ -117,6 +117,9 @@ type Session struct {
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
 }
+
+// State returns the inner state that's updated when StateEnabled is true.
+func (s *Session) State() *State { return s.state }
 
 // UserConnection is a Connection returned from the UserConnections endpoint
 type UserConnection struct {

--- a/structs_test.go
+++ b/structs_test.go
@@ -1,0 +1,50 @@
+package discordgo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSession_State(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func() *Session
+		want  func() *State
+	}{
+		{
+			name: "nil",
+			setup: func() *Session {
+				return &Session{}
+			},
+			want: func() *State {
+				return nil
+			},
+		},
+		{
+			name: "has_guild_id",
+			setup: func() *Session {
+				s := &Session{state: NewState()}
+				_ = s.state.GuildAdd(&Guild{ID: "42"})
+				_ = s.state.RoleAdd("guild", &Role{ID: "84"})
+				return s
+			},
+			want: func() *State {
+				s := NewState()
+				_ = s.GuildAdd(&Guild{ID: "42"})
+				_ = s.RoleAdd("guild", &Role{ID: "84"})
+				return s
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := tt.setup()
+			want := tt.want()
+
+			if inState := in.State(); !reflect.DeepEqual(inState, want) {
+				t.Fatalf("%#v\n\nnot equal to:\n\n%#v", inState, want)
+			}
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -11,6 +11,8 @@ package discordgo
 
 import (
 	"encoding/json"
+	"image"
+	"io"
 	"net/http"
 	"time"
 )
@@ -55,3 +57,801 @@ func newRestError(req *http.Request, resp *http.Response, body []byte) *RESTErro
 func (r RESTError) Error() string {
 	return "HTTP " + r.Response.Status + ", " + string(r.ResponseBody)
 }
+
+// Applicationer is the interface type to describe *Session functionality for
+// managing applications.
+type Applicationer interface {
+	// Application returns an Application structure of a specific Application
+	//   appID : The ID of an Application
+	Application(appID string) (st *Application, err error)
+
+	// ApplicationBotCreate creates an Application Bot Account
+	//
+	//   appID : The ID of an Application
+	ApplicationBotCreate(appID string) (st *User, err error)
+
+	// ApplicationCreate creates a new Application
+	//    name : Name of Application / Bot
+	//    uris : Redirect URIs (Not required)
+	ApplicationCreate(ap *Application) (st *Application, err error)
+
+	// ApplicationDelete deletes an existing Application
+	//   appID : The ID of an Application
+	ApplicationDelete(appID string) (err error)
+
+	// ApplicationUpdate updates an existing Application
+	//   var : desc
+	ApplicationUpdate(appID string, ap *Application) (st *Application, err error)
+
+	// Applications returns all applications for the authenticated user
+	Applications() (st []*Application, err error)
+}
+
+// Channeler is the interface type describing *Session functionality for
+// managing channels.
+type Channeler interface {
+	// Channel returns a Channel structure of a specific Channel.
+	//   channelID  : The ID of the Channel you want returned.
+	Channel(channelID string) (st *Channel, err error)
+
+	// ChannelDelete deletes the given channel
+	//   channelID  : The ID of a Channel
+	ChannelDelete(channelID string) (st *Channel, err error)
+
+	// ChannelEdit edits the given channel
+	//   channelID  : The ID of a Channel
+	//   name       : The new name to assign the channel.
+	ChannelEdit(channelID, name string) (*Channel, error)
+
+	// ChannelEditComplex edits an existing channel, replacing the parameters entirely with ChannelEdit struct
+	//   channelID  : The ID of a Channel
+	//   data          : The channel struct to send
+	ChannelEditComplex(channelID string, data *ChannelEdit) (st *Channel, err error)
+
+	// ChannelInviteCreate creates a new invite for the given channel.
+	//   channelID   : The ID of a Channel
+	//   i           : An Invite struct with the values MaxAge, MaxUses and Temporary defined.
+	ChannelInviteCreate(channelID string, i Invite) (st *Invite, err error)
+
+	// ChannelInvites returns an array of Invite structures for the given channel
+	//   channelID   : The ID of a Channel
+	ChannelInvites(channelID string) (st []*Invite, err error)
+
+	// ChannelPermissionDelete deletes a specific permission override for the given channel.
+	// NOTE: Name of this func may change.
+	ChannelPermissionDelete(channelID, targetID string) (err error)
+
+	// ChannelPermissionSet creates a Permission Override for the given channel.
+	// NOTE: This func name may changed.  Using Set instead of Create because
+	// you can both create a new override or update an override with this function.
+	ChannelPermissionSet(channelID, targetID, targetType string, allow, deny int) (err error)
+
+	// GuildChannelCreate creates a new channel in the given guild
+	//   guildID   : The ID of a Guild.
+	//   name      : Name of the channel (2-100 chars length)
+	//   ctype     : Type of the channel
+	GuildChannelCreate(guildID, name string, ctype ChannelType) (st *Channel, err error)
+
+	// GuildChannelCreateComplex creates a new channel in the given guild
+	//   guildID      : The ID of a Guild
+	//   data         : A data struct describing the new Channel, Name and Type are mandatory, other fields depending on the type
+	GuildChannelCreateComplex(guildID string, data GuildChannelCreateData) (st *Channel, err error)
+
+	// GuildChannels returns an array of Channel structures for all channels of a
+	// given guild.
+	//   guildID   : The ID of a Guild.
+	GuildChannels(guildID string) (st []*Channel, err error)
+
+	// GuildChannelsReorder updates the order of channels in a guild
+	//   guildID   : The ID of a Guild.
+	//   channels  : Updated channels.
+	GuildChannelsReorder(guildID string, channels []*Channel) (err error)
+}
+
+// ChannelFileSender is the interface type describing *Session functionality for
+// sending files.
+type ChannelFileSender interface {
+	// ChannelFileSend sends a file to the given channel.
+	//   channelID : The ID of a Channel.
+	//   name: The name of the file.
+	//   io.Reader : A reader for the file contents.
+	ChannelFileSend(channelID, name string, r io.Reader) (*Message, error)
+
+	// ChannelFileSendWithMessage sends a file to the given channel with an message.
+	// DEPRECATED. Use ChannelMessageSendComplex instead.
+	//   channelID : The ID of a Channel.
+	//   content: Optional Message content.
+	//   name: The name of the file.
+	//   io.Reader : A reader for the file contents.
+	ChannelFileSendWithMessage(channelID, content string, name string, r io.Reader) (*Message, error)
+}
+
+// ChannelMessager is the interface type to describe *Session functionality for
+// interacting with messages to channels.
+type ChannelMessager interface {
+	// ChannelMessage gets a single message by ID from a given channel.
+	//   channeld  : The ID of a Channel
+	//   messageID : the ID of a Message
+	ChannelMessage(channelID, messageID string) (st *Message, err error)
+
+	// ChannelMessageAck acknowledges and marks the given message as read
+	//   channeld  : The ID of a Channel
+	//   messageID : the ID of a Message
+	//   lastToken : token returned by last ack
+	ChannelMessageAck(channelID, messageID, lastToken string) (st *Ack, err error)
+
+	// ChannelMessageDelete deletes a message from the Channel.
+	ChannelMessageDelete(channelID, messageID string) (err error)
+
+	// ChannelMessageEdit edits an existing message, replacing it entirely with
+	// the given content.
+	//   channelID  : The ID of a Channel
+	//   messageID  : The ID of a Message
+	//   content    : The contents of the message
+	ChannelMessageEdit(channelID, messageID, content string) (*Message, error)
+
+	// ChannelMessageEditComplex edits an existing message, replacing it entirely with
+	// the given MessageEdit struct
+	ChannelMessageEditComplex(m *MessageEdit) (st *Message, err error)
+
+	// ChannelMessageEditEmbed edits an existing message with embedded data.
+	//   channelID : The ID of a Channel
+	//   messageID : The ID of a Message
+	//   embed     : The embed data to send
+	ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed) (*Message, error)
+
+	// ChannelMessagePin pins a message within a given channel.
+	//   channelID: The ID of a channel.
+	//   messageID: The ID of a message.
+	ChannelMessagePin(channelID, messageID string) (err error)
+
+	// ChannelMessageSend sends a message to the given channel.
+	//   channelID : The ID of a Channel.
+	//   content   : The message to send.
+	ChannelMessageSend(channelID string, content string) (*Message, error)
+
+	// ChannelMessageSendComplex sends a message to the given channel.
+	//   channelID : The ID of a Channel.
+	//   data      : The message struct to send.
+	ChannelMessageSendComplex(channelID string, data *MessageSend) (st *Message, err error)
+
+	// ChannelMessageSendEmbed sends a message to the given channel with embedded data.
+	//   channelID : The ID of a Channel.
+	//   embed     : The embed data to send.
+	ChannelMessageSendEmbed(channelID string, embed *MessageEmbed) (*Message, error)
+
+	// ChannelMessageSendTTS sends a message to the given channel with Text to Speech.
+	//   channelID : The ID of a Channel.
+	//   content   : The message to send.
+	ChannelMessageSendTTS(channelID string, content string) (*Message, error)
+
+	// ChannelMessageUnpin unpins a message within a given channel.
+	//   channelID: The ID of a channel.
+	//   messageID: The ID of a message.
+	ChannelMessageUnpin(channelID, messageID string) (err error)
+
+	// ChannelMessages returns an array of Message structures for messages within
+	// a given channel.
+	//   channelID : The ID of a Channel.
+	//   limit     : The number messages that can be returned. (max 100)
+	//   beforeID  : If provided all messages returned will be before given ID.
+	//   afterID   : If provided all messages returned will be after given ID.
+	//   aroundID  : If provided all messages returned will be around given ID.
+	ChannelMessages(channelID string, limit int, beforeID, afterID, aroundID string) (st []*Message, err error)
+
+	// ChannelMessagesBulkDelete bulk deletes the messages from the channel for the provided messageIDs.
+	// If only one messageID is in the slice call channelMessageDelete function.
+	// If the slice is empty do nothing.
+	//   channelID : The ID of the channel for the messages to delete.
+	//   messages  : The IDs of the messages to be deleted. A slice of string IDs. A maximum of 100 messages.
+	ChannelMessagesBulkDelete(channelID string, messages []string) (err error)
+
+	// ChannelMessagesPinned returns an array of Message structures for pinned messages
+	// within a given channel
+	//   channelID : The ID of a Channel.
+	ChannelMessagesPinned(channelID string) (st []*Message, err error)
+
+	// ChannelTyping broadcasts to all members that authenticated user is typing in
+	// the given channel.
+	//   channelID  : The ID of a Channel
+	ChannelTyping(channelID string) (err error)
+}
+
+// Guilder is the interface type to describe *Session functionality for managing
+// guilds and self membership.
+type Guilder interface {
+	// Guild returns a Guild structure of a specific Guild.
+	//   guildID   : The ID of a Guild
+	Guild(guildID string) (st *Guild, err error)
+
+	// GuildCreate creates a new Guild
+	//   name      : A name for the Guild (2-100 characters)
+	GuildCreate(name string) (st *Guild, err error)
+
+	// GuildDelete deletes a Guild.
+	//   guildID   : The ID of a Guild
+	GuildDelete(guildID string) (st *Guild, err error)
+
+	// GuildEdit edits a new Guild
+	//   guildID   : The ID of a Guild
+	//   g 		 : A GuildParams struct with the values Name, Region and VerificationLevel defined.
+	GuildEdit(guildID string, g GuildParams) (st *Guild, err error)
+
+	// GuildIcon returns an image.Image of a guild icon.
+	//   guildID   : The ID of a Guild.
+	GuildIcon(guildID string) (img image.Image, err error)
+
+	// GuildLeave leaves a Guild.
+	//   guildID   : The ID of a Guild
+	GuildLeave(guildID string) (err error)
+
+	// GuildSplash returns an image.Image of a guild splash image.
+	//   guildID   : The ID of a Guild.
+	GuildSplash(guildID string) (img image.Image, err error)
+}
+
+// GuildAuditLoger is the interface type to describe *Session functionality for
+// accessing the guild's audit log.
+type GuildAuditLoger interface {
+	// GuildAuditLog returns the audit log for a Guild.
+	//   guildID     : The ID of a Guild.
+	//   userID      : If provided the log will be filtered for the given ID.
+	//   beforeID    : If provided all log entries returned will be before the given ID.
+	//   actionType  : If provided the log will be filtered for the given Action Type.
+	//   limit       : The number messages that can be returned. (default 50, min 1, max 100)
+	GuildAuditLog(guildID, userID, beforeID string, actionType, limit int) (st *GuildAuditLog, err error)
+}
+
+// GuildBanner is the interface type to describe *Session functionality for
+// managing the guild's bans.
+type GuildBanner interface {
+	GuildBanCreate(guildID, userID string, days int) (err error)
+	GuildBanCreateWithReason(guildID, userID, reason string, days int) (err error)
+	GuildBanDelete(guildID, userID string) (err error)
+	GuildBans(guildID string) (st []*GuildBan, err error)
+}
+
+// GuildEmbeder is the intereface type to describe *Session functionality for
+// managing the guild's embeds.
+type GuildEmbeder interface {
+	// GuildEmbed returns the embed for a Guild.
+	//   guildID   : The ID of a Guild.
+	GuildEmbed(guildID string) (st *GuildEmbed, err error)
+
+	// GuildEmbed returns the embed for a Guild.
+	//   guildID   : The ID of a Guild.
+	GuildEmbedEdit(guildID string, enabled bool, channelID string) (err error)
+}
+
+// GuildEmojier is the interface type to describe *Session functionality for
+// managing the guild's emoji.
+type GuildEmojier interface {
+	// GuildEmojiCreate creates a new emoji
+	//   guildID : The ID of a Guild.
+	//   name    : The Name of the Emoji.
+	//   image   : The base64 encoded emoji image, has to be smaller than 256KB.
+	//   roles   : The roles for which this emoji will be whitelisted, can be nil.
+	GuildEmojiCreate(guildID, name, image string, roles []string) (emoji *Emoji, err error)
+
+	// GuildEmojiDelete deletes an Emoji.
+	//   guildID : The ID of a Guild.
+	//   emojiID : The ID of an Emoji.
+	GuildEmojiDelete(guildID, emojiID string) (err error)
+
+	// GuildEmojiEdit modifies an emoji
+	//   guildID : The ID of a Guild.
+	//   emojiID : The ID of an Emoji.
+	//   name    : The Name of the Emoji.
+	//   roles   : The roles for which this emoji will be whitelisted, can be nil.
+	GuildEmojiEdit(guildID, emojiID, name string, roles []string) (emoji *Emoji, err error)
+}
+
+// GuildIntegrationer is the interface type to describe *Session functionality
+// for managing the guild's integrations.
+type GuildIntegrationer interface {
+	// GuildIntegrationCreate creates a Guild Integration.
+	//   guildID          : The ID of a Guild.
+	//   integrationType  : The Integration type.
+	//   integrationID    : The ID of an integration.
+	GuildIntegrationCreate(guildID, integrationType, integrationID string) (err error)
+
+	// GuildIntegrationDelete removes the given integration from the Guild.
+	//   guildID          : The ID of a Guild.
+	//   integrationID    : The ID of an integration.
+	GuildIntegrationDelete(guildID, integrationID string) (err error)
+
+	// GuildIntegrationEdit edits a Guild Integration.
+	//   guildID              : The ID of a Guild.
+	//   integrationType      : The Integration type.
+	//   integrationID        : The ID of an integration.
+	//   expireBehavior	      : The behavior when an integration subscription lapses (see the integration object documentation).
+	//   expireGracePeriod    : Period (in seconds) where the integration will ignore lapsed subscriptions.
+	//   enableEmoticons	    : Whether emoticons should be synced for this integration (twitch only currently).
+	GuildIntegrationEdit(guildID, integrationID string, expireBehavior, expireGracePeriod int, enableEmoticons bool) (err error)
+
+	// GuildIntegrationSync syncs an integration.
+	//   guildID          : The ID of a Guild.
+	//   integrationID    : The ID of an integration.
+	GuildIntegrationSync(guildID, integrationID string) (err error)
+
+	// GuildIntegrations returns an array of Integrations for a guild.
+	//   guildID   : The ID of a Guild.
+	GuildIntegrations(guildID string) (st []*Integration, err error)
+}
+
+// GuildMemberer is the interface type to describe *Session functionality for
+// managing the guild's integrations.
+type GuildMemberer interface {
+	// GuildMember returns a member of a guild.
+	//   guildID   : The ID of a Guild.
+	//   userID    : The ID of a User
+	GuildMember(guildID, userID string) (st *Member, err error)
+
+	// GuildMemberAdd force joins a user to the guild.
+	//   accessToken   : Valid access_token for the user.
+	//   guildID       : The ID of a Guild.
+	//   userID        : The ID of a User.
+	//   nick          : Value to set users nickname to
+	//   roles         : A list of role ID's to set on the member.
+	//   mute          : If the user is muted.
+	//   deaf          : If the user is deafened.
+	GuildMemberAdd(accessToken, guildID, userID, nick string, roles []string, mute, deaf bool) (err error)
+
+	// GuildMemberDelete removes the given user from the given guild.
+	//   guildID   : The ID of a Guild.
+	//   userID    : The ID of a User
+	GuildMemberDelete(guildID, userID string) (err error)
+
+	// GuildMemberDeleteWithReason removes the given user from the given guild.
+	//   guildID   : The ID of a Guild.
+	//   userID    : The ID of a User
+	//   reason    : The reason for the kick
+	GuildMemberDeleteWithReason(guildID, userID, reason string) (err error)
+
+	// GuildMemberEdit edits the roles of a member.
+	//   guildID  : The ID of a Guild.
+	//   userID   : The ID of a User.
+	//   roles    : A list of role ID's to set on the member.
+	GuildMemberEdit(guildID, userID string, roles []string) (err error)
+
+	// GuildMemberMove moves a guild member from one voice channel to another/none
+	//   guildID   : The ID of a Guild.
+	//   userID    : The ID of a User.
+	//   channelID : The ID of a channel to move user to, or null?
+	// NOTE : I am not entirely set on the name of this function and it may change
+	// prior to the final 1.0.0 release of Discordgo
+	GuildMemberMove(guildID, userID, channelID string) (err error)
+
+	// GuildMemberNickname updates the nickname of a guild member
+	//   guildID   : The ID of a guild
+	//   userID    : The ID of a user
+	//   userID    : The ID of a user or "@me" which is a shortcut of the current user ID
+	GuildMemberNickname(guildID, userID, nickname string) (err error)
+
+	// GuildMemberRoleAdd adds the specified role to a given member
+	//   guildID   : The ID of a Guild.
+	//   userID    : The ID of a User.
+	//   roleID 	  : The ID of a Role to be assigned to the user.
+	GuildMemberRoleAdd(guildID, userID, roleID string) (err error)
+
+	// GuildMemberRoleRemove removes the specified role to a given member
+	//   guildID   : The ID of a Guild.
+	//   userID    : The ID of a User.
+	//   roleID 	  : The ID of a Role to be removed from the user.
+	GuildMemberRoleRemove(guildID, userID, roleID string) (err error)
+
+	// GuildMembers returns a list of members for a guild.
+	//    guildID  : The ID of a Guild.
+	//    after    : The id of the member to return members after
+	//    limit    : max number of members to return (max 1000)
+	GuildMembers(guildID string, after string, limit int) (st []*Member, err error)
+
+	// GuildPrune Begin as prune operation. Requires the 'KICK_MEMBERS' permission.
+	// Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation.
+	//   guildID	: The ID of a Guild.
+	//   days		: The number of days to count prune for (1 or more).
+	GuildPrune(guildID string, days uint32) (count uint32, err error)
+
+	// GuildPruneCount Returns the number of members that would be removed in a prune operation.
+	// Requires 'KICK_MEMBER' permission.
+	//   guildID	: The ID of a Guild.
+	//   days		: The number of days to count prune for (1 or more).
+	GuildPruneCount(guildID string, days uint32) (count uint32, err error)
+
+	// RequestGuildMembers requests guild members from the gateway
+	// The gateway responds with GuildMembersChunk events
+	//   guildID  : The ID of the guild to request members of
+	//   query    : String that username starts with, leave empty to return all members
+	//   limit    : Max number of items to return, or 0 to request all members matched
+	RequestGuildMembers(guildID, query string, limit int) (err error)
+}
+
+// GuildRoler is the interface type to describe *Session functionality for
+// managing the guild's roles.
+type GuildRoler interface {
+	// GuildRoleCreate returns a new Guild Role.
+	//   guildID: The ID of a Guild.
+	GuildRoleCreate(guildID string) (st *Role, err error)
+
+	// GuildRoleDelete deletes an existing role.
+	//   guildID   : The ID of a Guild.
+	//   roleID    : The ID of a Role.
+	GuildRoleDelete(guildID, roleID string) (err error)
+
+	// GuildRoleEdit updates an existing Guild Role with new values
+	//   guildID   : The ID of a Guild.
+	//   roleID    : The ID of a Role.
+	//   name      : The name of the Role.
+	//   color     : The color of the role (decimal, not hex).
+	//   hoist     : Whether to display the role's users separately.
+	//   perm      : The permissions for the role.
+	//   mention   : Whether this role is mentionable
+	GuildRoleEdit(guildID, roleID, name string, color int, hoist bool, perm int, mention bool) (st *Role, err error)
+
+	// GuildRoleReorder reoders guild roles
+	//   guildID   : The ID of a Guild.
+	//   roles     : A list of ordered roles.
+	GuildRoleReorder(guildID string, roles []*Role) (st []*Role, err error)
+
+	// GuildRoles returns all roles for a given guild.
+	//   guildID   : The ID of a Guild.
+	GuildRoles(guildID string) (st []*Role, err error)
+}
+
+// Inviter is the interface type to describe *Session functionality for managing
+// the guild's invites.
+type Inviter interface {
+	// GuildInvites returns an array of Invite structures for the given guild
+	//   guildID   : The ID of a Guild.
+	GuildInvites(guildID string) (st []*Invite, err error)
+
+	// Invite returns an Invite structure of the given invite
+	//   inviteID : The invite code
+	Invite(inviteID string) (st *Invite, err error)
+
+	// InviteAccept accepts an Invite to a Guild or Channel
+	//   inviteID : The invite code
+	InviteAccept(inviteID string) (st *Invite, err error)
+
+	// InviteDelete deletes an existing invite
+	//   inviteID   : the code of an invite
+	InviteDelete(inviteID string) (st *Invite, err error)
+
+	// InviteWithCounts returns an Invite structure of the given invite including approximate member counts
+	//   inviteID : The invite code
+	InviteWithCounts(inviteID string) (st *Invite, err error)
+}
+
+// MessageReactioner is the interface type to describe *Session functionality
+// for message reactions.
+type MessageReactioner interface {
+	// MessageReactionAdd creates an emoji reaction to a message.
+	//   channelID : The channel ID.
+	//   messageID : The message ID.
+	//   emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
+	MessageReactionAdd(channelID, messageID, emojiID string) error
+
+	// MessageReactionRemove deletes an emoji reaction to a message.
+	//   channelID : The channel ID.
+	//   messageID : The message ID.
+	//   emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
+	//   userID	 : @me or ID of the user to delete the reaction for.
+	MessageReactionRemove(channelID, messageID, emojiID, userID string) error
+
+	// MessageReactions gets all the users reactions for a specific emoji.
+	//   channelID : The channel ID.
+	//   messageID : The message ID.
+	//   emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
+	//   limit    : max number of users to return (max 100)
+	MessageReactions(channelID, messageID, emojiID string, limit int) (st []*User, err error)
+
+	// MessageReactionsRemoveAll deletes all reactions from a message
+	//   channelID : The channel ID
+	//   messageID : The message ID.
+	MessageReactionsRemoveAll(channelID, messageID string) error
+}
+
+// Relationshiper is the interface type to describe *Session functionality for
+// managing relationships.
+type Relationshiper interface {
+	// RelationshipDelete removes the relationship with a user.
+	//   userID: ID of the user.
+	RelationshipDelete(userID string) (err error)
+
+	// RelationshipFriendRequestAccept accepts a friend request from a user.
+	//   userID: ID of the user.
+	RelationshipFriendRequestAccept(userID string) (err error)
+
+	// RelationshipFriendRequestSend sends a friend request to a user.
+	//   userID: ID of the user.
+	RelationshipFriendRequestSend(userID string) (err error)
+
+	// RelationshipUserBlock blocks a user.
+	//   userID: ID of the user.
+	RelationshipUserBlock(userID string) (err error)
+
+	// RelationshipsGet returns an array of all the relationships of the user.
+	RelationshipsGet() (r []*Relationship, err error)
+
+	// RelationshipsMutualGet returns an array of all the users both @me and the given user is friends with.
+	//   userID: ID of the user.
+	RelationshipsMutualGet(userID string) (mf []*User, err error)
+}
+
+// Requester is the interface type to describe *Session functionality around
+// low-level requests.
+type Requester interface {
+	// Request is the same as RequestWithBucketID but the bucket id is the same
+	// as the urlStr
+	Request(method, urlStr string, data interface{}) (response []byte, err error)
+
+	// RequestWithBucketID makes a (GET/POST/...) Requests to Discord REST API
+	// with JSON data.
+	RequestWithBucketID(method, urlStr string, data interface{}, bucketID string) (response []byte, err error)
+
+	// RequestWithLockedBucket makes a request using a bucket that's already
+	// been locked
+	RequestWithLockedBucket(method, urlStr, contentType string, b []byte, bucket *Bucket, sequence int) (response []byte, err error)
+}
+
+// StatusUpdater is the interface type to describe *Session functionality for
+// managing user status updates.
+type StatusUpdater interface {
+	// UpdateListeningStatus is used to set the user to "Listening to..."
+	// If game!="" then set to what user is listening to
+	// Else, set user to active and no game.
+	UpdateListeningStatus(game string) (err error)
+
+	// UpdateStatus is used to update the user's status.
+	// If idle>0 then set status to idle.
+	// If game!="" then set game.
+	// if otherwise, set status to active, and no game.
+	UpdateStatus(idle int, game string) (err error)
+
+	// UpdateStatusComplex allows for sending the raw status update data
+	// untouched by discordgo.
+	UpdateStatusComplex(usd UpdateStatusData) (err error)
+
+	// UpdateStreamingStatus is used to update the user's streaming status.
+	// If idle>0 then set status to idle.
+	// If game!="" then set game.
+	// If game!="" and url!="" then set the status type to streaming with the URL set.
+	// if otherwise, set status to active, and no game.
+	UpdateStreamingStatus(idle int, game string, url string) (err error)
+
+	// UserUpdateStatus update the user status
+	//   status   : The new status (Actual valid status are 'online','idle','dnd','invisible')
+	UserUpdateStatus(status Status) (st *Settings, err error)
+}
+
+// Userer is the interface type to describe *Session functionlaity for doing
+// things as the authenticated user or for interacting with other users.
+type Userer interface {
+	// User returns the user details of the given userID
+	//   userID    : A user ID or "@me" which is a shortcut of current user ID
+	User(userID string) (st *User, err error)
+
+	// UserAvatar is deprecated. Please use UserAvatarDecode
+	//   userID    : A user ID or "@me" which is a shortcut of current user ID
+	UserAvatar(userID string) (img image.Image, err error)
+
+	// UserAvatarDecode returns an image.Image of a user's Avatar
+	//   user : The user which avatar should be retrieved
+	UserAvatarDecode(u *User) (img image.Image, err error)
+
+	// UserChannelCreate creates a new User (Private) Channel with another User
+	//   recipientID : A user ID for the user to which this channel is opened with.
+	UserChannelCreate(recipientID string) (st *Channel, err error)
+
+	// UserChannelPermissions returns the permission of a user in a channel.
+	//   userID    : The ID of the user to calculate permissions for.
+	//   channelID : The ID of the channel to calculate permission for.
+	//
+	// NOTE: This function is now deprecated and will be removed in the future.
+	// Please see the same function inside state.go
+	UserChannelPermissions(userID, channelID string) (apermissions int, err error)
+
+	// UserChannels returns an array of Channel structures for all private
+	// channels.
+	UserChannels() (st []*Channel, err error)
+
+	// UserConnections returns the user's connections
+	UserConnections() (conn []*UserConnection, err error)
+
+	// UserGuildSettingsEdit Edits the users notification settings for a guild
+	//   guildID   : The ID of the guild to edit the settings on
+	//   settings  : The settings to update
+	UserGuildSettingsEdit(guildID string, settings *UserGuildSettingsEdit) (st *UserGuildSettings, err error)
+
+	// UserGuilds returns an array of UserGuild structures for all guilds.
+	//   limit     : The number guilds that can be returned. (max 100)
+	//   beforeID  : If provided all guilds returned will be before given ID.
+	//   afterID   : If provided all guilds returned will be after given ID.
+	UserGuilds(limit int, beforeID, afterID string) (st []*UserGuild, err error)
+
+	// UserNoteSet sets the note for a specific user.
+	UserNoteSet(userID string, message string) (err error)
+
+	// UserSettings returns the settings for a given user
+	UserSettings() (st *Settings, err error)
+
+	// UserUpdate updates a users settings.
+	UserUpdate(email, password, username, avatar, newPassword string) (st *User, err error)
+}
+
+// Voicer is the interface type to describe *Session functionality for working
+// with voice channels.
+type Voicer interface {
+	// ChannelVoiceJoin joins the session user to a voice channel.
+	//    gID     : Guild ID of the channel to join.
+	//    cID     : Channel ID of the channel to join.
+	//    mute    : If true, you will be set to muted upon joining.
+	//    deaf    : If true, you will be set to deafened upon joining.
+	ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *VoiceConnection, err error)
+
+	// ChannelVoiceJoinManual initiates a voice session to a voice channel, but does not complete it.
+	//
+	// This should only be used when the VoiceServerUpdate will be intercepted and used elsewhere.
+	//
+	//    gID     : Guild ID of the channel to join.
+	//    cID     : Channel ID of the channel to join.
+	//    mute    : If true, you will be set to muted upon joining.
+	//    deaf    : If true, you will be set to deafened upon joining.
+	ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err error)
+
+	// VoiceICE returns the voice server ICE information
+	VoiceICE() (st *VoiceICE, err error)
+
+	// VoiceRegions returns the voice server regions
+	VoiceRegions() (st []*VoiceRegion, err error)
+}
+
+// i'm going to make my own Discord Go client with blackjack and webhookers...
+//
+// and you know what, forget the blackjack
+
+// Webhooker is the interface type to describe *Session functionality for
+// interacting with webhook configuration.
+type Webhooker interface {
+	// ChannelWebhooks returns all webhooks for a given channel.
+	//   channelID: The ID of a channel.
+	ChannelWebhooks(channelID string) (st []*Webhook, err error)
+
+	// GuildWebhooks returns all webhooks for a given guild.
+	//   guildID: The ID of a Guild.
+	GuildWebhooks(guildID string) (st []*Webhook, err error)
+
+	// Webhook returns a webhook for a given ID
+	//   webhookID: The ID of a webhook.
+	Webhook(webhookID string) (st *Webhook, err error)
+
+	// WebhookCreate returns a new Webhook.
+	//   channelID: The ID of a Channel.
+	//   name     : The name of the webhook.
+	//   avatar   : The avatar of the webhook.
+	WebhookCreate(channelID, name, avatar string) (st *Webhook, err error)
+
+	// WebhookDelete deletes a webhook for a given ID
+	//   webhookID: The ID of a webhook.
+	WebhookDelete(webhookID string) (err error)
+
+	// WebhookDeleteWithToken deletes a webhook for a given ID with an auth token.
+	//   webhookID: The ID of a webhook.
+	//   token    : The auth token for the webhook.
+	WebhookDeleteWithToken(webhookID, token string) (st *Webhook, err error)
+
+	// WebhookEdit updates an existing Webhook.
+	//   webhookID: The ID of a webhook.
+	//   name     : The name of the webhook.
+	//   avatar   : The avatar of the webhook.
+	WebhookEdit(webhookID, name, avatar, channelID string) (st *Role, err error)
+
+	// WebhookEditWithToken updates an existing Webhook with an auth token.
+	//   webhookID: The ID of a webhook.
+	//   token    : The auth token for the webhook.
+	//   name     : The name of the webhook.
+	//   avatar   : The avatar of the webhook.
+	WebhookEditWithToken(webhookID, token, name, avatar string) (st *Role, err error)
+
+	// WebhookExecute executes a webhook.
+	//   webhookID: The ID of a webhook.
+	//   token    : The auth token for the webhook
+	WebhookExecute(webhookID, token string, wait bool, data *WebhookParams) (err error)
+
+	// WebhookWithToken returns a webhook for a given ID
+	//   webhookID: The ID of a webhook.
+	//   token    : The auth token for the webhook.
+	WebhookWithToken(webhookID, token string) (st *Webhook, err error)
+}
+
+// Sessioner is the interface to describe a *discordgo.Session for dependency
+// injection in handlers. This composes smaller interfaces in to one giant one.
+type Sessioner interface {
+	// Open creates a websocket connection to Discord.
+	// See: https://discordapp.com/developers/docs/topics/gateway#connecting
+	Open() error
+
+	// Close closes a websocket and stops all listening/heartbeat goroutines.
+	Close() (err error)
+
+	// HeartbeatLatency returns the latency between heartbeat acknowledgement
+	// and heartbeat send.
+	HeartbeatLatency() time.Duration
+
+	// State returns the inner state that's updated when StateEnabled is true.
+	State() *State
+
+	// Applicationer is for configuring guild apps
+	Applicationer
+
+	// Channeler is for working with channels
+	Channeler
+
+	// ChannelFileSender is for sending files to the channel
+	ChannelFileSender
+
+	// ChannelMessager is for working with messages
+	ChannelMessager
+
+	// Guilder is for working with guilds
+	Guilder
+
+	// GuildAuditLoger is for working with the guild audit log
+	GuildAuditLoger
+
+	// GuildBanner is for working with user bans from the guild
+	GuildBanner
+
+	// GuildEmbeder is for working with guild embeds
+	GuildEmbeder
+
+	// GuildEmojier is for working with guild emoji
+	GuildEmojier
+
+	// GuildIntegrationer is for working with guild integrations
+	GuildIntegrationer
+
+	// GuildMemberer is for working with guild members
+	GuildMemberer
+
+	// GuildRoler is for working with guild roles
+	GuildRoler
+
+	// Inviter is for working with invites
+	Inviter
+
+	// MessageReactioner is for working with message reactions
+	MessageReactioner
+
+	// Relationshiper is for working with user relationships
+	Relationshiper
+
+	// Requester is for internal request functions
+	Requester
+
+	// StatusUpdater is for updating different user statuses
+	StatusUpdater
+
+	// Userer is for working with user data
+	Userer
+
+	// Voicer is for working with voice channels
+	Voicer
+
+	// Webhooker is for webhook management
+	Webhooker
+
+	AddHandler(handler interface{}) func()
+	AddHandlerOnce(handler interface{}) func()
+
+	Gateway() (gateway string, err error)
+	GatewayBot() (st *GatewayBotResponse, err error)
+
+	Login(email, password string) (err error)
+	Logout() (err error)
+
+	Register(username string) (token string, err error)
+}
+
+// compile-time check to ensure *Session satisfies Sessioner
+var _ Sessioner = (*Session)(nil)

--- a/wsapi.go
+++ b/wsapi.go
@@ -158,14 +158,14 @@ func (s *Session) Open() error {
 	// We create it here so the below READY/RESUMED packet can populate
 	// the state :)
 	// XXX: Move to New() func?
-	if s.State == nil {
+	if s.state == nil {
 		state := NewState()
 		state.TrackChannels = false
 		state.TrackEmojis = false
 		state.TrackMembers = false
 		state.TrackRoles = false
 		state.TrackVoice = false
-		s.State = state
+		s.state = state
 	}
 
 	// Now Discord should send us a READY or RESUMED packet.
@@ -667,7 +667,7 @@ func (s *Session) onVoiceStateUpdate(st *VoiceStateUpdate) {
 	}
 
 	// We only care about events that are about us.
-	if s.State.User.ID != st.UserID {
+	if s.state.User.ID != st.UserID {
 		return
 	}
 


### PR DESCRIPTION
Please be aware, this is a breaking API change.

This change adds a new `discordgo` type, `Sessioner`, which is an interface that
describes the full method set for the `*Session` type. In addition to the new
type, this change updates the package to no longer send a concrete `*Session`
value in to handlers it invokes as the first argument but a `Sessioner` instead.
This is to make testing of handlers much easier, as mock implementations of the
Sessioner interface can be passed right in.

This also renames the internal state field from `State` to `state`, and adds a
new method to `*Session`, `State()`, to expose that internal state to consumers.
A test was added to ensure this method works as expected.

The example projects were updated where necessary to work with the new API

Fixes #662.

Signed-off-by: Tim Heckman <t@heckman.io>