### PR TITLE
Switch library to API version v8

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -22,7 +22,7 @@ import (
 )
 
 // VERSION of DiscordGo, follows Semantic Versioning. (http://semver.org/)
-const VERSION = "0.22.0"
+const VERSION = "0.23.0-v8alpha"
 
 // ErrMFA will be risen by New when the user has 2FA.
 var ErrMFA = errors.New("account has 2FA enabled")

--- a/discord_test.go
+++ b/discord_test.go
@@ -125,7 +125,7 @@ func TestOpenClose(t *testing.T) {
 	// UpdateStatus - maybe we move this into wsapi_test.go but the websocket
 	// created here is needed.  This helps tests that the websocket was setup
 	// and it is working.
-	if err = d.UpdateStatus(0, time.Now().String()); err != nil {
+	if err = d.UpdateGameStatus(0, time.Now().String()); err != nil {
 		t.Errorf("UpdateStatus error: %+v", err)
 	}
 

--- a/endpoints.go
+++ b/endpoints.go
@@ -14,7 +14,7 @@ package discordgo
 import "strconv"
 
 // APIVersion is the Discord API version used for the REST and Websocket API.
-var APIVersion = "6"
+var APIVersion = "8"
 
 // Known Discord API Endpoints.
 var (

--- a/endpoints.go
+++ b/endpoints.go
@@ -90,7 +90,8 @@ var (
 	EndpointGuildRoles           = func(gID string) string { return EndpointGuilds + gID + "/roles" }
 	EndpointGuildRole            = func(gID, rID string) string { return EndpointGuilds + gID + "/roles/" + rID }
 	EndpointGuildInvites         = func(gID string) string { return EndpointGuilds + gID + "/invites" }
-	EndpointGuildEmbed           = func(gID string) string { return EndpointGuilds + gID + "/embed" }
+	EndpointGuildWidget          = func(gID string) string { return EndpointGuilds + gID + "/widget" }
+	EndpointGuildEmbed           = EndpointGuildWidget
 	EndpointGuildPrune           = func(gID string) string { return EndpointGuilds + gID + "/prune" }
 	EndpointGuildIcon            = func(gID, hash string) string { return EndpointCDNIcons + gID + "/" + hash + ".png" }
 	EndpointGuildIconAnimated    = func(gID, hash string) string { return EndpointCDNIcons + gID + "/" + hash + ".gif" }

--- a/events.go
+++ b/events.go
@@ -196,8 +196,7 @@ type PresencesReplace []*Presence
 // PresenceUpdate is the data for a PresenceUpdate event.
 type PresenceUpdate struct {
 	Presence
-	GuildID string   `json:"guild_id"`
-	Roles   []string `json:"roles"`
+	GuildID string `json:"guild_id"`
 }
 
 // Resumed is the data for a Resumed event.

--- a/examples/airhorn/main.go
+++ b/examples/airhorn/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// We need information about guilds (which includes their channels),
 	// messages and voice states.
-	dg.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuilds | discordgo.IntentsGuildMessages | discordgo.IntentsGuildVoiceStates)
+	dg.Identify.Intents = discordgo.IntentsGuilds | discordgo.IntentsGuildMessages | discordgo.IntentsGuildVoiceStates
 
 	// Open the websocket and begin listening.
 	err = dg.Open()

--- a/examples/airhorn/main.go
+++ b/examples/airhorn/main.go
@@ -78,7 +78,7 @@ func main() {
 func ready(s *discordgo.Session, event *discordgo.Ready) {
 
 	// Set the playing status.
-	s.UpdateStatus(0, "!airhorn")
+	s.UpdateGameStatus(0, "!airhorn")
 }
 
 // This function will be called (due to AddHandler above) every time a new

--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -34,7 +34,7 @@ func main() {
 	dg.AddHandler(messageCreate)
 
 	// In this example, we only care about receiving message events.
-	dg.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuildMessages)
+	dg.Identify.Intents = discordgo.IntentsGuildMessages
 
 	// Open a websocket connection to Discord and begin listening.
 	err = dg.Open()

--- a/examples/voice_receive/main.go
+++ b/examples/voice_receive/main.go
@@ -75,7 +75,7 @@ func main() {
 	defer s.Close()
 
 	// We only really care about receiving voice state updates.
-	s.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuildVoiceStates)
+	s.Identify.Intents = discordgo.IntentsGuildVoiceStates
 
 	err = s.Open()
 	if err != nil {

--- a/message.go
+++ b/message.go
@@ -36,6 +36,8 @@ const (
 	MessageTypeChannelFollowAdd
 	MessageTypeGuildDiscoveryDisqualified = iota + 1
 	MessageTypeGuildDiscoveryRequalified
+	MessageTypeReply = iota + 4
+	MessageTypeApplicationCommand
 )
 
 // A Message stores all data related to a specific Discord message.

--- a/message.go
+++ b/message.go
@@ -34,7 +34,7 @@ const (
 	MessageTypeUserPremiumGuildSubscriptionTierTwo
 	MessageTypeUserPremiumGuildSubscriptionTierThree
 	MessageTypeChannelFollowAdd
-	MessageTypeGuildDiscoveryDisqualified
+	MessageTypeGuildDiscoveryDisqualified = iota + 1
 	MessageTypeGuildDiscoveryRequalified
 )
 

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,6 +1,7 @@
 package discordgo
 
 import (
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -140,20 +141,21 @@ func (b *Bucket) Release(headers http.Header) error {
 	remaining := headers.Get("X-RateLimit-Remaining")
 	reset := headers.Get("X-RateLimit-Reset")
 	global := headers.Get("X-RateLimit-Global")
-	retryAfter := headers.Get("Retry-After")
+	resetAfter := headers.Get("X-RateLimit-Reset-After")
 
 	// Update global and per bucket reset time if the proper headers are available
 	// If global is set, then it will block all buckets until after Retry-After
 	// If Retry-After without global is provided it will use that for the new reset
 	// time since it's more accurate than X-RateLimit-Reset.
 	// If Retry-After after is not proided, it will update the reset time from X-RateLimit-Reset
-	if retryAfter != "" {
-		parsedAfter, err := strconv.ParseInt(retryAfter, 10, 64)
+	if resetAfter != "" {
+		parsedAfter, err := strconv.ParseFloat(resetAfter, 64)
 		if err != nil {
 			return err
 		}
 
-		resetAt := time.Now().Add(time.Duration(parsedAfter) * time.Millisecond)
+		whole, frac := math.Modf(parsedAfter)
+		resetAt := time.Now().Add(time.Duration(whole) * time.Second).Add(time.Duration(frac*1000) * time.Millisecond)
 
 		// Lock either this single bucket or all buckets
 		if global != "" {
@@ -168,7 +170,7 @@ func (b *Bucket) Release(headers http.Header) error {
 			return err
 		}
 
-		unix, err := strconv.ParseInt(reset, 10, 64)
+		unix, err := strconv.ParseFloat(reset, 64)
 		if err != nil {
 			return err
 		}
@@ -177,7 +179,8 @@ func (b *Bucket) Release(headers http.Header) error {
 		// some extra time is added because without it i still encountered 429's.
 		// The added amount is the lowest amount that gave no 429's
 		// in 1k requests
-		delta := time.Unix(unix, 0).Sub(discordTime) + time.Millisecond*250
+		whole, frac := math.Modf(unix)
+		delta := time.Unix(int64(whole), 0).Add(time.Duration(frac*1000)*time.Millisecond).Sub(discordTime) + time.Millisecond*250
 		b.reset = time.Now().Add(delta)
 	}
 

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -57,7 +57,7 @@ func TestRatelimitGlobal(t *testing.T) {
 
 		headers.Set("X-RateLimit-Global", "1")
 		// Reset for approx 1 seconds from now
-		headers.Set("Retry-After", "1000")
+		headers.Set("X-RateLimit-Reset-After", "1")
 
 		err := bucket.Release(headers)
 		if err != nil {

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,6 +1,7 @@
 package discordgo
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
@@ -18,7 +19,7 @@ func TestRatelimitReset(t *testing.T) {
 
 		headers.Set("X-RateLimit-Remaining", "0")
 		// Reset for approx 2 seconds from now
-		headers.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Second*2).Unix(), 10))
+		headers.Set("X-RateLimit-Reset", fmt.Sprint(float64(time.Now().Add(time.Second*2).UnixNano())/1e6))
 		headers.Set("Date", time.Now().Format(time.RFC850))
 
 		err := bucket.Release(headers)
@@ -105,7 +106,7 @@ func sendBenchReq(endpoint string, rl *RateLimiter) {
 	headers := http.Header(make(map[string][]string))
 
 	headers.Set("X-RateLimit-Remaining", "10")
-	headers.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Unix(), 10))
+	headers.Set("X-RateLimit-Reset", fmt.Sprint(float64(time.Now().UnixNano())/1e6))
 	headers.Set("Date", time.Now().Format(time.RFC850))
 
 	bucket.Release(headers)

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -19,7 +19,7 @@ func TestRatelimitReset(t *testing.T) {
 
 		headers.Set("X-RateLimit-Remaining", "0")
 		// Reset for approx 2 seconds from now
-		headers.Set("X-RateLimit-Reset", fmt.Sprint(float64(time.Now().Add(time.Second*2).UnixNano())/1e6))
+		headers.Set("X-RateLimit-Reset", fmt.Sprint(float64(time.Now().Add(time.Second*2).UnixNano())/1e9))
 		headers.Set("Date", time.Now().Format(time.RFC850))
 
 		err := bucket.Release(headers)
@@ -106,7 +106,7 @@ func sendBenchReq(endpoint string, rl *RateLimiter) {
 	headers := http.Header(make(map[string][]string))
 
 	headers.Set("X-RateLimit-Remaining", "10")
-	headers.Set("X-RateLimit-Reset", fmt.Sprint(float64(time.Now().UnixNano())/1e6))
+	headers.Set("X-RateLimit-Reset", fmt.Sprint(float64(time.Now().UnixNano())/1e9))
 	headers.Set("Date", time.Now().Format(time.RFC850))
 
 	bucket.Release(headers)

--- a/restapi.go
+++ b/restapi.go
@@ -715,7 +715,7 @@ func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days 
 
 	queryParams := url.Values{}
 	if days > 0 {
-		queryParams.Set("delete-message-days", strconv.Itoa(days))
+		queryParams.Set("delete_message_days", strconv.Itoa(days))
 	}
 	if reason != "" {
 		queryParams.Set("reason", reason)

--- a/restapi.go
+++ b/restapi.go
@@ -465,7 +465,7 @@ func (s *Session) UserGuildSettingsEdit(guildID string, settings *UserGuildSetti
 //
 // NOTE: This function is now deprecated and will be removed in the future.
 // Please see the same function inside state.go
-func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions int, err error) {
+func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions int64, err error) {
 	// Try to just get permissions from state.
 	apermissions, err = s.State.UserChannelPermissions(userID, channelID)
 	if err == nil {
@@ -507,7 +507,7 @@ func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions
 
 // Calculates the permissions for a member.
 // https://support.discord.com/hc/en-us/articles/206141927-How-is-the-permission-hierarchy-structured-
-func memberPermissions(guild *Guild, channel *Channel, userID string, roles []string) (apermissions int) {
+func memberPermissions(guild *Guild, channel *Channel, userID string, roles []string) (apermissions int64) {
 	if userID == guild.OwnerID {
 		apermissions = PermissionAll
 		return
@@ -542,13 +542,11 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 		}
 	}
 
-	denies := 0
-	allows := 0
-
+	var denies, allows int64
 	// Member overwrites can override role overrides, so do two passes
 	for _, overwrite := range channel.PermissionOverwrites {
 		for _, roleID := range roles {
-			if overwrite.Type == "role" && roleID == overwrite.ID {
+			if overwrite.Type == PermissionOverwriteTypeRole && roleID == overwrite.ID {
 				denies |= overwrite.Deny
 				allows |= overwrite.Allow
 				break
@@ -560,7 +558,7 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 	apermissions |= allows
 
 	for _, overwrite := range channel.PermissionOverwrites {
-		if overwrite.Type == "member" && overwrite.ID == userID {
+		if overwrite.Type == PermissionOverwriteTypeMember && overwrite.ID == userID {
 			apermissions &= ^overwrite.Deny
 			apermissions |= overwrite.Allow
 			break
@@ -1809,13 +1807,13 @@ func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, e
 // ChannelPermissionSet creates a Permission Override for the given channel.
 // NOTE: This func name may changed.  Using Set instead of Create because
 // you can both create a new override or update an override with this function.
-func (s *Session) ChannelPermissionSet(channelID, targetID, targetType string, allow, deny int) (err error) {
+func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType PermissionOverwriteType, allow, deny int) (err error) {
 
 	data := struct {
-		ID    string `json:"id"`
-		Type  string `json:"type"`
-		Allow int    `json:"allow"`
-		Deny  int    `json:"deny"`
+		ID    string                  `json:"id"`
+		Type  PermissionOverwriteType `json:"type"`
+		Allow int                     `json:"allow"`
+		Deny  int                     `json:"deny"`
 	}{targetID, targetType, allow, deny}
 
 	_, err = s.RequestWithBucketID("PUT", EndpointChannelPermission(channelID, targetID), data, EndpointChannelPermission(channelID, ""))

--- a/state.go
+++ b/state.go
@@ -997,7 +997,7 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 // UserChannelPermissions returns the permission of a user in a channel.
 // userID    : The ID of the user to calculate permissions for.
 // channelID : The ID of the channel to calculate permission for.
-func (s *State) UserChannelPermissions(userID, channelID string) (apermissions int, err error) {
+func (s *State) UserChannelPermissions(userID, channelID string) (apermissions int64, err error) {
 	if s == nil {
 		return 0, ErrNilState
 	}
@@ -1022,7 +1022,7 @@ func (s *State) UserChannelPermissions(userID, channelID string) (apermissions i
 
 // MessagePermissions returns the permissions of the author of the message
 // in the channel in which it was sent.
-func (s *State) MessagePermissions(message *Message) (apermissions int, err error) {
+func (s *State) MessagePermissions(message *Message) (apermissions int64, err error) {
 	if s == nil {
 		return 0, ErrNilState
 	}

--- a/state.go
+++ b/state.go
@@ -200,13 +200,9 @@ func (s *State) PresenceAdd(guildID string, presence *Presence) error {
 			//guild.Presences[i] = presence
 
 			//Update status
-			guild.Presences[i].Game = presence.Game
-			guild.Presences[i].Roles = presence.Roles
+			guild.Presences[i].Activities = presence.Activities
 			if presence.Status != "" {
 				guild.Presences[i].Status = presence.Status
-			}
-			if presence.Nick != "" {
-				guild.Presences[i].Nick = presence.Nick
 			}
 
 			//Update the optionally sent user information
@@ -966,24 +962,12 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 				// Member not found; this is a user coming online
 				m = &Member{
 					GuildID: t.GuildID,
-					Nick:    t.Nick,
 					User:    t.User,
-					Roles:   t.Roles,
 				}
-
 			} else {
-
-				if t.Nick != "" {
-					m.Nick = t.Nick
-				}
-
 				if t.User.Username != "" {
 					m.User.Username = t.User.Username
 				}
-
-				// PresenceUpdates always contain a list of roles, so there's no need to check for an empty list here
-				m.Roles = t.Roles
-
 			}
 
 			err = s.MemberAdd(m)

--- a/structs.go
+++ b/structs.go
@@ -817,6 +817,8 @@ type TooManyRequests struct {
 	RetryAfter time.Duration `json:"retry_after"`
 }
 
+// UnmarshalJSON helps support translation of a milliseconds-based float
+// into a time.Duration on TooManyRequests.
 func (t *TooManyRequests) UnmarshalJSON(b []byte) error {
 	u := struct {
 		Bucket     string  `json:"bucket"`

--- a/structs.go
+++ b/structs.go
@@ -437,9 +437,6 @@ type Guild struct {
 	// The ID of the AFK voice channel.
 	AfkChannelID string `json:"afk_channel_id"`
 
-	// The ID of the embed channel ID, used for embed widgets.
-	EmbedChannelID string `json:"embed_channel_id"`
-
 	// The user ID of the owner of the guild.
 	OwnerID string `json:"owner_id"`
 
@@ -467,9 +464,6 @@ type Guild struct {
 
 	// The verification level required for the guild.
 	VerificationLevel VerificationLevel `json:"verification_level"`
-
-	// Whether the guild has embedding enabled.
-	EmbedEnabled bool `json:"embed_enabled"`
 
 	// Whether the guild is considered large. This is
 	// determined by a member threshold in the identify packet,

--- a/structs.go
+++ b/structs.go
@@ -14,6 +14,7 @@ package discordgo
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -692,39 +693,10 @@ type VoiceState struct {
 
 // A Presence stores the online, offline, or idle and game status of Guild members.
 type Presence struct {
-	User       *User    `json:"user"`
-	Status     Status   `json:"status"`
-	Game       *Game    `json:"game"`
-	Activities []*Game  `json:"activities"`
-	Nick       string   `json:"nick"`
-	Roles      []string `json:"roles"`
-	Since      *int     `json:"since"`
-}
-
-// GameType is the type of "game" (see GameType* consts) in the Game struct
-type GameType int
-
-// Valid GameType values
-const (
-	GameTypeGame GameType = iota
-	GameTypeStreaming
-	GameTypeListening
-	GameTypeWatching
-	GameTypeCustom
-)
-
-// A Game struct holds the name of the "playing .." game for a user
-type Game struct {
-	Name          string     `json:"name"`
-	Type          GameType   `json:"type"`
-	URL           string     `json:"url,omitempty"`
-	Details       string     `json:"details,omitempty"`
-	State         string     `json:"state,omitempty"`
-	TimeStamps    TimeStamps `json:"timestamps,omitempty"`
-	Assets        Assets     `json:"assets,omitempty"`
-	ApplicationID string     `json:"application_id,omitempty"`
-	Instance      int8       `json:"instance,omitempty"`
-	// TODO: Party and Secrets (unknown structure)
+	User       *User       `json:"user"`
+	Status     Status      `json:"status"`
+	Activities []*Activity `json:"activities"`
+	Since      *int        `json:"since"`
 }
 
 // A TimeStamps struct contains start and end times used in the rich presence "playing .." Game
@@ -1153,7 +1125,7 @@ type ActivityType int
 
 // Valid ActivityType values
 const (
-	ActivityTypeGame GameType = iota
+	ActivityTypeGame ActivityType = iota
 	ActivityTypeStreaming
 	ActivityTypeListening
 	//	ActivityTypeWatching // not valid in this use case?

--- a/structs.go
+++ b/structs.go
@@ -845,6 +845,24 @@ type TooManyRequests struct {
 	RetryAfter time.Duration `json:"retry_after"`
 }
 
+func (t *TooManyRequests) UnmarshalJSON(b []byte) error {
+	u := struct {
+		Bucket     string  `json:"bucket"`
+		Message    string  `json:"message"`
+		RetryAfter float64 `json:"retry_after"`
+	}{}
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		return err
+	}
+
+	t.Bucket = u.Bucket
+	t.Message = u.Message
+	whole, frac := math.Modf(u.RetryAfter)
+	t.RetryAfter = time.Duration(whole)*time.Second + time.Duration(frac*1000)*time.Millisecond
+	return nil
+}
+
 // A ReadState stores data on the read state of channels.
 type ReadState struct {
 	MentionCount  int    `json:"mention_count"`

--- a/structs.go
+++ b/structs.go
@@ -611,7 +611,7 @@ type UserGuild struct {
 	Name        string `json:"name"`
 	Icon        string `json:"icon"`
 	Owner       bool   `json:"owner"`
-	Permissions int    `json:"permissions"`
+	Permissions int64  `json:"permissions,string"`
 }
 
 // A GuildParams stores all the data needed to update discord guild settings

--- a/structs.go
+++ b/structs.go
@@ -1158,7 +1158,7 @@ type Identify struct {
 	Shard              *[2]int             `json:"shard,omitempty"`
 	Presence           GatewayStatusUpdate `json:"presence,omitempty"`
 	GuildSubscriptions bool                `json:"guild_subscriptions"`
-	Intents            *Intent             `json:"intents,omitempty"`
+	Intents            Intent              `json:"intents"`
 }
 
 // IdentifyProperties contains the "properties" portion of an Identify packet
@@ -1345,7 +1345,9 @@ const (
 	IntentsNone Intent = 0
 )
 
-// MakeIntent helps convert a gateway intent value for use in the Identify structure.
-func MakeIntent(intents Intent) *Intent {
-	return &intents
+// MakeIntent used to help convert a gateway intent value for use in the Identify structure;
+// this was useful to help support the use of a pointer type when intents were optional.
+// This is now a no-op, and is not necessary to use.
+func MakeIntent(intents Intent) Intent {
+	return intents
 }

--- a/structs.go
+++ b/structs.go
@@ -322,12 +322,22 @@ type ChannelFollow struct {
 	WebhookID string `json:"webhook_id"`
 }
 
+// PermissionOverwriteType represents the type of resource on which
+// a permission overwrite acts.
+type PermissionOverwriteType int
+
+// The possible permission overwrite types.
+const (
+	PermissionOverwriteTypeRole PermissionOverwriteType = iota
+	PermissionOverwriteTypeMember
+)
+
 // A PermissionOverwrite holds permission overwrite data for a Channel
 type PermissionOverwrite struct {
-	ID    string `json:"id"`
-	Type  string `json:"type"`
-	Deny  int    `json:"deny"`
-	Allow int    `json:"allow"`
+	ID    string                  `json:"id"`
+	Type  PermissionOverwriteType `json:"type"`
+	Deny  int64                   `json:"deny,string"`
+	Allow int64                   `json:"allow,string"`
 }
 
 // Emoji struct holds data related to Emoji's
@@ -564,7 +574,7 @@ type Guild struct {
 	ApproximatePresenceCount int `json:"approximate_presence_count"`
 
 	// Permissions of our user
-	Permissions int `json:"permissions"`
+	Permissions int64 `json:"permissions,string"`
 }
 
 // MessageNotifications is the notification level for a guild
@@ -650,7 +660,7 @@ type Role struct {
 	// The permissions of the role on the guild (doesn't include channel overrides).
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the permission.
-	Permissions int `json:"permissions"`
+	Permissions int64 `json:"permissions,string"`
 }
 
 // Mention returns a string which mentions the role

--- a/wsapi.go
+++ b/wsapi.go
@@ -353,7 +353,7 @@ func newUpdateStatusData(idle int, activityType ActivityType, name, url string) 
 	return usd
 }
 
-// UpdateStatus is used to update the user's status.
+// UpdateGameStatus is used to update the user's status.
 // If idle>0 then set status to idle.
 // If name!="" then set game.
 // if otherwise, set status to active, and no activity.

--- a/wsapi.go
+++ b/wsapi.go
@@ -322,10 +322,10 @@ func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}
 
 // UpdateStatusData ia provided to UpdateStatusComplex()
 type UpdateStatusData struct {
-	IdleSince *int   `json:"since"`
-	Game      *Game  `json:"game"`
-	AFK       bool   `json:"afk"`
-	Status    string `json:"status"`
+	IdleSince  *int        `json:"since"`
+	Activities []*Activity `json:"activities"`
+	AFK        bool        `json:"afk"`
+	Status     string      `json:"status"`
 }
 
 type updateStatusOp struct {
@@ -333,7 +333,7 @@ type updateStatusOp struct {
 	Data UpdateStatusData `json:"d"`
 }
 
-func newUpdateStatusData(idle int, gameType GameType, game, url string) *UpdateStatusData {
+func newUpdateStatusData(idle int, activityType ActivityType, name, url string) *UpdateStatusData {
 	usd := &UpdateStatusData{
 		Status: "online",
 	}
@@ -342,12 +342,12 @@ func newUpdateStatusData(idle int, gameType GameType, game, url string) *UpdateS
 		usd.IdleSince = &idle
 	}
 
-	if game != "" {
-		usd.Game = &Game{
-			Name: game,
-			Type: gameType,
+	if name != "" {
+		usd.Activities = []*Activity{{
+			Name: name,
+			Type: activityType,
 			URL:  url,
-		}
+		}}
 	}
 
 	return usd
@@ -355,30 +355,30 @@ func newUpdateStatusData(idle int, gameType GameType, game, url string) *UpdateS
 
 // UpdateStatus is used to update the user's status.
 // If idle>0 then set status to idle.
-// If game!="" then set game.
-// if otherwise, set status to active, and no game.
-func (s *Session) UpdateStatus(idle int, game string) (err error) {
-	return s.UpdateStatusComplex(*newUpdateStatusData(idle, GameTypeGame, game, ""))
+// If name!="" then set game.
+// if otherwise, set status to active, and no activity.
+func (s *Session) UpdateGameStatus(idle int, name string) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(idle, ActivityTypeGame, name, ""))
 }
 
 // UpdateStreamingStatus is used to update the user's streaming status.
 // If idle>0 then set status to idle.
-// If game!="" then set game.
-// If game!="" and url!="" then set the status type to streaming with the URL set.
+// If name!="" then set game.
+// If name!="" and url!="" then set the status type to streaming with the URL set.
 // if otherwise, set status to active, and no game.
-func (s *Session) UpdateStreamingStatus(idle int, game string, url string) (err error) {
-	gameType := GameTypeGame
+func (s *Session) UpdateStreamingStatus(idle int, name string, url string) (err error) {
+	gameType := ActivityTypeGame
 	if url != "" {
-		gameType = GameTypeStreaming
+		gameType = ActivityTypeStreaming
 	}
-	return s.UpdateStatusComplex(*newUpdateStatusData(idle, gameType, game, url))
+	return s.UpdateStatusComplex(*newUpdateStatusData(idle, gameType, name, url))
 }
 
 // UpdateListeningStatus is used to set the user to "Listening to..."
-// If game!="" then set to what user is listening to
-// Else, set user to active and no game.
-func (s *Session) UpdateListeningStatus(game string) (err error) {
-	return s.UpdateStatusComplex(*newUpdateStatusData(0, GameTypeListening, game, ""))
+// If name!="" then set to what user is listening to
+// Else, set user to active and no activity.
+func (s *Session) UpdateListeningStatus(name string) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(0, ActivityTypeListening, name, ""))
 }
 
 // UpdateStatusComplex allows for sending the raw status update data untouched by discordgo.


### PR DESCRIPTION
Hi all!

I'm currently in the process of implementing API version 8 support; there was a previous PR, but it seems to have stalled out (with the user contributing having their account vanish). I've started an implementation on the `v8` branch, and would appreciate some review on it before we go ahead and merge!

There are some breaking changes: the `Game` struct is completely gone (the API doesn't have any such concept anymore), and `UpdateStatus` was changed to `UpdateGameStatus` to better reflect the true meaning of it now that games don't have elevated status; presences no longer contain information about nicknames and roles, which are now relegated to members; permissions are now represented throughout the library by `int64` rather than `int` now that they can go above 31 bits; permission overwrite types switched from a string to an integer type. There might be some I missed. Although breaking changes are never desired, they correspond to the breaking nature of switching API versions, and the current tags will still exist for those looking to remain on v6.

The ultimate goal here is to get the changes into the hands of users, as there are inevitably changes that won't be picked up by the test suite (this does speak to the quality of the test suite to an extent, but fully modeling API behavior is also hard). v6 is going by the wayside soon, and this should help propel DiscordGo into a better position for the future!