### PR TITLE
Revert "Changed domain from `discordapp.com` to `discord.com`"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # DiscordGo
 
-[![GoDoc](https://godoc.org/github.com/bwmarrin/discordgo?status.svg)](https://godoc.org/github.com/bwmarrin/discordgo) [![Go report](http://goreportcard.com/badge/bwmarrin/discordgo)](http://goreportcard.com/report/bwmarrin/discordgo) [![Build Status](https://travis-ci.org/bwmarrin/discordgo.svg?branch=master)](https://travis-ci.org/bwmarrin/discordgo) [![Discord Gophers](https://img.shields.io/badge/Discord%20Gophers-%23discordgo-blue.svg)](https://discord.gg/0f1SbxBZjYoCtNPP) [![Discord API](https://img.shields.io/badge/Discord%20API-%23go_discordgo-blue.svg)](https://discord.com/invite/discord-api)
+[![GoDoc](https://godoc.org/github.com/bwmarrin/discordgo?status.svg)](https://godoc.org/github.com/bwmarrin/discordgo) [![Go report](http://goreportcard.com/badge/bwmarrin/discordgo)](http://goreportcard.com/report/bwmarrin/discordgo) [![Build Status](https://travis-ci.org/bwmarrin/discordgo.svg?branch=master)](https://travis-ci.org/bwmarrin/discordgo) [![Discord Gophers](https://img.shields.io/badge/Discord%20Gophers-%23discordgo-blue.svg)](https://discord.gg/0f1SbxBZjYoCtNPP) [![Discord API](https://img.shields.io/badge/Discord%20API-%23go_discordgo-blue.svg)](https://discordapp.com/invite/discord-api)
 
 <img align="right" src="http://bwmarrin.github.io/discordgo/img/discordgo.png">
 
 DiscordGo is a [Go](https://golang.org/) package that provides low level 
-bindings to the [Discord](https://discord.com/) chat client API. DiscordGo 
+bindings to the [Discord](https://discordapp.com/) chat client API. DiscordGo 
 has nearly complete support for all of the Discord API endpoints, websocket
 interface, and voice interface.
 
 If you would like to help the DiscordGo package please use 
-[this link](https://discord.com/oauth2/authorize?client_id=173113690092994561&scope=bot)
+[this link](https://discordapp.com/oauth2/authorize?client_id=173113690092994561&scope=bot)
 to add the official DiscordGo test bot **dgo** to your server. This provides 
 indispensable help to this project.
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -58,7 +58,7 @@ support multi-server voice connections and some other features that are
 exclusive to Bot accounts only.
 
 To create a new user account (if you have not done so already) visit the 
-[Discord](https://discord.com/) website and click on the 
+[Discord](https://discordapp.com/) website and click on the 
 **Try Discord Now, It's Free** button then follow the steps to setup your
 new account.
 
@@ -77,12 +77,12 @@ have access to some user client specific features however they gain access to
 many Bot specific features.
 
 To create a new bot account first create yourself a normal user account on 
-Discord then visit the [My Applications](https://discord.com/developers/applications/me)
+Discord then visit the [My Applications](https://discordapp.com/developers/applications/me)
 page and click on the **New Application** box.  Follow the prompts from there
 to finish creating your account.
 
 
-**More information about Bots vs Client accounts can be found [here](https://discord.com/developers/docs/topics/oauth2#bot-vs-user-accounts)**
+**More information about Bots vs Client accounts can be found [here](https://discordapp.com/developers/docs/topics/oauth2#bot-vs-user-accounts)**
 
 # Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,12 @@
 <hr>
 <img align="right" src="http://bwmarrin.github.io/discordgo/img/discordgo.png">
 
-[Go](https://golang.org/) (golang) interface for the [Discord](https://discord.com/) 
+[Go](https://golang.org/) (golang) interface for the [Discord](https://discordapp.com/) 
 chat service.  Provides both low-level direct bindings to the 
 Discord API and helper functions that allow you to make custom clients and chat 
 bot applications easily.
 
-[Discord](https://discord.com/) is an all-in-one voice and text chat for 
+[Discord](https://discordapp.com/) is an all-in-one voice and text chat for 
 gamers that's free, secure, and works on both your desktop and phone. 
  
 ### Why DiscordGo?
@@ -30,4 +30,4 @@ information and support for DiscordGo.  There's also a chance to make some
 friends :)
 
 * Join the [Discord Gophers](https://discord.gg/0f1SbxBZjYoCtNPP) chat server dedicated to Go programming.
-* Join the [Discord API](https://discord.com/invite/discord-API) chat server dedicated to the Discord API.
+* Join the [Discord API](https://discordapp.com/invite/discord-API) chat server dedicated to the Discord API.

--- a/endpoints.go
+++ b/endpoints.go
@@ -18,12 +18,12 @@ var APIVersion = "6"
 
 // Known Discord API Endpoints.
 var (
-	EndpointStatus     = "https://status.discord.com/api/v2/"
+	EndpointStatus     = "https://status.discordapp.com/api/v2/"
 	EndpointSm         = EndpointStatus + "scheduled-maintenances/"
 	EndpointSmActive   = EndpointSm + "active.json"
 	EndpointSmUpcoming = EndpointSm + "upcoming.json"
 
-	EndpointDiscord    = "https://discord.com/"
+	EndpointDiscord    = "https://discordapp.com/"
 	EndpointAPI        = EndpointDiscord + "api/v" + APIVersion + "/"
 	EndpointGuilds     = EndpointAPI + "guilds/"
 	EndpointChannels   = EndpointAPI + "channels/"

--- a/event.go
+++ b/event.go
@@ -110,7 +110,7 @@ func (s *Session) addEventHandlerOnce(eventHandler EventHandler) func() {
 //     })
 //
 // List of events can be found at this page, with corresponding names in the
-// library for each event: https://discord.com/developers/docs/topics/gateway#event-names
+// library for each event: https://discordapp.com/developers/docs/topics/gateway#event-names
 // There are also synthetic events fired by the library internally which are
 // available for handling, like Connect, Disconnect, and RateLimit.
 // events.go contains all of the Discord WSAPI and synthetic events that can be handled.

--- a/examples/appmaker/README.md
+++ b/examples/appmaker/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to utilize DiscordGo to create, view, and delete
 Bot Applications on your account.
 
 These tasks are normally accomplished from the 
-[Discord Developers](https://discord.com/developers/applications/me) site.
+[Discord Developers](https://discordapp.com/developers/applications/me) site.
 
 **Join [Discord Gophers](https://discord.gg/0f1SbxBZjYoCtNPP)
 Discord chat channel for support.**

--- a/restapi.go
+++ b/restapi.go
@@ -38,7 +38,7 @@ var (
 	ErrPruneDaysBounds         = errors.New("the number of days should be more than or equal to 1")
 	ErrGuildNoIcon             = errors.New("guild does not have an icon set")
 	ErrGuildNoSplash           = errors.New("guild does not have a splash set")
-	ErrUnauthorized            = errors.New("HTTP request was unauthorized. This could be because the provided token was not a bot token. Please add \"Bot \" to the start of your token. https://discord.com/developers/docs/reference#authentication-example-bot-token-authorization-header")
+	ErrUnauthorized            = errors.New("HTTP request was unauthorized. This could be because the provided token was not a bot token. Please add \"Bot \" to the start of your token. https://discordapp.com/developers/docs/reference#authentication-example-bot-token-authorization-header")
 )
 
 // Request is the same as RequestWithBucketID but the bucket id is the same as the urlStr
@@ -506,7 +506,7 @@ func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions
 }
 
 // Calculates the permissions for a member.
-// https://support.discord.com/hc/en-us/articles/206141927-How-is-the-permission-hierarchy-structured-
+// https://support.discordapp.com/hc/en-us/articles/206141927-How-is-the-permission-hierarchy-structured-
 func memberPermissions(guild *Guild, channel *Channel, member *Member) (apermissions int) {
 	userID := member.User.ID
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -46,7 +46,7 @@ type resumePacket struct {
 }
 
 // Open creates a websocket connection to Discord.
-// See: https://discord.com/developers/docs/topics/gateway#connecting
+// See: https://discordapp.com/developers/docs/topics/gateway#connecting
 func (s *Session) Open() error {
 	s.log(LogInformational, "called")
 
@@ -836,10 +836,6 @@ func (s *Session) reconnect() {
 			}
 		}
 	}
-}
-
-func (s *Session) Close() error {
-	return s.CloseWithCode(websocket.CloseNormalClosure)
 }
 
 // Close closes a websocket and stops all listening/heartbeat goroutines.


### PR DESCRIPTION
Reverts bwmarrin/discordgo#769

The rebase in this PR seems to be faulty—the second `Close` should have been `CloseWithCode`, but was not updated to reflect this.