### PR TITLE
Add function that checks voice channel for users

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1378,6 +1378,25 @@ func (s *Session) Channel(channelID string) (st *Channel, err error) {
 	return
 }
 
+// VoiceChannelUsers returns IDS of users present in given channelID
+func (s *Session) VoiceChannelUsers(channelID, guildID string) (st []string, err error) {
+	g, err := s.Guild(guildID)
+	if err != nil {
+		return
+	}
+
+	st = make([]string, 0)
+
+	for _, voiceStates := range g.VoiceStates {
+
+		if channelID == voiceStates.ChannelID {
+			st = append(st, voiceStates.UserID)
+		}
+	}
+
+	return
+}
+
 // ChannelEdit edits the given channel
 // channelID  : The ID of a Channel
 // name       : The new name to assign the channel.


### PR DESCRIPTION
In discord.js there's a function [member](https://discord.js.org/#/docs/main/stable/class/VoiceChannel?scrollTo=members) that returns and in discord.py there's [is](https://discordpy.readthedocs.io/en/latest/api.html?highlight=voice%20members#discord.VoiceChannel.members), we need something similiar for go, i wrote a small example code that accepts channelID and guildID and returns either empty array or array populated with userIDs, the code itself probably works poorly because i wrote it w/o understanding how exactly it should be implemented, but we still need something similiar.