### PR TITLE
Webhook files

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -40,5 +40,6 @@ type WebhookParams struct {
 type WebhookEdit struct {
 	Content         string                  `json:"content,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
+	Files           []*File                 `json:"-"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 }


### PR DESCRIPTION
Webhook edits can now add files to messages.

https://discord.com/developers/docs/resources/webhook#edit-webhook-message


The code for sending files is nearly identical to the code in `WebhookExecute` and `ChannelMessageSendComplex`. Should I move the duplicate code in all 3 functions to a helper function?