### PR TITLE
Fixed typo "consistancy" to "consistency"

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION of DiscordGo, follows Semantic Versioning. (http://semver.org/)
-const VERSION = "0.20.2"
+const VERSION = "0.20.3"
 
 // ErrMFA will be risen by New when the user has 2FA.
 var ErrMFA = errors.New("account has 2FA enabled")

--- a/logging.go
+++ b/logging.go
@@ -37,7 +37,7 @@ const (
 // Logger can be used to replace the standard logging for discordgo
 var Logger func(msgL, caller int, format string, a ...interface{})
 
-// msglog provides package wide logging consistancy for discordgo
+// msglog provides package wide logging consistency for discordgo
 // the format, a...  portion this command follows that of fmt.Printf
 //   msgL   : LogLevel of the message
 //   caller : 1 + the number of callers away from the message source


### PR DESCRIPTION
📝 Changed "consistancy" in msglog comment in logging.go to "consistency".