### PR TITLE
Update unmarshal function to wrap ErrJSONUnmarshal. Requires at least Go 1.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
     - 1.13.x
     - 1.14.x
     - 1.15.x
+    - 1.16.x
 env:
     - GO111MODULE=on
 install:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/bwmarrin/discordgo
 
+go 1.13
+
 require (
 	github.com/gorilla/websocket v1.4.2
-	golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16
+	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 )
-
-go 1.10

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=
-golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/restapi.go
+++ b/restapi.go
@@ -178,7 +178,7 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 func unmarshal(data []byte, v interface{}) error {
 	err := json.Unmarshal(data, v)
 	if err != nil {
-		return ErrJSONUnmarshal
+		return fmt.Errorf("%w: %s", ErrJSONUnmarshal, err)
 	}
 
 	return nil

--- a/restapi_test.go
+++ b/restapi_test.go
@@ -1,6 +1,7 @@
 package discordgo
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -285,3 +286,10 @@ func TestGuildPrune(t *testing.T) {
 	}
 }
 */
+
+func Test_unmarshal(t *testing.T) {
+	err := unmarshal([]byte{}, &struct{}{})
+	if !errors.Is(err, ErrJSONUnmarshal) {
+		t.Errorf("Unexpected error type: %T", err)
+	}
+}


### PR DESCRIPTION
Update unmarshal function to wrap ErrJSONUnmarshal and return specific error message.

Requires at least Go 1.13.

Resolves #923