### PR TITLE
Add in some missing permission constants

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1167,6 +1167,7 @@ const (
 	PermissionReadMessageHistory
 	PermissionMentionEveryone
 	PermissionUseExternalEmojis
+	PermissionUseSlashCommands = 1 << (iota + 22)
 )
 
 // Constants for the different bit offsets of voice permissions
@@ -1178,6 +1179,8 @@ const (
 	PermissionVoiceMoveMembers
 	PermissionVoiceUseVAD
 	PermissionVoicePrioritySpeaker = 1 << (iota + 2)
+	PermissionVoiceStreamVideo
+	PermissionVoiceRequestToSpeak = 1 << (iota + 24)
 )
 
 // Constants for general management.
@@ -1199,7 +1202,8 @@ const (
 	PermissionManageServer
 	PermissionAddReactions
 	PermissionViewAuditLogs
-	PermissionViewChannel = 1 << (iota + 2)
+	PermissionViewChannel       = 1 << (iota + 2)
+	PermissionViewGuildInsights = 1 << (iota + 10)
 
 	PermissionAllText = PermissionViewChannel |
 		PermissionSendMessages |


### PR DESCRIPTION
Half of what i mentioned in #904, adds in the 4 missing permissions constants, specifically:
- `1 << _9` PermissionVoiceStreamVideo
- `1 << 19` PermissionViewGuildInsights
- `1 << 31` PermissionUseSlashCommands
- `1 << 32` PermissionRequestToSpeak

to quote from the issue
> (the latter 2 are not currently in the official documentation, and the last one was only added within the past week, but being they are launched features i don't think they'll see any sudden changes at this point and are probably safe to add, and the former 2 have been around for awhile and really shouldn't be missing)

Nothing else, just adds those 4 constants