### PR TITLE
Adding millisecond precision to SnowflakeTimestamp utility

### DIFF
--- a/util.go
+++ b/util.go
@@ -12,6 +12,6 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 		return
 	}
 	timestamp := (i >> 22) + 1420070400000
-	t = time.Unix(timestamp/1000, (timestamp%1000) * 1000000)
+	t = time.Unix(timestamp/1000, (timestamp%1000)*1000000)
 	return
 }

--- a/util.go
+++ b/util.go
@@ -12,6 +12,6 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 		return
 	}
 	timestamp := (i >> 22) + 1420070400000
-	t = time.Unix(0, timestamp*int64(1000000))
+	t = time.Unix(0, timestamp*1000000)
 	return
 }

--- a/util.go
+++ b/util.go
@@ -12,6 +12,6 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 		return
 	}
 	timestamp := (i >> 22) + 1420070400000
-	t = time.Unix(timestamp/1000, (timestamp%1000)*1000000)
+	t = time.Unix(0, timestamp*int64(1000000))
 	return
 }

--- a/util.go
+++ b/util.go
@@ -12,6 +12,6 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 		return
 	}
 	timestamp := (i >> 22) + 1420070400000
-	t = time.Unix(timestamp/1000, 0)
+	t = time.Unix(timestamp/1000, (timestamp%1000) * 1000000)
 	return
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,21 @@
+package discordgo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSnowflakeTimestamp(t *testing.T) {
+	// #discordgo channel ID :)
+	id := "155361364909621248"
+	parsedTimestamp, err := SnowflakeTimestamp(id)
+
+	if err != nil {
+		t.Errorf("returned error incorrect: got %v, want nil", err)
+	}
+
+	correctTimestamp := time.Date(2016, time.March, 4, 17, 10, 35, 869*1000000, time.UTC)
+	if !parsedTimestamp.Equal(correctTimestamp) {
+		t.Errorf("parsed time incorrect: got %v, want %v", parsedTimestamp, correctTimestamp)
+	}
+}


### PR DESCRIPTION
The current utility only allows second precision and maybe to some people millisecond precision will come in handy since Discord timestamps are in milliseconds.