### PR TITLE
Allow resume on reconnect

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -516,7 +516,7 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 	// Must immediately disconnect from gateway and reconnect to new gateway.
 	if e.Operation == 7 {
 		s.log(LogInformational, "Closing and reconnecting in response to Op7")
-		s.Close()
+		s.CloseWithCode(websocket.CloseServiceRestart)
 		s.reconnect()
 		return e, nil
 	}
@@ -838,9 +838,13 @@ func (s *Session) reconnect() {
 	}
 }
 
+func (s *Session) Close() error {
+	return s.CloseWithCode(websocket.CloseNormalClosure)
+}
+
 // Close closes a websocket and stops all listening/heartbeat goroutines.
 // TODO: Add support for Voice WS/UDP connections
-func (s *Session) Close() (err error) {
+func (s *Session) CloseWithCode(closeCode int) (err error) {
 
 	s.log(LogInformational, "called")
 	s.Lock()
@@ -862,7 +866,7 @@ func (s *Session) Close() (err error) {
 		// To cleanly close a connection, a client should send a close
 		// frame and wait for the server to close the connection.
 		s.wsMutex.Lock()
-		err := s.wsConn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		err := s.wsConn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(closeCode, ""))
 		s.wsMutex.Unlock()
 		if err != nil {
 			s.log(LogInformational, "error closing websocket, %s", err)


### PR DESCRIPTION
Currently, when a reconnection is requested we close the connection with a `1000` close code, on which the API seems to disallow resuming. This is problematic with the recent changes to the API where it requests reconnections much more frequently, and can easily lead to token reset issues on large bots (a re-identify uses one of the 1000/24h identifies, but a resume does not). This PR fixes this, instead closing with a `1012` (service restart) close code, which from some discussion on the API server seems to allow resumes.

This adds a new method `CloseWithCode`, which I propose makes sense to be exported as although close codes may seem more of an internal concern, with the API exposing an implementation detail of substantial differences in close codes, users of the library should be able to choose the close code they use when disconnecting. The existing `Close` method stays exactly the same, closing with a `1000` close code as before.

Fixes #759.