### PR TITLE
Add support for sending message reply

### DIFF
--- a/message.go
+++ b/message.go
@@ -150,6 +150,7 @@ type MessageSend struct {
 	TTS             bool                    `json:"tts"`
 	Files           []*File                 `json:"-"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
+	Reference       *MessageReference       `json:"message_reference,omitempty"`
 
 	// TODO: Remove this when compatibility is not required.
 	File *File `json:"-"`
@@ -369,6 +370,15 @@ type MessageReference struct {
 	MessageID string `json:"message_id"`
 	ChannelID string `json:"channel_id"`
 	GuildID   string `json:"guild_id"`
+}
+
+// Reference returns MessageReference of given message
+func (m *Message) Reference() *MessageReference {
+	return &MessageReference{
+		GuildID:   m.GuildID,
+		ChannelID: m.ChannelID,
+		MessageID: m.ID,
+	}
 }
 
 // ContentWithMentionsReplaced will replace all @<id> mentions with the

--- a/restapi.go
+++ b/restapi.go
@@ -1629,6 +1629,17 @@ func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed)
 	})
 }
 
+// ChannelMessageSendReply sends a message to the given channel with reference data.
+// channelID : The ID of a Channel.
+// content   : The message to send.
+// reference : The message reference to send.
+func (s *Session) ChannelMessageSendReply(channelID string, content string, reference *MessageReference) (*Message, error) {
+	return s.ChannelMessageSendComplex(channelID, &MessageSend{
+		Content:   content,
+		Reference: reference,
+	})
+}
+
 // ChannelMessageEdit edits an existing message, replacing it entirely with
 // the given content.
 // channelID  : The ID of a Channel


### PR DESCRIPTION
Added the ability to send messages with a response (replying to another message). According to the `message_reference` field in API

https://discord.com/developers/docs/resources/channel#create-message-params

Code example:
```go
session.ChannelMessageSendComplex(channelID, &discordgo.MessageSend{
	Content:   "Test",
	Reference: message.Reference(),
})
```
Or:
```go
session.ChannelMessageSendReply(channelID, "Test", message.Reference())
```

