### PR TITLE
Fix invalid RateLimit event type

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -155,7 +155,7 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 			return
 		}
 		s.log(LogInformational, "Rate Limiting %s, retry in %d", urlStr, rl.RetryAfter)
-		s.handleEvent(rateLimitEventType, RateLimit{TooManyRequests: &rl, URL: urlStr})
+		s.handleEvent(rateLimitEventType, &RateLimit{TooManyRequests: &rl, URL: urlStr})
 
 		time.Sleep(rl.RetryAfter * time.Millisecond)
 		// we can make the above smarter


### PR DESCRIPTION
Addresses https://github.com/bwmarrin/discordgo/issues/860

Using the test code referenced in that issue produces the following (expected) logs:
```
=== RUN   TestRateLimitEvent
2020/12/30 13:54:06 [DG2] restapi.go:157:RequestWithLockedBucket() Rate Limiting https://discord.com/api/v6/channels/<redacted>/messages, retry in 4873
2020/12/30 13:54:06 Rate limit event triggered
2020/12/30 13:54:06 You are being rate limited.
2020/12/30 13:54:06 [DG2] restapi.go:157:RequestWithLockedBucket() Rate Limiting https://discord.com/api/v6/channels/<redacted>/messages, retry in 4856
2020/12/30 13:54:06 Rate limit event triggered
2020/12/30 13:54:06 You are being rate limited.
```