### PR TITLE
Allow resetting ChannelEdit ParentID

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -277,7 +277,7 @@ type ChannelEdit struct {
 	Bitrate              int                    `json:"bitrate,omitempty"`
 	UserLimit            int                    `json:"user_limit,omitempty"`
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
-	ParentID             string                 `json:"parent_id,omitempty"`
+	ParentID             *NullString            `json:"parent_id,omitempty"`
 	RateLimitPerUser     int                    `json:"rate_limit_per_user,omitempty"`
 }
 
@@ -1036,3 +1036,18 @@ const (
 
 	ErrCodeReactionBlocked = 90001
 )
+
+// NullString is a custom String type to allow for optional modifying strings that can be reset
+// the JSON Marshalling encoding is unique:
+// if the string is empty, it will be encoded as null
+// if the string is not empty, it will be encoded as a string
+type NullString string
+
+// MarshalJSON returns the JSON encoding of the NullString
+func (s NullString) MarshalJSON() ([]byte, error) {
+	if s == "" {
+		return json.Marshal(nil)
+	}
+
+	return json.Marshal(string(s))
+}


### PR DESCRIPTION
### The problem:
Currently the `ParentID` of a Channel cannot be reset using `ChannelEditComplex` because the `ParentID` field will not be marshalled when it is empty.

I have a few possible solutions in mind, each with their own downsides.

### The solutions:
1.
``` ParentID *string `json:"parent_id,omitempty"` ```
- To keep current value 
```
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{})
```
- To reset field
```
var newParentID string
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{ParentID: &newParentID})
```
- To set field
```
newParentID := "1234567890"
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{ParentID: &newParentID})
```

**Does not work,** because the Discord API does not accept empty strings: `HTTP 400 Bad Request, {"parent_id": ["Value \"\" is not snowflake."]}`.

2.
``` ParentID *string `json:"parent_id"` ```
- To keep current value 

**not possible,** you would need to set the current value from the State.
- To reset field
```
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{ParentID: nil})
```
- To set field
```
newParentID := "1234567890"
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{ParentID: &newParentID})
```

**Downside:** you have to always the the current ParentID when calling `ChannelEditComplex` to not reset the ParentID, calling other ChannelEdit methods would always reset the ChannelID (the latter could be prevented by setting the ChannelID from the state).

3.
```
ParentID *NullString `json:"parent_id,omitempty"`

// NullString is a custom String type to allow for optional modifying strings that can be reset
// the JSON Marshalling encoding is unique:
// if the string is empty, it will be encoded as null
// if the string is not empty, it will be encoded as a string
type NullString string

// MarshalJSON returns the JSON encoding of the NullString
func (s NullString) MarshalJSON() ([]byte, error) {
	if s == "" {
		return json.Marshal(nil)
	}

	return json.Marshal(string(s))
}
```
- To keep current value 
```
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{})
```
- To reset field
```
newParentID := discordgo.NullString("")
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{ParentID: &newParentID})
```
- To set field
```
newParentID := discordgo.NullString("362129396850622464")
dg.ChannelEditComplex("1234567890", &discordgo.ChannelEdit{ParentID: &newParentID})
```

**Downside:** custom String type.

### Proposal:
This PR implements solution three which is the best solution in my opinion. This is a breaking change if the field `ParentID` of the `ChannelEdit` struct is being used.

**I would be happy to hear alternative solutions!**

This PR would fix #571. 