### PR TITLE
Add missing fields in GuildChannelCreateData

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -923,6 +923,8 @@ type GuildChannelCreateData struct {
 	Topic                string                 `json:"topic,omitempty"`
 	Bitrate              int                    `json:"bitrate,omitempty"`
 	UserLimit            int                    `json:"user_limit,omitempty"`
+	RateLimitPerUser     int                    `json:"rate_limit_per_user,omitempty"`
+	Position             int                    `json:"position,omitempty"`
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
 	ParentID             string                 `json:"parent_id,omitempty"`
 	NSFW                 bool                   `json:"nsfw,omitempty"`


### PR DESCRIPTION
According to https://discord.com/developers/docs/resources/guild#create-guild-channel, the endpoint also accepts the following fields:

- rate_limit_per_user: integer
- position: integer