### PR TITLE
Add `Available` field to Emoji struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -283,6 +283,7 @@ type Emoji struct {
 	Managed       bool     `json:"managed"`
 	RequireColons bool     `json:"require_colons"`
 	Animated      bool     `json:"animated"`
+	Available     bool     `json:"available"`
 }
 
 // MessageFormat returns a correctly formatted Emoji for use in Message content and embeds


### PR DESCRIPTION
There's a `available` field in the JSON data from Discord for Discord emojis, even though it's not documented. [Another library has implemented this in their master branch](https://discord.js.org/#/docs/main/master/class/GuildEmoji?scrollTo=available).