### PR TITLE
Add omitempty to MessageReference's GuildID field

### DIFF
--- a/message.go
+++ b/message.go
@@ -369,7 +369,7 @@ type MessageApplication struct {
 type MessageReference struct {
 	MessageID string `json:"message_id"`
 	ChannelID string `json:"channel_id"`
-	GuildID   string `json:"guild_id"`
+	GuildID   string `json:"guild_id,omitempty"`
 }
 
 // Reference returns MessageReference of given message


### PR DESCRIPTION
Direct Messages do not have the **guild_id** field for Message Referencing / the new Reply feature.
Instead it is only **message_id** and **guild_id**