### PR TITLE
Add query escape to GuildEmojiCreate and update documentation

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -2137,11 +2137,10 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 // MessageReactionAdd creates an emoji reaction to a message.
 // channelID : The channel ID.
 // messageID : The message ID.
-// emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
+// emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier (":emojiName:emojiID").
 func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error {
 
-	// emoji such as  #⃣ need to have # escaped
-	emojiID = strings.Replace(emojiID, "#", "%23", -1)
+	emojiID = url.QueryEscape(emojiID)
 	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, "", "", ""))
 
 	return err

--- a/restapi.go
+++ b/restapi.go
@@ -1325,7 +1325,7 @@ func (s *Session) GuildEmojis(guildID string) (emoji []*Emoji, err error) {
 // GuildEmojiCreate creates a new emoji
 // guildID : The ID of a Guild.
 // name    : The Name of the Emoji.
-// image   : The base64 encoded emoji image, has to be smaller than 256KB.
+// image   : The base64 encoded emoji image, has to be smaller than 256KB and provided in the data URI scheme.
 // roles   : The roles for which this emoji will be whitelisted, can be nil.
 func (s *Session) GuildEmojiCreate(guildID, name, image string, roles []string) (emoji *Emoji, err error) {
 

--- a/restapi.go
+++ b/restapi.go
@@ -2137,10 +2137,11 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 // MessageReactionAdd creates an emoji reaction to a message.
 // channelID : The channel ID.
 // messageID : The message ID.
-// emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier (":emojiName:emojiID").
+// emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier (via Emoji.APIName).
 func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error {
 
-	emojiID = url.QueryEscape(emojiID)
+	// emoji such as  #⃣ need to have # escaped
+	emojiID = strings.Replace(emojiID, "#", "%23", -1)
 	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, "", "", ""))
 
 	return err


### PR DESCRIPTION
As described in the Discord API documentation of the `Create Reaction` endpoint, the `emoji` parameter must be URL encoded:  
https://discord.com/developers/docs/resources/channel#create-reaction

So, I've added URL query escaping for the `emoji` parameter of the `MessageReactionAdd` function. This should also cover the current implementation to escape `#` characters in emoji strings.  
https://github.com/bwmarrin/discordgo/blob/master/restapi.go#L2144

Sadly, the Discord documentation does not specify how the emoji identifier is composed. This took me some time to figure out by asking some other developers and taking a look into the docs of discord.js, where the emoji identifier is shown in an example. To clarify the usage of the emoji identifier, I've added the structure of it to the methods documentation.

Also, I found another potential ambiguity in the documentation of the `GuildEmojiCreate` function. To clarify that the `image` string must be in the base64 data URI scheme, following to the Discord documentation, I've added this to the parameters documentation of the function.  
https://discord.com/developers/docs/reference#image-data