### PR TITLE
support allowing webhook edits with files, and responding to interactions with files

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -40,6 +40,10 @@ var (
 			Description: "Basic command",
 		},
 		{
+			Name: "basic-command-with-files",
+			Description: "Basic command with files",
+		},
+		{
 			Name:        "options",
 			Description: "Command for demonstrating options",
 			Options: []*discordgo.ApplicationCommandOption{
@@ -165,6 +169,21 @@ var (
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionApplicationCommandResponseData{
 					Content: "Hey there! Congratulations, you just executed your first slash command",
+				},
+			})
+		},
+		"basic-command-with-files": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Files: []*discordgo.File{
+					{
+						ContentType: "text/plain",
+						Name: "test.txt",
+						Reader: strings.NewReader("Hello Discord!!"),
+					},
+				},
+				Data: &discordgo.InteractionApplicationCommandResponseData{
+					Content: "Hey there! Congratulations, you just executed your first slash command with a file in the response",
 				},
 			})
 		},

--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -175,7 +175,7 @@ var (
 						Reader:      strings.NewReader("Hello Discord!!"),
 					},
 				},
-				Data: &discordgo.InteractionApplicationCommandResponseData{
+				Data: &discordgo.InteractionResponseData{
 					Content: "Hey there! Congratulations, you just executed your first slash command with a file in the response",
 				},
 			})

--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -168,15 +168,15 @@ var (
 		"basic-command-with-files": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
-				Files: []*discordgo.File{
-					{
-						ContentType: "text/plain",
-						Name:        "test.txt",
-						Reader:      strings.NewReader("Hello Discord!!"),
-					},
-				},
 				Data: &discordgo.InteractionResponseData{
 					Content: "Hey there! Congratulations, you just executed your first slash command with a file in the response",
+					Files: []*discordgo.File{
+						{
+							ContentType: "text/plain",
+							Name:        "test.txt",
+							Reader:      strings.NewReader("Hello Discord!!"),
+						},
+					},
 				},
 			})
 		},

--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -40,7 +41,7 @@ var (
 			Description: "Basic command",
 		},
 		{
-			Name: "basic-command-with-files",
+			Name:        "basic-command-with-files",
 			Description: "Basic command with files",
 		},
 		{
@@ -178,8 +179,8 @@ var (
 				Files: []*discordgo.File{
 					{
 						ContentType: "text/plain",
-						Name: "test.txt",
-						Reader: strings.NewReader("Hello Discord!!"),
+						Name:        "test.txt",
+						Reader:      strings.NewReader("Hello Discord!!"),
 					},
 				},
 				Data: &discordgo.InteractionApplicationCommandResponseData{

--- a/interactions.go
+++ b/interactions.go
@@ -327,7 +327,7 @@ const (
 // InteractionResponse represents a response for an interaction event.
 type InteractionResponse struct {
 	Type  InteractionResponseType  `json:"type,omitempty"`
-  Files []*File                 `json:"-"`
+	Files []*File                  `json:"-"`
 	Data  *InteractionResponseData `json:"data,omitempty"`
 }
 

--- a/interactions.go
+++ b/interactions.go
@@ -242,8 +242,9 @@ const (
 
 // InteractionResponse represents a response for an interaction event.
 type InteractionResponse struct {
-	Type InteractionResponseType                    `json:"type,omitempty"`
-	Data *InteractionApplicationCommandResponseData `json:"data,omitempty"`
+	Type  InteractionResponseType                    `json:"type,omitempty"`
+	Files []*File `json:"-"`
+	Data  *InteractionApplicationCommandResponseData `json:"data,omitempty"`
 }
 
 // InteractionApplicationCommandResponseData is response data for a slash command interaction.
@@ -252,7 +253,6 @@ type InteractionApplicationCommandResponseData struct {
 	Content         string                  `json:"content,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
-	Files           []*File `json:"-"`
 
 	// NOTE: Undocumented feature, be careful with it.
 	Flags uint64 `json:"flags,omitempty"`

--- a/interactions.go
+++ b/interactions.go
@@ -243,7 +243,7 @@ const (
 // InteractionResponse represents a response for an interaction event.
 type InteractionResponse struct {
 	Type  InteractionResponseType                    `json:"type,omitempty"`
-	Files []*File `json:"-"`
+	Files []*File                                    `json:"-"`
 	Data  *InteractionApplicationCommandResponseData `json:"data,omitempty"`
 }
 

--- a/interactions.go
+++ b/interactions.go
@@ -326,9 +326,8 @@ const (
 
 // InteractionResponse represents a response for an interaction event.
 type InteractionResponse struct {
-	Type  InteractionResponseType  `json:"type,omitempty"`
-	Files []*File                  `json:"-"`
-	Data  *InteractionResponseData `json:"data,omitempty"`
+	Type InteractionResponseType  `json:"type,omitempty"`
+	Data *InteractionResponseData `json:"data,omitempty"`
 }
 
 // InteractionResponseData is response data for an interaction.
@@ -341,6 +340,8 @@ type InteractionResponseData struct {
 
 	// NOTE: Undocumented feature, be careful with it.
 	Flags uint64 `json:"flags,omitempty"`
+
+	Files []*File `json:"-"`
 }
 
 // VerifyInteraction implements message verification of the discord interactions api

--- a/interactions.go
+++ b/interactions.go
@@ -252,6 +252,7 @@ type InteractionApplicationCommandResponseData struct {
 	Content         string                  `json:"content,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
+	Files           []*File `json:"-"`
 
 	// NOTE: Undocumented feature, be careful with it.
 	Flags uint64 `json:"flags,omitempty"`

--- a/restapi.go
+++ b/restapi.go
@@ -1571,7 +1571,7 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 
 	var response []byte
 	if len(files) > 0 {
-		contentType, body, encodeErr := EncodeWithFiles(data, files)
+		contentType, body, encodeErr := MultipartBodyWithJSON(data, files)
 		if encodeErr != nil {
 			return st, encodeErr
 		}
@@ -2131,7 +2131,7 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 
 	var response []byte
 	if len(data.Files) > 0 {
-		contentType, body, encodeErr := EncodeWithFiles(data, data.Files)
+		contentType, body, encodeErr := MultipartBodyWithJSON(data, data.Files)
 		if encodeErr != nil {
 			return st, encodeErr
 		}
@@ -2155,7 +2155,7 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *WebhookEdit) (err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 	if len(data.Files) > 0 {
-		contentType, body, err := EncodeWithFiles(data, data.Files)
+		contentType, body, err := MultipartBodyWithJSON(data, data.Files)
 		if err != nil {
 			return err
 		}
@@ -2453,7 +2453,7 @@ func (s *Session) InteractionRespond(interaction *Interaction, resp *Interaction
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
 	if len(resp.Files) > 0 {
-		contentType, body, err := EncodeWithFiles(resp, resp.Files)
+		contentType, body, err := MultipartBodyWithJSON(resp, resp.Files)
 		if err != nil {
 			return err
 		}

--- a/restapi.go
+++ b/restapi.go
@@ -2453,9 +2453,9 @@ func (s *Session) InteractionRespond(interaction *Interaction, resp *Interaction
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
 	if len(resp.Files) > 0 {
-		contentType, body, err := MakeFilesBody(interaction,  resp.Files)
+		contentType, body, err := MakeFilesBody(interaction, resp.Files)
 		if err != nil {
-			return  err
+			return err
 		}
 
 		_, err = s.request("POST", endpoint, contentType, body, endpoint, 0)

--- a/restapi.go
+++ b/restapi.go
@@ -1571,9 +1571,9 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 
 	var response []byte
 	if len(files) > 0 {
-		contentType, body, makeFilesErr := MakeFilesBody(data, files)
-		if makeFilesErr != nil {
-			return st, makeFilesErr
+		contentType, body, encodeErr := EncodeWithFiles(data, files)
+		if encodeErr != nil {
+			return st, encodeErr
 		}
 
 		response, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
@@ -2131,9 +2131,9 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 
 	var response []byte
 	if len(data.Files) > 0 {
-		contentType, body, makeFilesErr := MakeFilesBody(data, data.Files)
-		if makeFilesErr != nil {
-			return st, makeFilesErr
+		contentType, body, encodeErr := EncodeWithFiles(data, data.Files)
+		if encodeErr != nil {
+			return st, encodeErr
 		}
 
 		response, err = s.request("POST", uri, contentType, body, uri, 0)
@@ -2155,7 +2155,7 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *WebhookEdit) (err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 	if len(data.Files) > 0 {
-		contentType, body, err := MakeFilesBody(data, data.Files)
+		contentType, body, err := EncodeWithFiles(data, data.Files)
 		if err != nil {
 			return err
 		}
@@ -2449,19 +2449,19 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 // appID       : The application ID.
 // interaction : Interaction instance.
 // resp        : Response message data.
-func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) error {
+func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) (err error) {
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
 	if len(resp.Files) > 0 {
-		contentType, body, err := MakeFilesBody(interaction, resp.Files)
+		contentType, body, err := EncodeWithFiles(interaction, resp.Files)
 		if err != nil {
 			return err
 		}
 
 		_, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
+	} else {
+		_, err = s.RequestWithBucketID("POST", endpoint, *resp, endpoint)
 	}
-	_, err := s.RequestWithBucketID("POST", endpoint, *resp, endpoint)
-
 	return err
 }
 

--- a/restapi.go
+++ b/restapi.go
@@ -2453,7 +2453,7 @@ func (s *Session) InteractionRespond(interaction *Interaction, resp *Interaction
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
 	if len(resp.Files) > 0 {
-		contentType, body, err := EncodeWithFiles(interaction, resp.Files)
+		contentType, body, err := EncodeWithFiles(resp, resp.Files)
 		if err != nil {
 			return err
 		}

--- a/restapi.go
+++ b/restapi.go
@@ -21,9 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"mime/multipart"
 	"net/http"
-	"net/textproto"
 	"net/url"
 	"strconv"
 	"strings"
@@ -1573,55 +1571,12 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 
 	var response []byte
 	if len(files) > 0 {
-		body := &bytes.Buffer{}
-		bodywriter := multipart.NewWriter(body)
-
-		var payload []byte
-		payload, err = json.Marshal(data)
+		contentType, body, err := MakeFilesBody(data, files)
 		if err != nil {
 			return
 		}
 
-		var p io.Writer
-
-		h := make(textproto.MIMEHeader)
-		h.Set("Content-Disposition", `form-data; name="payload_json"`)
-		h.Set("Content-Type", "application/json")
-
-		p, err = bodywriter.CreatePart(h)
-		if err != nil {
-			return
-		}
-
-		if _, err = p.Write(payload); err != nil {
-			return
-		}
-
-		for i, file := range files {
-			h := make(textproto.MIMEHeader)
-			h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file%d"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
-			contentType := file.ContentType
-			if contentType == "" {
-				contentType = "application/octet-stream"
-			}
-			h.Set("Content-Type", contentType)
-
-			p, err = bodywriter.CreatePart(h)
-			if err != nil {
-				return
-			}
-
-			if _, err = io.Copy(p, file.Reader); err != nil {
-				return
-			}
-		}
-
-		err = bodywriter.Close()
-		if err != nil {
-			return
-		}
-
-		response, err = s.request("POST", endpoint, bodywriter.FormDataContentType(), body.Bytes(), endpoint, 0)
+		response, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
 	} else {
 		response, err = s.RequestWithBucketID("POST", endpoint, data, endpoint)
 	}
@@ -2176,55 +2131,12 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 
 	var response []byte
 	if len(data.Files) > 0 {
-		body := &bytes.Buffer{}
-		bodywriter := multipart.NewWriter(body)
-
-		var payload []byte
-		payload, err = json.Marshal(data)
+		contentType, body, err := MakeFilesBody(data, data.Files)
 		if err != nil {
 			return
 		}
 
-		var p io.Writer
-
-		h := make(textproto.MIMEHeader)
-		h.Set("Content-Disposition", `form-data; name="payload_json"`)
-		h.Set("Content-Type", "application/json")
-
-		p, err = bodywriter.CreatePart(h)
-		if err != nil {
-			return
-		}
-
-		if _, err = p.Write(payload); err != nil {
-			return
-		}
-
-		for i, file := range data.Files {
-			h := make(textproto.MIMEHeader)
-			h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file%d"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
-			contentType := file.ContentType
-			if contentType == "" {
-				contentType = "application/octet-stream"
-			}
-			h.Set("Content-Type", contentType)
-
-			p, err = bodywriter.CreatePart(h)
-			if err != nil {
-				return
-			}
-
-			if _, err = io.Copy(p, file.Reader); err != nil {
-				return
-			}
-		}
-
-		err = bodywriter.Close()
-		if err != nil {
-			return
-		}
-
-		response, err = s.request("POST", uri, bodywriter.FormDataContentType(), body.Bytes(), uri, 0)
+		response, err = s.request("POST", uri, contentType, body, uri, 0)
 	} else {
 		response, err = s.RequestWithBucketID("POST", uri, data, uri)
 	}
@@ -2243,55 +2155,12 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *WebhookEdit) (err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 	if len(data.Files) > 0 {
-		body := &bytes.Buffer{}
-		bodywriter := multipart.NewWriter(body)
-
-		var payload []byte
-		payload, err = json.Marshal(data)
+		contentType, body, err := MakeFilesBody(data, data.Files)
 		if err != nil {
-			return
+			return err
 		}
 
-		var p io.Writer
-
-		h := make(textproto.MIMEHeader)
-		h.Set("Content-Disposition", `form-data; name="payload_json"`)
-		h.Set("Content-Type", "application/json")
-
-		p, err = bodywriter.CreatePart(h)
-		if err != nil {
-			return
-		}
-
-		if _, err = p.Write(payload); err != nil {
-			return
-		}
-
-		for i, file := range data.Files {
-			h := make(textproto.MIMEHeader)
-			h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file%d"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
-			contentType := file.ContentType
-			if contentType == "" {
-				contentType = "application/octet-stream"
-			}
-			h.Set("Content-Type", contentType)
-
-			p, err = bodywriter.CreatePart(h)
-			if err != nil {
-				return
-			}
-
-			if _, err = io.Copy(p, file.Reader); err != nil {
-				return
-			}
-		}
-
-		err = bodywriter.Close()
-		if err != nil {
-			return
-		}
-
-		_, err = s.request("PATCH", uri, bodywriter.FormDataContentType(), body.Bytes(), uri, 0)
+		_, err = s.request("PATCH", uri, contentType, body, uri, 0)
 	} else {
 		_, err = s.RequestWithBucketID("PATCH", uri, data, EndpointWebhookToken("", ""))
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -2488,8 +2488,8 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) (err error) {
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
-	if len(resp.Files) > 0 {
-		contentType, body, err := MultipartBodyWithJSON(resp, resp.Files)
+	if resp.Data != nil && len(resp.Data.Files) > 0 {
+		contentType, body, err := MultipartBodyWithJSON(resp, resp.Data.Files)
 		if err != nil {
 			return err
 		}

--- a/restapi.go
+++ b/restapi.go
@@ -1571,9 +1571,9 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 
 	var response []byte
 	if len(files) > 0 {
-		contentType, body, err := MakeFilesBody(data, files)
-		if err != nil {
-			return
+		contentType, body, makeFilesErr := MakeFilesBody(data, files)
+		if makeFilesErr != nil {
+			return st, makeFilesErr
 		}
 
 		response, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
@@ -2131,9 +2131,9 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 
 	var response []byte
 	if len(data.Files) > 0 {
-		contentType, body, err := MakeFilesBody(data, data.Files)
-		if err != nil {
-			return
+		contentType, body, makeFilesErr := MakeFilesBody(data, data.Files)
+		if makeFilesErr != nil {
+			return st, makeFilesErr
 		}
 
 		response, err = s.request("POST", uri, contentType, body, uri, 0)

--- a/restapi.go
+++ b/restapi.go
@@ -2452,6 +2452,14 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) error {
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
+	if len(resp.Files) > 0 {
+		contentType, body, err := MakeFilesBody(interaction,  resp.Files)
+		if err != nil {
+			return  err
+		}
+
+		_, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
+	}
 	_, err := s.RequestWithBucketID("POST", endpoint, *resp, endpoint)
 
 	return err

--- a/util.go
+++ b/util.go
@@ -22,10 +22,10 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 	return
 }
 
-// EncodeWithFiles returns the contentType and body for a discord request
+// MultipartBodyWithJSON returns the contentType and body for a discord request
 // data  : The object to encode for payload_json in the multipart request
 // files : Files to include in the request
-func EncodeWithFiles(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
+func MultipartBodyWithJSON(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
 	body := &bytes.Buffer{}
 	bodywriter := multipart.NewWriter(body)
 

--- a/util.go
+++ b/util.go
@@ -22,6 +22,9 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 	return
 }
 
+// MakeFilesBody returns the contentType and body for a discord request
+// data  : The object to encode for payload_json in the multipart request
+// files : Files to include in the request
 func MakeFilesBody(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
 	body := &bytes.Buffer{}
 	bodywriter := multipart.NewWriter(body)

--- a/util.go
+++ b/util.go
@@ -1,6 +1,12 @@
 package discordgo
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/textproto"
 	"strconv"
 	"time"
 )
@@ -14,4 +20,56 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 	timestamp := (i >> 22) + 1420070400000
 	t = time.Unix(0, timestamp*1000000)
 	return
+}
+
+
+func MakeFilesBody(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
+	body := &bytes.Buffer{}
+	bodywriter := multipart.NewWriter(body)
+
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+
+	var p io.Writer
+
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", `form-data; name="payload_json"`)
+	h.Set("Content-Type", "application/json")
+
+	p, err = bodywriter.CreatePart(h)
+	if err != nil {
+		return
+	}
+
+	if _, err = p.Write(payload); err != nil {
+		return
+	}
+
+	for i, file := range files {
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file%d"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
+		contentType := file.ContentType
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		h.Set("Content-Type", contentType)
+
+		p, err = bodywriter.CreatePart(h)
+		if err != nil {
+			return
+		}
+
+		if _, err = io.Copy(p, file.Reader); err != nil {
+			return
+		}
+	}
+
+	err = bodywriter.Close()
+	if err != nil {
+		return
+	}
+
+	return bodywriter.FormDataContentType(), body.Bytes(), nil
 }

--- a/util.go
+++ b/util.go
@@ -22,10 +22,10 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 	return
 }
 
-// MakeFilesBody returns the contentType and body for a discord request
+// EncodeWithFiles returns the contentType and body for a discord request
 // data  : The object to encode for payload_json in the multipart request
 // files : Files to include in the request
-func MakeFilesBody(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
+func EncodeWithFiles(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
 	body := &bytes.Buffer{}
 	bodywriter := multipart.NewWriter(body)
 

--- a/util.go
+++ b/util.go
@@ -22,7 +22,6 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 	return
 }
 
-
 func MakeFilesBody(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
 	body := &bytes.Buffer{}
 	bodywriter := multipart.NewWriter(body)

--- a/webhook.go
+++ b/webhook.go
@@ -40,5 +40,6 @@ type WebhookParams struct {
 type WebhookEdit struct {
 	Content         string                  `json:"content,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
+	Files           []*File                 `json:"-"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 }


### PR DESCRIPTION
Webhook edits and as a result interaction followups support uploading files
https://discord.com/developers/docs/resources/webhook#edit-webhook-message

While not documented it is also possible to include files in slash command responses

This implements the same functionality as https://github.com/bwmarrin/discordgo/pull/913. and that pr may be closed if this one is approved.