### PR TITLE
tools/eventhandlers: Don't pass Buffer by value

### DIFF
--- a/tools/cmd/eventhandlers/main.go
+++ b/tools/cmd/eventhandlers/main.go
@@ -92,7 +92,7 @@ func main() {
 
 	err = ioutil.WriteFile(filepath.Join(dir, strings.ToLower("eventhandlers.go")), src, 0644)
 	if err != nil {
-		log.Fatal(buf, "writing output: %s", err)
+		log.Fatalf("%s\nCould not write output: %s", buf.Bytes(), err)
 	}
 }
 


### PR DESCRIPTION
A copy of a bytes.Buffer will not function like the original. Additionally, it may have looked to the casual reader like log.Fatal was somehow writing to the buffer. Instead, the content is explicitly included at the top of the error, followed by a newline.