### PR TITLE
Add example of emojiID to MessageReactionAdd

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -2100,7 +2100,7 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 // MessageReactionAdd creates an emoji reaction to a message.
 // channelID : The channel ID.
 // messageID : The message ID.
-// emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
+// emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier in name:id format (e.g. "hello:1234567654321")
 func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error {
 
 	// emoji such as  #⃣ need to have # escaped


### PR DESCRIPTION
Since i ran into the same issue today, the documentation for MessageReactionAdd should be improved, thanks to #750 