### PR TITLE
Add more to Activity struct.

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1116,9 +1116,11 @@ type GatewayStatusUpdate struct {
 // Activity defines the Activity sent with GatewayStatusUpdate
 // https://discord.com/developers/docs/topics/gateway#activity-object
 type Activity struct {
-	Name string       `json:"name"`
-	Type ActivityType `json:"type"`
-	URL  string       `json:"url,omitempty"`
+	Name    string       `json:"name"`
+	Type    ActivityType `json:"type"`
+	URL     string       `json:"url,omitempty"`
+	Details string       `json:"details,omitempty"`
+	State   string       `json:"state,omitempty"`
 }
 
 // ActivityType is the type of Activity (see ActivityType* consts) in the Activity struct


### PR DESCRIPTION
When I was making a bot to track Spotify playing presences, I noticed that discordgo didn't support seeing the song or author of the Spotify presence. This change adds support for that, not just for Spotify though, Spotify is just an example. Refer to [docs](https://discord.com/developers/docs/topics/gateway#activity-object) for more information on these fields.