### PR TITLE
examples/{airhorn,pingpong}: os.Kill cannot be caught

### DIFF
--- a/examples/airhorn/main.go
+++ b/examples/airhorn/main.go
@@ -62,7 +62,7 @@ func main() {
 	// Wait here until CTRL-C or other term signal is received.
 	fmt.Println("Airhorn is now running.  Press CTRL-C to exit.")
 	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
 
 	// Cleanly close down the Discord session.

--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -43,7 +43,7 @@ func main() {
 	// Wait here until CTRL-C or other term signal is received.
 	fmt.Println("Bot is now running.  Press CTRL-C to exit.")
 	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
 
 	// Cleanly close down the Discord session.


### PR DESCRIPTION
os.Kill cannot be caught, only sent, so there's no point in passing it to signal.Notify.