### PR TITLE
Bump to v8, add Sticker struct

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -14,7 +14,7 @@ package discordgo
 import "strconv"
 
 // APIVersion is the Discord API version used for the REST and Websocket API.
-var APIVersion = "6"
+var APIVersion = "8"
 
 // Known Discord API Endpoints.
 var (

--- a/message.go
+++ b/message.go
@@ -122,20 +122,21 @@ type Message struct {
 	// be checked by performing a bitwise AND between this int and the flag.
 	Flags MessageFlags `json:"flags"`
 
-	// A sticker, which is a special type of message.
-	Stickers []*Sticker `json:"stickers"`
+	// A sticker which is a special type of message that displays a GIF.
+	// TODO: Currently not documented in Discord API but appears in stable clients.
+	Stickers *[]Sticker `json:"stickers"`
 }
 
 // Sticker contains the data that determines how a sticker is displayed in a channel.
 type Sticker struct {
-	ID           string `json:"string"`
-	Name         string `json:"name"`
-	Description  string `json:"description,omitempty"`
-	PackID       string `json:"pack_id"`
-	Asset        string `json:"asset"`
-	PreviewAsset string `json:"preview_asset,omitempty"`
-	FormatType   int    `json:"format_type"`
-	Tags         string `json:"tags,omitempty"`
+	ID           string  `json:"string"`
+	Name         string  `json:"name"`
+	Description  *string `json:"description,omitempty"`
+	PackID       string  `json:"pack_id"`
+	Asset        string  `json:"asset"`
+	PreviewAsset *string `json:"preview_asset,omitempty"`
+	FormatType   int     `json:"format_type"`
+	Tags         *string `json:"tags,omitempty"`
 }
 
 // MessageFlags is the flags of "message" (see MessageFlags* consts)

--- a/message.go
+++ b/message.go
@@ -121,6 +121,21 @@ type Message struct {
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the flag.
 	Flags MessageFlags `json:"flags"`
+
+	// A sticker, which is a special type of message.
+	Stickers []*Sticker `json:"stickers"`
+}
+
+// Sticker contains the data that determines how a sticker is displayed in a channel.
+type Sticker struct {
+	ID           string `json:"string"`
+	Name         string `json:"name"`
+	Description  string `json:"description,omitempty"`
+	PackID       string `json:"pack_id"`
+	Asset        string `json:"asset"`
+	PreviewAsset string `json:"preview_asset,omitempty"`
+	FormatType   int    `json:"format_type"`
+	Tags         string `json:"tags,omitempty"`
 }
 
 // MessageFlags is the flags of "message" (see MessageFlags* consts)

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -153,7 +153,7 @@ func (b *Bucket) Release(headers http.Header) error {
 			return err
 		}
 
-		resetAt := time.Now().Add(time.Duration(parsedAfter) * time.Millisecond)
+		resetAt := time.Now().Add(time.Duration(parsedAfter) * time.Second)
 
 		// Lock either this single bucket or all buckets
 		if global != "" {

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -56,7 +56,7 @@ func TestRatelimitGlobal(t *testing.T) {
 
 		headers.Set("X-RateLimit-Global", "1")
 		// Reset for approx 1 seconds from now
-		headers.Set("Retry-After", "1000")
+		headers.Set("Retry-After", "1")
 
 		err := bucket.Release(headers)
 		if err != nil {

--- a/restapi.go
+++ b/restapi.go
@@ -33,7 +33,7 @@ import (
 // All error constants
 var (
 	ErrJSONUnmarshal           = errors.New("json unmarshal")
-	ErrStatusOffline           = errors.New("You can't set your Status to offline")
+	ErrStatusOffline           = errors.New("status cannot be set to offline")
 	ErrVerificationLevelBounds = errors.New("VerificationLevel out of bounds, should be between 0 and 3")
 	ErrPruneDaysBounds         = errors.New("the number of days should be more than or equal to 1")
 	ErrGuildNoIcon             = errors.New("guild does not have an icon set")
@@ -704,7 +704,7 @@ func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days 
 
 	queryParams := url.Values{}
 	if days > 0 {
-		queryParams.Set("delete-message-days", strconv.Itoa(days))
+		queryParams.Set("delete_message_days", strconv.Itoa(days))
 	}
 	if reason != "" {
 		queryParams.Set("reason", reason)

--- a/restapi.go
+++ b/restapi.go
@@ -540,7 +540,7 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 	for _, overwrite := range channel.PermissionOverwrites {
 		if guild.ID == overwrite.ID {
 			denyInt, _ := strconv.Atoi(overwrite.Deny)
-			allowInt, _ := strconv.Atoi(overwrite.Deny)
+			allowInt, _ := strconv.Atoi(overwrite.Allow)
 
 			apermissions &= ^denyInt
 			apermissions |= allowInt
@@ -554,9 +554,9 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 	// Member overwrites can override role overrides, so do two passes
 	for _, overwrite := range channel.PermissionOverwrites {
 		for _, roleID := range roles {
-			if overwrite.Type == 1 && roleID == overwrite.ID {
+			if overwrite.Type == 0 && roleID == overwrite.ID {
 				denyInt, _ := strconv.Atoi(overwrite.Deny)
-				allowInt, _ := strconv.Atoi(overwrite.Deny)
+				allowInt, _ := strconv.Atoi(overwrite.Allow)
 
 				denies |= denyInt
 				allows |= allowInt
@@ -569,9 +569,9 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 	apermissions |= allows
 
 	for _, overwrite := range channel.PermissionOverwrites {
-		if overwrite.Type == 0 && overwrite.ID == userID {
+		if overwrite.Type == 1 && overwrite.ID == userID {
 			denyInt, _ := strconv.Atoi(overwrite.Deny)
-			allowInt, _ := strconv.Atoi(overwrite.Deny)
+			allowInt, _ := strconv.Atoi(overwrite.Allow)
 
 			apermissions &= ^denyInt
 			apermissions |= allowInt

--- a/state.go
+++ b/state.go
@@ -201,13 +201,8 @@ func (s *State) PresenceAdd(guildID string, presence *Presence) error {
 			//guild.Presences[i] = presence
 
 			//Update status
-			guild.Presences[i].Game = presence.Game
-			guild.Presences[i].Roles = presence.Roles
 			if presence.Status != "" {
 				guild.Presences[i].Status = presence.Status
-			}
-			if presence.Nick != "" {
-				guild.Presences[i].Nick = presence.Nick
 			}
 
 			//Update the optionally sent user information
@@ -940,24 +935,13 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 				// Member not found; this is a user coming online
 				m = &Member{
 					GuildID: t.GuildID,
-					Nick:    t.Nick,
 					User:    t.User,
-					Roles:   t.Roles,
 				}
 
 			} else {
-
-				if t.Nick != "" {
-					m.Nick = t.Nick
-				}
-
 				if t.User.Username != "" {
 					m.User.Username = t.User.Username
 				}
-
-				// PresenceUpdates always contain a list of roles, so there's no need to check for an empty list here
-				m.Roles = t.Roles
-
 			}
 
 			err = s.MemberAdd(m)

--- a/state.go
+++ b/state.go
@@ -200,6 +200,7 @@ func (s *State) PresenceAdd(guildID string, presence *Presence) error {
 		if p.User.ID == presence.User.ID {
 			//guild.Presences[i] = presence
 
+			guild.Presences[i].Activities = presence.Activities
 			//Update status
 			if presence.Status != "" {
 				guild.Presences[i].Status = presence.Status

--- a/structs.go
+++ b/structs.go
@@ -427,9 +427,6 @@ type Guild struct {
 	// The ID of the AFK voice channel.
 	AfkChannelID string `json:"afk_channel_id"`
 
-	// The ID of the embed channel ID, used for embed widgets.
-	EmbedChannelID string `json:"embed_channel_id"`
-
 	// The user ID of the owner of the guild.
 	OwnerID string `json:"owner_id"`
 
@@ -457,9 +454,6 @@ type Guild struct {
 
 	// The verification level required for the guild.
 	VerificationLevel VerificationLevel `json:"verification_level"`
-
-	// Whether the guild has embedding enabled.
-	EmbedEnabled bool `json:"embed_enabled"`
 
 	// Whether the guild is considered large. This is
 	// determined by a member threshold in the identify packet,
@@ -688,13 +682,10 @@ type VoiceState struct {
 
 // A Presence stores the online, offline, or idle and game status of Guild members.
 type Presence struct {
-	User       *User    `json:"user"`
-	Status     Status   `json:"status"`
-	Game       *Game    `json:"game"`
-	Activities []*Game  `json:"activities"`
-	Nick       string   `json:"nick"`
-	Roles      []string `json:"roles"`
-	Since      *int     `json:"since"`
+	User       *User     `json:"user"`
+	Status     Status    `json:"status"`
+	Activities []*Game   `json:"activities"`
+	Since      *int      `json:"since"`
 }
 
 // GameType is the type of "game" (see GameType* consts) in the Game struct
@@ -776,7 +767,7 @@ type Member struct {
 	// A list of IDs of the roles which are possessed by the member.
 	Roles []string `json:"roles"`
 
-	// When the user used their Nitro boost on the server
+	// When the user used their Nitro boost on the server.
 	PremiumSince Timestamp `json:"premium_since"`
 }
 
@@ -1105,10 +1096,10 @@ type GatewayBotResponse struct {
 // GatewayStatusUpdate is sent by the client to indicate a presence or status update
 // https://discord.com/developers/docs/topics/gateway#update-status-gateway-status-update-structure
 type GatewayStatusUpdate struct {
-	Since  int      `json:"since"`
-	Game   Activity `json:"game"`
-	Status string   `json:"status"`
-	AFK    bool     `json:"afk"`
+	Since      int         `json:"since"`
+	Activities *[]Activity `json:"activities"`
+	Status     string      `json:"status"`
+	AFK        bool        `json:"afk"`
 }
 
 // Activity defines the Activity sent with GatewayStatusUpdate

--- a/structs.go
+++ b/structs.go
@@ -325,9 +325,9 @@ type ChannelFollow struct {
 // A PermissionOverwrite holds permission overwrite data for a Channel
 type PermissionOverwrite struct {
 	ID    string `json:"id"`
-	Type  string `json:"type"`
-	Deny  int    `json:"deny"`
-	Allow int    `json:"allow"`
+	Type  int    `json:"type"`
+	Deny  string `json:"deny"`
+	Allow string `json:"allow"`
 }
 
 // Emoji struct holds data related to Emoji's
@@ -644,7 +644,7 @@ type Role struct {
 	// The permissions of the role on the guild (doesn't include channel overrides).
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the permission.
-	Permissions int `json:"permissions"`
+	Permissions string `json:"permissions"`
 }
 
 // Mention returns a string which mentions the role

--- a/wsapi.go
+++ b/wsapi.go
@@ -322,10 +322,10 @@ func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}
 
 // UpdateStatusData ia provided to UpdateStatusComplex()
 type UpdateStatusData struct {
-	IdleSince *int   `json:"since"`
-	Game      *Game  `json:"game"`
-	AFK       bool   `json:"afk"`
-	Status    string `json:"status"`
+	IdleSince       *int     `json:"since"`
+	Activities      *[]Game  `json:"activities"`
+	AFK             bool     `json:"afk"`
+	Status          string   `json:"status"`
 }
 
 type updateStatusOp struct {
@@ -334,20 +334,23 @@ type updateStatusOp struct {
 }
 
 func newUpdateStatusData(idle int, gameType GameType, game, url string) *UpdateStatusData {
+	var newActivities []Game
+
+	if game != "" {
+		newActivities = append(newActivities, Game{
+			Name: game,
+			Type: gameType,
+			URL:  url,
+		})
+	}
+
 	usd := &UpdateStatusData{
 		Status: "online",
+		Activities: &newActivities,
 	}
 
 	if idle > 0 {
 		usd.IdleSince = &idle
-	}
-
-	if game != "" {
-		usd.Game = &Game{
-			Name: game,
-			Type: gameType,
-			URL:  url,
-		}
 	}
 
 	return usd


### PR DESCRIPTION
This PR aims to bump discordgo from v6 to v8, as well as add the new Sticker struct that is currently present in the Discord API.

In accordance with the [v8 change logs](https://discord.com/developers/docs/change-log), the following changes have been made:

- `Game` no longer a member of any struct in favor of using `Activities[0]`
- Channel permission overwrite types are now 0 and 1 instead of "role" and "member".
- `Retry-After` header value is now 1 instead of 1000. Similarily, it is parsed using time.Second instead of time.Millisecond
- `delete-message-days` changed to `delete_message_days`.
- Removed `Roles` and `Nick` from the presence update struct
- All permission overwrites now deserialize to `string` instead of `int` but parsed when calculating overwrites

Additionally, the Sticker struct has been added. While it is not in the Discord API documentation, it has been exhibited in stable Discord clients and thus this struct has been built around what is currently known about stickers.
