### PR TITLE
Adding ability to redirect discordgo generated logs

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -12,6 +12,8 @@ package discordgo
 import (
 	"fmt"
 	"log"
+    "io"
+    "os"
 	"runtime"
 	"strings"
 )
@@ -37,6 +39,41 @@ const (
 // Logger can be used to replace the standard logging for discordgo
 var Logger func(msgL, caller int, format string, a ...interface{})
 
+// outfiles is used for granular control of logging output paths.
+// The keyspace consists of the 4 log level constants defined above.
+// LogLevel, LogWarning, LogInformational, and LogDebug. Each corresponding 
+// value is an output file for the logger.
+// defaults to stderr
+var outfiles = map[int]io.Writer{
+    LogError : os.Stderr,
+    LogWarning : os.Stderr,
+    LogInformational : os.Stderr,
+    LogDebug : os.Stderr,
+}
+
+// SetOutFile is used to change the output file of a specific log level
+//   level : LogLevel of messages to redirect
+//   file  : file to redirect new messages of LogLevel to
+func SetOutFile(level int, file io.Writer) {
+    if level < 0 || level > 3 {
+        log.Println("Error setting loglevel output file. level must be between 0 and 3.")
+        return;
+    }
+    outfiles[level] = file
+}
+
+// SetLogFlags is synonymous with log.SetFlags
+// https://golang.org/pkg/log/#SetFlags
+func SetLogFlags(flags int) {
+    log.SetFlags(flags)
+}
+
+// SetLogPrefix is synonymous with log.SetPrefix
+// https://golang.org/pkg/log/#SetPrefix
+func SetLogPrefix(prefix string) {
+    log.SetPrefix(prefix)
+}
+
 // msglog provides package wide logging consistancy for discordgo
 // the format, a...  portion this command follows that of fmt.Printf
 //   msgL   : LogLevel of the message
@@ -59,6 +96,8 @@ func msglog(msgL, caller int, format string, a ...interface{}) {
 		name = fns[len(fns)-1]
 
 		msg := fmt.Sprintf(format, a...)
+
+        log.SetOutput(outfiles[msgL])
 
 		log.Printf("[DG%d] %s:%d:%s() %s\n", msgL, file, line, name, msg)
 	}

--- a/logging.go
+++ b/logging.go
@@ -11,9 +11,9 @@ package discordgo
 
 import (
 	"fmt"
+	"io"
 	"log"
-    "io"
-    "os"
+	"os"
 	"runtime"
 	"strings"
 )
@@ -41,37 +41,37 @@ var Logger func(msgL, caller int, format string, a ...interface{})
 
 // outfiles is used for granular control of logging output paths.
 // The keyspace consists of the 4 log level constants defined above.
-// LogLevel, LogWarning, LogInformational, and LogDebug. Each corresponding 
+// LogLevel, LogWarning, LogInformational, and LogDebug. Each corresponding
 // value is an output file for the logger.
 // defaults to stderr
 var outfiles = map[int]io.Writer{
-    LogError : os.Stderr,
-    LogWarning : os.Stderr,
-    LogInformational : os.Stderr,
-    LogDebug : os.Stderr,
+	LogError:         os.Stderr,
+	LogWarning:       os.Stderr,
+	LogInformational: os.Stderr,
+	LogDebug:         os.Stderr,
 }
 
 // SetOutFile is used to change the output file of a specific log level
 //   level : LogLevel of messages to redirect
 //   file  : file to redirect new messages of LogLevel to
 func SetOutFile(level int, file io.Writer) {
-    if level < 0 || level > 3 {
-        log.Println("Error setting loglevel output file. level must be between 0 and 3.")
-        return;
-    }
-    outfiles[level] = file
+	if level < 0 || level > 3 {
+		log.Println("Error setting loglevel output file. level must be between 0 and 3.")
+		return
+	}
+	outfiles[level] = file
 }
 
 // SetLogFlags is synonymous with log.SetFlags
 // https://golang.org/pkg/log/#SetFlags
 func SetLogFlags(flags int) {
-    log.SetFlags(flags)
+	log.SetFlags(flags)
 }
 
 // SetLogPrefix is synonymous with log.SetPrefix
 // https://golang.org/pkg/log/#SetPrefix
 func SetLogPrefix(prefix string) {
-    log.SetPrefix(prefix)
+	log.SetPrefix(prefix)
 }
 
 // msglog provides package wide logging consistancy for discordgo
@@ -97,7 +97,7 @@ func msglog(msgL, caller int, format string, a ...interface{}) {
 
 		msg := fmt.Sprintf(format, a...)
 
-        log.SetOutput(outfiles[msgL])
+		log.SetOutput(outfiles[msgL])
 
 		log.Printf("[DG%d] %s:%d:%s() %s\n", msgL, file, line, name, msg)
 	}


### PR DESCRIPTION
This PR aims to make it easier for developers to redirect log output from discordgo. It uses a map to redirect each log level individually and some helper functions to expose underlying `log` functionality to the developers. Here is an example usage, the code is simply re-purposed from the `myToken` example

>
    file, err := os.OpenFile("debug.log", os.O_APPEND|os.O_WRONLY, 0644)
    if err != nil {
        fmt.Println("error creating log file.", err)
        return
    }

    // Create a new Discord session using the provided login information.
    dg, err := discordgo.New(Email, Password)
    if err != nil {
        fmt.Println("error creating Discord session,", err)
        return
    }

    dg.LogLevel = 2

    discordgo.SetOutFile(discordgo.LogError, file)
    discordgo.SetOutFile(discordgo.LogWarning, file)
    discordgo.SetOutFile(discordgo.LogInformational, file)

    discordgo.SetLogPrefix("[example] ")

    discordgo.SetLogFlags(Ldate|Ltime|Lmicroseconds)

There are two issues that aren't resolved currently. 
- redirecting the logs is very verbose as you need to specify the package name each time. 
  - this isn't really a huge issue, just looks weird
- Not all of the print statements in the library use the logger, for example voice.go
https://github.com/bwmarrin/discordgo/blob/8d8906ce4b959dacabfefbad9bacf11b6ffd8035/voice.go#L95

My go isn't the greatest, but if you have some suggestions on how to solve those two problems I can work on fixing it. 