### PR TITLE
add user public flags field and public flag consts

### DIFF
--- a/user.go
+++ b/user.go
@@ -2,6 +2,27 @@ package discordgo
 
 import "strings"
 
+// UserFlags is the flags of "user" (see UserFlags* consts)
+// https://discord.com/developers/docs/resources/user#user-object-user-flags
+type UserFlags int
+
+// Valid UserFlags values
+const (
+	UserFlagDiscordEmployee      UserFlags = 1 << iota
+	UserFlagDiscordPartner                 = 1 << iota
+	UserFlagHypeSquadEvents                = 1 << iota
+	UserFlagBugHunterLevel1                = 1 << iota
+	UserFlagHouseBravery                   = 1 << iota
+	UserFlagHouseBrilliance                = 1 << iota
+	UserFlagHouseBalance                   = 1 << iota
+	UserFlagEarlySupporter                 = 1 << iota
+	UserFlagTeamUser                       = 1 << iota
+	UserFlagSystem                         = 1 << iota
+	UserFlagBugHunterLevel2                = 1 << iota
+	UserFlagVerifiedBot                    = 1 << iota
+	UserFlagVerifiedBotDeveloper           = 1 << iota
+)
+
 // A User stores all data for an individual Discord user.
 type User struct {
 	// The ID of the user.
@@ -36,6 +57,11 @@ type User struct {
 
 	// Whether the user is a bot.
 	Bot bool `json:"bot"`
+
+	// The public flags on a users account.
+	// This is a combination of bit masks; the presence of a certain flag can
+	// be checked by performing a bitwise AND between this int and the flag.
+	PublicFlags UserFlags `json:"public_flags"`
 }
 
 // String returns a unique identifier of the form username#discriminator

--- a/user.go
+++ b/user.go
@@ -8,19 +8,19 @@ type UserFlags int
 
 // Valid UserFlags values
 const (
-	UserFlagDiscordEmployee UserFlags = 1 << iota
-	UserFlagDiscordPartner
-	UserFlagHypeSquadEvents
-	UserFlagBugHunterLevel1
-	UserFlagHouseBravery
-	UserFlagHouseBrilliance
-	UserFlagHouseBalance
-	UserFlagEarlySupporter
-	UserFlagTeamUser
-	UserFlagSystem
-	UserFlagBugHunterLevel2
-	UserFlagVerifiedBot
-	UserFlagVerifiedBotDeveloper
+	UserFlagDiscordEmployee      UserFlags = 1 << 0
+	UserFlagDiscordPartner                 = 1 << 1
+	UserFlagHypeSquadEvents                = 1 << 2
+	UserFlagBugHunterLevel1                = 1 << 3
+	UserFlagHouseBravery                   = 1 << 6
+	UserFlagHouseBrilliance                = 1 << 7
+	UserFlagHouseBalance                   = 1 << 8
+	UserFlagEarlySupporter                 = 1 << 9
+	UserFlagTeamUser                       = 1 << 10
+	UserFlagSystem                         = 1 << 12
+	UserFlagBugHunterLevel2                = 1 << 14
+	UserFlagVerifiedBot                    = 1 << 16
+	UserFlagVerifiedBotDeveloper           = 1 << 17
 )
 
 // A User stores all data for an individual Discord user.

--- a/user.go
+++ b/user.go
@@ -8,19 +8,19 @@ type UserFlags int
 
 // Valid UserFlags values
 const (
-	UserFlagDiscordEmployee      UserFlags = 1 << iota
-	UserFlagDiscordPartner                 = 1 << iota
-	UserFlagHypeSquadEvents                = 1 << iota
-	UserFlagBugHunterLevel1                = 1 << iota
-	UserFlagHouseBravery                   = 1 << iota
-	UserFlagHouseBrilliance                = 1 << iota
-	UserFlagHouseBalance                   = 1 << iota
-	UserFlagEarlySupporter                 = 1 << iota
-	UserFlagTeamUser                       = 1 << iota
-	UserFlagSystem                         = 1 << iota
-	UserFlagBugHunterLevel2                = 1 << iota
-	UserFlagVerifiedBot                    = 1 << iota
-	UserFlagVerifiedBotDeveloper           = 1 << iota
+	UserFlagDiscordEmployee UserFlags = 1 << iota
+	UserFlagDiscordPartner
+	UserFlagHypeSquadEvents
+	UserFlagBugHunterLevel1
+	UserFlagHouseBravery
+	UserFlagHouseBrilliance
+	UserFlagHouseBalance
+	UserFlagEarlySupporter
+	UserFlagTeamUser
+	UserFlagSystem
+	UserFlagBugHunterLevel2
+	UserFlagVerifiedBot
+	UserFlagVerifiedBotDeveloper
 )
 
 // A User stores all data for an individual Discord user.
@@ -58,7 +58,7 @@ type User struct {
 	// Whether the user is a bot.
 	Bot bool `json:"bot"`
 
-	// The public flags on a users account.
+	// The public flags on a user's account.
 	// This is a combination of bit masks; the presence of a certain flag can
 	// be checked by performing a bitwise AND between this int and the flag.
 	PublicFlags UserFlags `json:"public_flags"`


### PR DESCRIPTION
In this pull request, I've added the `PublicFlags` field to the `User` struct as documented here:  
https://discord.com/developers/docs/resources/user#user-object-user-structure

This field holds publicly avaliable flags like some profile badges, for example the "Hype Squad" badges, the "Partner" badge or the "Verified Bot Developer" badge.

Also, I've added the flag values as constants to perform bitwise operations on user flags in an convenient way. The flag values are defined as documented here:  
https://discord.com/developers/docs/resources/user#user-object-user-flags

I've tried to adapt the code documentation from other flag and type descriptions as consistent as possible. If there is any issue with my implementation, please contact me and I will correct the issue. :)