### PR TITLE
Add GuildMemberEditComplex for Guild Member Mute/Deaf Edit Support

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -828,16 +828,18 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // userID   : The ID of a User.
 // roles    : A list of role ID's to set on the member.
 func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err error) {
+	// TODO: Change to GuildMemberEditRoles later, kept for backwards-compatability
+	return s.GuildMemberEditComplex(guildID, userID, &MemberEdit{
+		Roles: roles,
+	})
+}
 
-	data := struct {
-		Roles []string `json:"roles"`
-	}{roles}
-
+// GuildMemberEditComplex edits a member
+// guildID  : The ID of a Guild.
+// userID   : The ID of a User.
+// data     : MemberEdit struct to send
+func (s *Session) GuildMemberEditComplex(guildID, userID string, data *MemberEdit) (err error) {
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
-	if err != nil {
-		return
-	}
-
 	return
 }
 
@@ -848,16 +850,11 @@ func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err e
 // NOTE : I am not entirely set on the name of this function and it may change
 // prior to the final 1.0.0 release of Discordgo
 func (s *Session) GuildMemberMove(guildID string, userID string, channelID *string) (err error) {
-
 	data := struct {
 		ChannelID *string `json:"channel_id"`
 	}{channelID}
 
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
-	if err != nil {
-		return
-	}
-
 	return
 }
 

--- a/restapi.go
+++ b/restapi.go
@@ -828,17 +828,11 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // userID   : The ID of a User.
 // roles    : A list of role ID's to set on the member.
 func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err error) {
-	// TODO: Change to GuildMemberEditRoles later, kept for backwards-compatability
-	return s.GuildMemberEditComplex(guildID, userID, &MemberEdit{
-		Roles: roles,
-	})
-}
 
-// GuildMemberEditComplex edits a member
-// guildID  : The ID of a Guild.
-// userID   : The ID of a User.
-// data     : MemberEdit struct to send
-func (s *Session) GuildMemberEditComplex(guildID, userID string, data *MemberEdit) (err error) {
+	data := struct {
+		Roles []string `json:"roles"`
+	}{roles}
+
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	return
 }
@@ -862,6 +856,7 @@ func (s *Session) GuildMemberMove(guildID string, userID string, channelID *stri
 // guildID   : The ID of a guild
 // userID    : The ID of a user
 // userID    : The ID of a user or "@me" which is a shortcut of the current user ID
+// nickname  : The nickname of the member, "" will reset their nickname
 func (s *Session) GuildMemberNickname(guildID, userID, nickname string) (err error) {
 
 	data := struct {
@@ -871,6 +866,32 @@ func (s *Session) GuildMemberNickname(guildID, userID, nickname string) (err err
 	if userID == "@me" {
 		userID += "/nick"
 	}
+
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	return
+}
+
+// GuildMemberMute server mutes a guild member
+//  guildID   : The ID of a Guild.
+//  userID    : The ID of a User.
+//  mute    : boolean value for if the user should be muted
+func (s *Session) GuildMemberMute(guildID string, userID string, mute bool) (err error) {
+	data := struct {
+		Mute bool `json:"mute"`
+	}{mute}
+
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	return
+}
+
+// GuildMemberDeafen server deafens a guild member
+//  guildID   : The ID of a Guild.
+//  userID    : The ID of a User.
+//  deaf    : boolean value for if the user should be deafened
+func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool) (err error) {
+	data := struct {
+		Deaf bool `json:"deaf"`
+	}{deaf}
 
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	return

--- a/structs.go
+++ b/structs.go
@@ -784,6 +784,20 @@ func (m *Member) Mention() string {
 	return "<@!" + m.User.ID + ">"
 }
 
+// A MemberEdit holds Member Field data for a member edit.
+type MemberEdit struct {
+	Nick  string   `json:"nick,omitempty"`
+	Roles []string `json:"roles,omitempty"`
+
+	// Cannot change below fields if user is not in voice channel
+	Mute bool `json:"mute,omitempty"`
+	Deaf bool `json:"deaf,omitempty"`
+
+	// ChannelID is ommitted from this because Discord API requires a nil value
+	// which cannot work with omitempty, since nil value would be omitted from
+	// the request, use GuildMemberMove instead
+}
+
 // A Settings stores data for a specific users Discord client settings.
 type Settings struct {
 	RenderEmbeds           bool               `json:"render_embeds"`

--- a/structs.go
+++ b/structs.go
@@ -784,20 +784,6 @@ func (m *Member) Mention() string {
 	return "<@!" + m.User.ID + ">"
 }
 
-// A MemberEdit holds Member Field data for a member edit.
-type MemberEdit struct {
-	Nick  string   `json:"nick,omitempty"`
-	Roles []string `json:"roles,omitempty"`
-
-	// Cannot change below fields if user is not in voice channel
-	Mute bool `json:"mute,omitempty"`
-	Deaf bool `json:"deaf,omitempty"`
-
-	// ChannelID is ommitted from this because Discord API requires a nil value
-	// which cannot work with omitempty, since nil value would be omitted from
-	// the request, use GuildMemberMove instead
-}
-
 // A Settings stores data for a specific users Discord client settings.
 type Settings struct {
 	RenderEmbeds           bool               `json:"render_embeds"`


### PR DESCRIPTION
Currently, as far as I know, there is no support for muting or deafening a user (when they are in the voice channel). I've added support for that in this PR.

As a note, `GuildMemberNickname` is still using the old code because of the `/guilds/{guild.id}/members/@me/nick` endpoint. 

On top of that, the `GuildMemberMove` command is also not using `GuildMemberEditComplex` because Discord requires the JSON request value for the `channel_id` key when removing a user to be `null` (if you want to disconnect the user), in Go, this is represented as `nil` and would be omitted by the default JSON marshaller. As a result, if `GuildMemberEditComplex` also attempted to support `ChannelID` modifications, then every change would disconnect the user unintentionally, so I omitted that functionality.

This is a non-breaking change.