### PR TITLE
Fix slash commands example bug

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -150,6 +150,7 @@ var (
 							Value: 5,
 						},
 					},
+					Required: true,
 				},
 			},
 		},


### PR DESCRIPTION
This fixes a bug in the slash commands example that causes an out-of-range error. 