### PR TITLE
Remove deprecated response types

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -247,12 +247,6 @@ var (
 			// As you can see, the response type names used here are pretty self-explanatory,
 			// but for those who want more information see the official documentation
 			switch i.Data.Options[0].IntValue() {
-			case int64(discordgo.InteractionResponseChannelMessage):
-				content =
-					"Well, you just responded to an interaction, and sent a message.\n" +
-						"That's all what I wanted to say, yeah."
-				content +=
-					"\nAlso... you can edit your response, wait 5 seconds and this message will be changed"
 			case int64(discordgo.InteractionResponseChannelMessageWithSource):
 				content =
 					"You just responded to an interaction, sent a message and showed the original one. " +

--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -134,19 +134,11 @@ var (
 					Type:        discordgo.ApplicationCommandOptionInteger,
 					Choices: []*discordgo.ApplicationCommandOptionChoice{
 						{
-							Name:  "Acknowledge",
-							Value: 2,
-						},
-						{
-							Name:  "Channel message",
-							Value: 3,
-						},
-						{
 							Name:  "Channel message with source",
 							Value: 4,
 						},
 						{
-							Name:  "Acknowledge with source",
+							Name:  "Deferred response With Source",
 							Value: 5,
 						},
 					},

--- a/interactions.go
+++ b/interactions.go
@@ -226,12 +226,11 @@ type InteractionResponseType uint8
 // Interaction response types.
 const (
 	// InteractionResponsePong is for ACK ping event.
-	InteractionResponsePong = InteractionResponseType(iota + 1)
+	InteractionResponsePong InteractionResponseType = 1
 	// InteractionResponseChannelMessageWithSource is for responding with a message, showing the user's input.
-	InteractionResponseChannelMessageWithSource
+	InteractionResponseChannelMessageWithSource InteractionResponseType = 4
 	// InteractionResponseDeferredChannelMessageWithSource acknowledges that the event was received, and that a follow-up will come later.
-	// It was previously named InteractionResponseACKWithSource.
-	InteractionResponseDeferredChannelMessageWithSource
+	InteractionResponseDeferredChannelMessageWithSource InteractionResponseType = 5
 )
 
 // InteractionResponse represents a response for an interaction event.

--- a/interactions.go
+++ b/interactions.go
@@ -227,12 +227,6 @@ type InteractionResponseType uint8
 const (
 	// InteractionResponsePong is for ACK ping event.
 	InteractionResponsePong = InteractionResponseType(iota + 1)
-	// InteractionResponseAcknowledge is for ACK a command without sending a message, eating the user's input.
-	// Deprecated: this response type is no longer supported.
-	InteractionResponseAcknowledge
-	// InteractionResponseChannelMessage is for responding with a message, eating the user's input.
-	// Deprecated: this response type is no longer supported.
-	InteractionResponseChannelMessage
 	// InteractionResponseChannelMessageWithSource is for responding with a message, showing the user's input.
 	InteractionResponseChannelMessageWithSource
 	// InteractionResponseDeferredChannelMessageWithSource acknowledges that the event was received, and that a follow-up will come later.

--- a/interactions.go
+++ b/interactions.go
@@ -228,10 +228,10 @@ const (
 	// InteractionResponsePong is for ACK ping event.
 	InteractionResponsePong = InteractionResponseType(iota + 1)
 	// InteractionResponseAcknowledge is for ACK a command without sending a message, eating the user's input.
-	// NOTE: this type is being imminently deprecated, and **will be removed when this occurs.**
+	// Deprecated: this response type is no longer supported.
 	InteractionResponseAcknowledge
 	// InteractionResponseChannelMessage is for responding with a message, eating the user's input.
-	// NOTE: this type is being imminently deprecated, and **will be removed when this occurs.**
+	// Deprecated: this response type is no longer supported.
 	InteractionResponseChannelMessage
 	// InteractionResponseChannelMessageWithSource is for responding with a message, showing the user's input.
 	InteractionResponseChannelMessageWithSource


### PR DESCRIPTION
~~These types were not registering as deprecated in GoLand. I updated them so that they would be recognized as deprecated.~~
Remove deprecated types as stated by the previous comments.

Relevant discord documentation: https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactioncallbacktype