### PR TITLE
Fix for Discord's API returning a 400 Bad Request from empty request body

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -88,7 +88,12 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 		req.Header.Set("authorization", s.Token)
 	}
 
-	req.Header.Set("Content-Type", contentType)
+	// Discord's API returns a 400 Bad Request is Content-Type is set, but the
+	// request body is empty.
+	if b != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+
 	// TODO: Make a configurable static variable.
 	req.Header.Set("User-Agent", s.UserAgent)
 


### PR DESCRIPTION
Fix for Discord's API returning a `400: Bad Request` from empty request body when `Content-Type` header is set.

This PR is associated with issue https://github.com/bwmarrin/discordgo/issues/716