### PR TITLE
Fix RateLimitPerUser on Channel Create/Edit

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -962,7 +962,7 @@ type GuildChannelCreateData struct {
 	Topic                string                 `json:"topic,omitempty"`
 	Bitrate              int                    `json:"bitrate,omitempty"`
 	UserLimit            int                    `json:"user_limit,omitempty"`
-	RateLimitPerUser     int                    `json:"rate_limit_per_user,omitempty"`
+	RateLimitPerUser     *int                    `json:"rate_limit_per_user,omitempty"`
 	Position             int                    `json:"position,omitempty"`
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
 	ParentID             string                 `json:"parent_id,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -315,7 +315,7 @@ type ChannelEdit struct {
 	UserLimit            int                    `json:"user_limit,omitempty"`
 	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
 	ParentID             string                 `json:"parent_id,omitempty"`
-	RateLimitPerUser     int                    `json:"rate_limit_per_user,omitempty"`
+	RateLimitPerUser     *int                    `json:"rate_limit_per_user,omitempty"`
 }
 
 // A ChannelFollow holds data returned after following a news channel

--- a/structs.go
+++ b/structs.go
@@ -1087,7 +1087,7 @@ type UserGuildSettingsEdit struct {
 	Muted                bool                                         `json:"muted"`
 	MobilePush           bool                                         `json:"mobile_push"`
 	MessageNotifications int                                          `json:"message_notifications"`
-	ChannelOverrides     map[string]*UserGuildSettingsChannelOverride `json:"channel_overrides"`
+	ChannelOverrides     []*UserGuildSettingsChannelOverride `json:"channel_overrides"`
 }
 
 // An APIErrorMessage is an api error message returned from discord


### PR DESCRIPTION
I noticed you couldn't properly turn off "slow-mode" (RateLimitPerUser) as 0 is considered empty in the struct, I also noticed someone else tried (#811)  to fix this issue and was denied as if (RateLimitPerUser) was not specified it would remove slow-mode entirely. My proposal of a fix includes passing through a pointer instead of the integer itself. It works functionally the same, just with a pointer, It is not the "cleanest" fix but at least it works. 

My proposal:
  ```go
	seconds := 0
	s.ChannelEditComplex("ChanID", &discordgo.ChannelEdit{
		RateLimitPerUser: &sec, // this is what has been changed
	})
```

Currently (Non-Functioning):
```go
	s.ChannelEditComplex("ChanID", &discordgo.ChannelEdit{
		RateLimitPerUser: 0, // this will do nothing as it was omitted as it was considered "empty".
	})
 ```
