### PR TITLE
Add a toggle for ephemeral messages to slash commands response

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -252,6 +252,8 @@ type InteractionApplicationCommandResponseData struct {
 	Content         string                  `json:"content,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
+	
+	Ephemeral       bool
 
 	// NOTE: Undocumented feature, be careful with it.
 	Flags uint64 `json:"flags,omitempty"`

--- a/restapi.go
+++ b/restapi.go
@@ -2533,6 +2533,10 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) error {
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
+	if resp.Data.Ephemeral {
+		resp.Data.Flags = 1 << 6
+	}
+
 	_, err := s.RequestWithBucketID("POST", endpoint, *resp, endpoint)
 
 	return err

--- a/restapi.go
+++ b/restapi.go
@@ -2533,8 +2533,10 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) error {
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
-	if resp.Data.Ephemeral {
-		resp.Data.Flags = 1 << 6
+	if resp.Data != nil {
+		if resp.Data.Ephemeral {
+			resp.Data.Flags = 1 << 6
+		}
 	}
 
 	_, err := s.RequestWithBucketID("POST", endpoint, *resp, endpoint)


### PR DESCRIPTION
Just an ease-of-use feature, does not break the API because it defaults to `false`.

I can also change `1 << 6` to `64`, if that's possible.

This maybe could've been done better, but this is how I implemented it for myself locally to test.