### PR TITLE
Add 1.15 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
     - 1.12.x
     - 1.13.x
     - 1.14.x
+    - 1.15.x
 env:
     - GO111MODULE=on
 install:


### PR DESCRIPTION
Go 1.15 was released today, this PR adds basic testing for it within Travis CI as well. 