### PR TITLE
Add support for news channels

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -112,6 +112,8 @@ var (
 	EndpointChannelMessagesBulkDelete = func(cID string) string { return EndpointChannel(cID) + "/messages/bulk-delete" }
 	EndpointChannelMessagesPins       = func(cID string) string { return EndpointChannel(cID) + "/pins" }
 	EndpointChannelMessagePin         = func(cID, mID string) string { return EndpointChannel(cID) + "/pins/" + mID }
+	EndpointChannelMessageCrosspost   = func(cID, mID string) string { return EndpointChannel(cID) + "/messages/" + mID + "/crosspost" }
+	EndpointChannelFollow             = func(cID string) string { return EndpointChannel(cID) + "/followers" }
 
 	EndpointGroupIcon = func(cID, hash string) string { return EndpointCDNChannelIcons + cID + "/" + hash + ".png" }
 

--- a/restapi.go
+++ b/restapi.go
@@ -1790,6 +1790,38 @@ func (s *Session) ChannelPermissionDelete(channelID, targetID string) (err error
 	return
 }
 
+// ChannelMessageCrosspost cross posts a message in a news channel to followers
+// of the channel
+// channelID   : The ID of a Channel
+// messageID   : The ID of a Message
+func (s *Session) ChannelMessageCrosspost(channelID, messageID string) (st *Message, err error) {
+
+	endpoint := EndpointChannelMessageCrosspost(channelID, messageID)
+
+	body, err := s.RequestWithBucketID("POST", endpoint, nil, endpoint)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
+// ChannelNewsFollow follows a news channel in the targetID
+// channelID   : The ID of a News Channel
+// targetID    : The ID of a Channel where the News Channel should post to
+func (s *Session) ChannelNewsFollow(channelID, targetID string) (err error) {
+
+	endpoint := EndpointChannelFollow(channelID)
+
+	data := struct {
+		WebhookChannelID string `json:"webhook_channel_id"`
+	}{targetID}
+
+	_, err = s.RequestWithBucketID("POST", endpoint, data, endpoint)
+	return
+}
+
 // ------------------------------------------------------------------------------------------------
 // Functions specific to Discord Invites
 // ------------------------------------------------------------------------------------------------

--- a/restapi.go
+++ b/restapi.go
@@ -1819,6 +1819,9 @@ func (s *Session) ChannelNewsFollow(channelID, targetID string) (st *ChannelFoll
 	}{targetID}
 
 	body, err := s.RequestWithBucketID("POST", endpoint, data, endpoint)
+	if err != nil {
+		return
+	}
 
 	err = unmarshal(body, &st)
 	return

--- a/restapi.go
+++ b/restapi.go
@@ -1810,7 +1810,7 @@ func (s *Session) ChannelMessageCrosspost(channelID, messageID string) (st *Mess
 // ChannelNewsFollow follows a news channel in the targetID
 // channelID   : The ID of a News Channel
 // targetID    : The ID of a Channel where the News Channel should post to
-func (s *Session) ChannelNewsFollow(channelID, targetID string) (err error) {
+func (s *Session) ChannelNewsFollow(channelID, targetID string) (st *ChannelFollow, err error) {
 
 	endpoint := EndpointChannelFollow(channelID)
 
@@ -1818,7 +1818,9 @@ func (s *Session) ChannelNewsFollow(channelID, targetID string) (err error) {
 		WebhookChannelID string `json:"webhook_channel_id"`
 	}{targetID}
 
-	_, err = s.RequestWithBucketID("POST", endpoint, data, endpoint)
+	body, err := s.RequestWithBucketID("POST", endpoint, data, endpoint)
+
+	err = unmarshal(body, &st)
 	return
 }
 

--- a/structs.go
+++ b/structs.go
@@ -316,6 +316,11 @@ type ChannelEdit struct {
 	RateLimitPerUser     int                    `json:"rate_limit_per_user,omitempty"`
 }
 
+type ChannelFollow struct {
+	ChannelID string `json:"channel_id"`
+	WebhookID string `json:"webhook_id"`
+}
+
 // A PermissionOverwrite holds permission overwrite data for a Channel
 type PermissionOverwrite struct {
 	ID    string `json:"id"`

--- a/structs.go
+++ b/structs.go
@@ -316,6 +316,7 @@ type ChannelEdit struct {
 	RateLimitPerUser     int                    `json:"rate_limit_per_user,omitempty"`
 }
 
+// A ChannelFollow holds data returned after following a news channel
 type ChannelFollow struct {
 	ChannelID string `json:"channel_id"`
 	WebhookID string `json:"webhook_id"`


### PR DESCRIPTION
Resolves #799 

Adds support for the following endpoints:
- `@/channels/:id/messages/:id/crosspost`: publishes a message in a news channel to followers
- `@/channels/:id/followers`: follows a news channel