### PR TITLE
Add bitwise permission const PermissionViewChannel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IDE-specific metadata
+.idea/

--- a/structs.go
+++ b/structs.go
@@ -973,6 +973,7 @@ type IdentifyProperties struct {
 
 // Constants for the different bit offsets of text channel permissions
 const (
+	// Deprecated: PermissionReadMessages has been replaced with PermissionViewChannel for text and voice channels
 	PermissionReadMessages = 1 << (iota + 10)
 	PermissionSendMessages
 	PermissionSendTTSMessages

--- a/structs.go
+++ b/structs.go
@@ -1017,7 +1017,7 @@ const (
 	PermissionViewAuditLogs
 	PermissionViewChannel
 
-	PermissionAllText = PermissionReadMessages |
+	PermissionAllText = PermissionViewChannel |
 		PermissionSendMessages |
 		PermissionSendTTSMessages |
 		PermissionManageMessages |
@@ -1025,7 +1025,8 @@ const (
 		PermissionAttachFiles |
 		PermissionReadMessageHistory |
 		PermissionMentionEveryone
-	PermissionAllVoice = PermissionVoiceConnect |
+	PermissionAllVoice = PermissionViewChannel |
+		PermissionVoiceConnect |
 		PermissionVoiceSpeak |
 		PermissionVoiceMuteMembers |
 		PermissionVoiceDeafenMembers |

--- a/structs.go
+++ b/structs.go
@@ -1014,6 +1014,7 @@ const (
 	PermissionManageServer
 	PermissionAddReactions
 	PermissionViewAuditLogs
+	PermissionViewChannel
 
 	PermissionAllText = PermissionReadMessages |
 		PermissionSendMessages |


### PR DESCRIPTION
Based upon bitwise permissions defined at: https://discordapp.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags

Note: The new `PermissionViewChannel` is technically the same offset as the existing `PermissionReadMessages` permission. However, the Discord documentation doesn't have a specific "READ_MESSAGES" permission, instead using "VIEW_CHANNEL" to govern visibility of both text and voice channels.

To maintain backward compatibility without breaking existing users, `PermissionReadMessages` has been left in because it's an exported const. We may want to somehow mark it as deprecated though.