### PR TITLE
Emoji improvements

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1309,6 +1309,19 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 	return
 }
 
+// GuildEmoji returns all emoji
+// guildID : The ID of a Guild.
+func (s *Session) GuildEmoji(guildID string) (emoji []*Emoji, err error) {
+
+	body, err := s.RequestWithBucketID("GET", EndpointGuildEmojis(guildID), nil, EndpointGuildEmojis(guildID))
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &emoji)
+	return
+}
+
 // GuildEmojiCreate creates a new emoji
 // guildID : The ID of a Guild.
 // name    : The Name of the Emoji.

--- a/restapi.go
+++ b/restapi.go
@@ -1309,9 +1309,9 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 	return
 }
 
-// GuildEmoji returns all emoji
+// GuildEmojis returns all emoji
 // guildID : The ID of a Guild.
-func (s *Session) GuildEmoji(guildID string) (emoji []*Emoji, err error) {
+func (s *Session) GuildEmojis(guildID string) (emoji []*Emoji, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildEmojis(guildID), nil, EndpointGuildEmojis(guildID))
 	if err != nil {

--- a/structs.go
+++ b/structs.go
@@ -330,8 +330,8 @@ type Emoji struct {
 	Name          string   `json:"name"`
 	Roles         []string `json:"roles"`
 	User          *User    `json:"user"`
-	Managed       bool     `json:"managed"`
 	RequireColons bool     `json:"require_colons"`
+	Managed       bool     `json:"managed"`
 	Animated      bool     `json:"animated"`
 	Available     bool     `json:"available"`
 }


### PR DESCRIPTION
- Re-arrange Emoji to match docs
- Add new function `GuildEmoji` to get all the emoji part of a guild. The style of other GET functions is to pluralize the resource type, but pretty sure Emoji is used as both singular and plural form. Happy to change it to be `GuildEmojis` though.