### PR TITLE
Add clarifying docs for using an OAuth2 token

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -30,10 +30,13 @@ var ErrMFA = errors.New("account has 2FA enabled")
 // tasks if given enough information to do so.  Currently you can pass zero
 // arguments and it will return an empty Discord session.
 // There are 3 ways to call New:
-//     With a single auth token - All requests will use the token blindly,
+//     With a single auth token - All requests will use the token blindly
+//         (just tossing it into the HTTP Authorization header);
 //         no verification of the token will be done and requests may fail.
 //         IF THE TOKEN IS FOR A BOT, IT MUST BE PREFIXED WITH `BOT `
 //         eg: `"Bot <token>"`
+//         IF IT IS AN OAUTH2 ACCESS TOKEN, IT MUST BE PREFIXED WITH `Bearer `
+//         eg: `"Bearer <token>"`
 //     With an email and password - Discord will sign in with the provided
 //         credentials.
 //     With an email, password and auth token - Discord will verify the auth


### PR DESCRIPTION
While the existing docs for the `New(...)` function say that the token is used "blindly", and specify that a `Bot ` prefix is necessary for bot tokens, they are not clear that if a single string argument is passed in, it gets passed through to the HTTP Authorization header untouched. They also do not mention the knock-on effect of that, which is that an OAuth2 access token must be prefixed with `Bearer ` when passed into `New(...)` in order to work.

This PR alters the docs to address this issue.