### PR TITLE
Change log level for websocket connection failure from warning to error

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -79,7 +79,7 @@ func (s *Session) Open() error {
 	header.Add("accept-encoding", "zlib")
 	s.wsConn, _, err = websocket.DefaultDialer.Dial(s.gateway, header)
 	if err != nil {
-		s.log(LogWarning, "error connecting to gateway %s, %s", s.gateway, err)
+		s.log(LogError, "error connecting to gateway %s, %s", s.gateway, err)
 		s.gateway = "" // clear cached gateway
 		s.wsConn = nil // Just to be safe.
 		return err


### PR DESCRIPTION
This PR is in support of Issue https://github.com/bwmarrin/discordgo/issues/754.