### PR TITLE
Fixed holdup issue in voice

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16
 )
+
+go 1.13

--- a/voice.go
+++ b/voice.go
@@ -243,6 +243,7 @@ type voiceOP2 struct {
 	Port              int           `json:"port"`
 	Modes             []string      `json:"modes"`
 	HeartbeatInterval time.Duration `json:"heartbeat_interval"`
+	IP                string        `json:"ip"`
 }
 
 // WaitUntilConnected waits for the Voice Connection to
@@ -542,7 +543,7 @@ func (v *VoiceConnection) udpOpen() (err error) {
 		return fmt.Errorf("empty endpoint")
 	}
 
-	host := strings.TrimSuffix(v.endpoint, ":80") + ":" + strconv.Itoa(v.op2.Port)
+	host := v.op2.IP + ":" + strconv.Itoa(v.op2.Port)
 	addr, err := net.ResolveUDPAddr("udp", host)
 	if err != nil {
 		v.log(LogWarning, "error resolving udp host %s, %s", host, err)


### PR DESCRIPTION
### The Problem
Whenever trying to connect to a voice channel the function never returns.

### The Solution
Use the UDP Endpoint IP from the Ready payload instead of the WebSocket endpoint.

### Fixes Issues
#701 and #702 