### PR TITLE
Add previous state to VoiceStateUpdate event (#823)

### DIFF
--- a/events.go
+++ b/events.go
@@ -252,6 +252,8 @@ type VoiceServerUpdate struct {
 // VoiceStateUpdate is the data for a VoiceStateUpdate event.
 type VoiceStateUpdate struct {
 	*VoiceState
+	// BeforeUpdate will be nil if the VoiceState was not previously cached in the state cache.
+	BeforeUpdate *VoiceState `json:"-"`
 }
 
 // MessageDeleteBulk is the data for a MessageDeleteBulk event


### PR DESCRIPTION
Similar to MessageUpdate, this change allows tracking which voice channel a user left from.

This uses the existing VoiceState tracker to include the previous VoiceState as part of the VoiceStateUpdate event.