### PR TITLE
Add team data to applications

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -15,20 +15,20 @@ package discordgo
 
 // A TeamMember struct stores values for a single Team Member, extending the normal User data. Note that the user field is partial.
 type TeamMember struct {
-	User 				*User    `json:"user"`
-	TeamID 				string   `json:"team_id"`
-	MembershipState 	string   `json:"membership_state"`
-	Permissions 		[]string `json:"permissions"`
+	User            *User    `json:"user"`
+	TeamID          string   `json:"team_id"`
+	MembershipState string   `json:"membership_state"`
+	Permissions     []string `json:"permissions"`
 }
 
 // A Team struct stores the members of a Discord Developer Team as well as some metadata about it
 type Team struct {
-	ID 					string	      `json:"id"`
-	Name                string        `json:"name"`
-	Description         string        `json:"description"`
-	Icon                string        `json:"icon"`
-	OwnerID 			string        `json:"owner_user_id"`
-	Members 			[]*TeamMember `json:"members"`
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Icon        string        `json:"icon"`
+	OwnerID     string        `json:"owner_user_id"`
+	Members     []*TeamMember `json:"members"`
 }
 
 // An Application struct stores values for a Discord OAuth2 Application
@@ -45,7 +45,7 @@ type Application struct {
 	Flags               int       `json:"flags,omitempty"`
 	Owner               *User     `json:"owner"`
 	Bot                 *User     `json:"bot"`
-	Team 				*Team 	  `json:"team"`
+	Team                *Team     `json:"team"`
 }
 
 // Application returns an Application structure of a specific Application

--- a/oauth2.go
+++ b/oauth2.go
@@ -13,6 +13,24 @@ package discordgo
 // Code specific to Discord OAuth2 Applications
 // ------------------------------------------------------------------------------------------------
 
+// A TeamMember struct stores values for a single Team Member, extending the normal User data. Note that the user field is partial.
+type TeamMember struct {
+	User 				*User    `json:"user"`
+	TeamID 				string   `json:"team_id"`
+	MembershipState 	string   `json:"membership_state"`
+	Permissions 		[]string `json:"permissions"`
+}
+
+// A Team struct stores the members of a Discord Developer Team as well as some metadata about it
+type Team struct {
+	ID 					string	      `json:"id"`
+	Name                string        `json:"name"`
+	Description         string        `json:"description"`
+	Icon                string        `json:"icon"`
+	OwnerID 			string        `json:"owner_user_id"`
+	Members 			[]*TeamMember `json:"members"`
+}
+
 // An Application struct stores values for a Discord OAuth2 Application
 type Application struct {
 	ID                  string    `json:"id,omitempty"`
@@ -27,6 +45,7 @@ type Application struct {
 	Flags               int       `json:"flags,omitempty"`
 	Owner               *User     `json:"owner"`
 	Bot                 *User     `json:"bot"`
+	Team 				*Team 	  `json:"team"`
 }
 
 // Application returns an Application structure of a specific Application

--- a/oauth2.go
+++ b/oauth2.go
@@ -13,12 +13,20 @@ package discordgo
 // Code specific to Discord OAuth2 Applications
 // ------------------------------------------------------------------------------------------------
 
+// The MembershipState represents whether the user is in the team or has been invited into it
+type MembershipState int
+
+const (
+	MembershipStateInvited MembershipState = iota + 1
+	MembershipStateAccepted
+)
+
 // A TeamMember struct stores values for a single Team Member, extending the normal User data - note that the user field is partial
 type TeamMember struct {
-	User            *User    `json:"user"`
-	TeamID          string   `json:"team_id"`
-	MembershipState int      `json:"membership_state"`
-	Permissions     []string `json:"permissions"`
+	User            *User           `json:"user"`
+	TeamID          string          `json:"team_id"`
+	MembershipState MembershipState `json:"membership_state"`
+	Permissions     []string        `json:"permissions"`
 }
 
 // A Team struct stores the members of a Discord Developer Team as well as some metadata about it

--- a/oauth2.go
+++ b/oauth2.go
@@ -13,7 +13,7 @@ package discordgo
 // Code specific to Discord OAuth2 Applications
 // ------------------------------------------------------------------------------------------------
 
-// A TeamMember struct stores values for a single Team Member, extending the normal User data. Note that the user field is partial.
+// A TeamMember struct stores values for a single Team Member, extending the normal User data - note that the user field is partial
 type TeamMember struct {
 	User            *User    `json:"user"`
 	TeamID          string   `json:"team_id"`

--- a/oauth2.go
+++ b/oauth2.go
@@ -17,7 +17,7 @@ package discordgo
 type TeamMember struct {
 	User            *User    `json:"user"`
 	TeamID          string   `json:"team_id"`
-	MembershipState string   `json:"membership_state"`
+	MembershipState int      `json:"membership_state"`
 	Permissions     []string `json:"permissions"`
 }
 

--- a/oauth2.go
+++ b/oauth2.go
@@ -16,6 +16,7 @@ package discordgo
 // The MembershipState represents whether the user is in the team or has been invited into it
 type MembershipState int
 
+// Constants for the different stages of the MembershipState
 const (
 	MembershipStateInvited MembershipState = iota + 1
 	MembershipStateAccepted


### PR DESCRIPTION
This adds data about the Team owning an application (if there is a team owning the application), as well as its members