### PR TITLE
Fix all the typos that goreportcard detected.

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -102,7 +102,7 @@ var (
 					Description: "Subcommands group",
 					Options: []*discordgo.ApplicationCommandOption{
 						// Also, subcommand groups aren't capable of
-						// containg options, by the name of them, you can see
+						// containing options, by the name of them, you can see
 						// they can only contain subcommands
 						{
 							Name:        "nst-subcmd",

--- a/interactions.go
+++ b/interactions.go
@@ -150,7 +150,7 @@ func (o ApplicationCommandInteractionDataOption) BoolValue() bool {
 }
 
 // ChannelValue is a utility function for casting option value to channel object.
-// s : Session object, if not nil, function additionaly fetches all channel's data
+// s : Session object, if not nil, function additionally fetches all channel's data
 func (o ApplicationCommandInteractionDataOption) ChannelValue(s *Session) *Channel {
 	chanID := o.StringValue()
 	if chanID == "" {
@@ -173,7 +173,7 @@ func (o ApplicationCommandInteractionDataOption) ChannelValue(s *Session) *Chann
 }
 
 // RoleValue is a utility function for casting option value to role object.
-// s : Session object, if not nil, function additionaly fetches all role's data
+// s : Session object, if not nil, function additionally fetches all role's data
 func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID string) *Role {
 	roleID := o.StringValue()
 	if roleID == "" {
@@ -201,7 +201,7 @@ func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID strin
 }
 
 // UserValue is a utility function for casting option value to user object.
-// s : Session object, if not nil, function additionaly fetches all user's data
+// s : Session object, if not nil, function additionally fetches all user's data
 func (o ApplicationCommandInteractionDataOption) UserValue(s *Session) *User {
 	userID := o.StringValue()
 	if userID == "" {

--- a/structs.go
+++ b/structs.go
@@ -95,7 +95,7 @@ type Session struct {
 	// The user agent used for REST APIs
 	UserAgent string
 
-	// Stores the last HeartbeatAck that was recieved (in UTC)
+	// Stores the last HeartbeatAck that was received (in UTC)
 	LastHeartbeatAck time.Time
 
 	// Stores the last Heartbeat sent (in UTC)

--- a/wsapi.go
+++ b/wsapi.go
@@ -384,7 +384,7 @@ func (s *Session) UpdateListeningStatus(name string) (err error) {
 // UpdateStatusComplex allows for sending the raw status update data untouched by discordgo.
 func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
 	// The comment does say "untouched by discordgo", but we might need to lie a bit here.
-	// The Discord documentation lists `activites` as being nullable, but in practice this
+	// The Discord documentation lists `activities` as being nullable, but in practice this
 	// doesn't seem to be the case. I had filed an issue about this at
 	// https://github.com/discord/discord-api-docs/issues/2559, but as of writing this
 	// haven't had any movement on it, so at this point I'm assuming this is an error,
@@ -766,13 +766,13 @@ func (s *Session) identify() error {
 	s.log(LogDebug, "called")
 
 	// TODO: This is a temporary block of code to help
-	// maintain backwards compatability
+	// maintain backwards compatibility
 	if s.Compress == false {
 		s.Identify.Compress = false
 	}
 
 	// TODO: This is a temporary block of code to help
-	// maintain backwards compatability
+	// maintain backwards compatibility
 	if s.Token != "" && s.Identify.Token == "" {
 		s.Identify.Token = s.Token
 	}


### PR DESCRIPTION
Fixed all the misspells Go Report Card found except "themselvs" which is not in the code anymore.