### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DiscordGo
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo) [![Go report](http://goreportcard.com/badge/bwmarrin/discordgo)](http://goreportcard.com/report/bwmarrin/discordgo) [![Build Status](https://travis-ci.com/bwmarrin/discordgo.svg?branch=master)](https://travis-ci.com/bwmarrin/discordgo) [![Discord Gophers](https://img.shields.io/badge/Discord%20Gophers-%23discordgo-blue.svg)](https://discord.gg/0f1SbxBZjYoCtNPP) [![Discord API](https://img.shields.io/badge/Discord%20API-%23go_discordgo-blue.svg)](https://discord.com/invite/discord-api)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo) [![Go Report Card](https://goreportcard.com/badge/github.com/bwmarrin/discordgo)](https://goreportcard.com/report/github.com/bwmarrin/discordgo) [![Build Status](https://travis-ci.com/bwmarrin/discordgo.svg?branch=master)](https://travis-ci.com/bwmarrin/discordgo) [![Discord Gophers](https://img.shields.io/badge/Discord%20Gophers-%23discordgo-blue.svg)](https://discord.gg/golang) [![Discord API](https://img.shields.io/badge/Discord%20API-%23go_discordgo-blue.svg)](https://discord.com/invite/discord-api)
 
 <img align="right" src="https://github.com/bwmarrin/discordgo/blob/master/docs/img/discordgo.png">
 
@@ -22,7 +22,7 @@ tool that wraps `ffmpeg` to create opus encoded audio appropriate for use with
 Discord (and DiscordGo).
 
 **For help with this package or general Go discussion, please join the [Discord 
-Gophers](https://discord.gg/0f1SbxBZjYq9jLBk) chat server.**
+Gophers](https://discord.gg/golang) chat server.**
 
 ## Getting Started
 
@@ -65,7 +65,7 @@ the only documentation available.  Both GoDoc and GoWalker (below) present
 that information in a nice format.
 
 - [![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo)
-- [![Go Walker](http://gowalker.org/api/v1/badge)](https://gowalker.org/github.com/bwmarrin/discordgo) 
+- [![Go Walker](https://gowalker.org/api/v1/badge)](https://gowalker.org/github.com/bwmarrin/discordgo) 
 - Hand crafted documentation coming eventually.
 
 

--- a/user.go
+++ b/user.go
@@ -8,20 +8,20 @@ type UserFlags int
 
 // Valid UserFlags values
 const (
-	UserFlagDiscordEmployee      UserFlags = 1 << 0
-	UserFlagDiscordPartner                 = 1 << 1
-	UserFlagHypeSquadEvents                = 1 << 2
-	UserFlagBugHunterLevel1                = 1 << 3
-	UserFlagHouseBravery                   = 1 << 6
-	UserFlagHouseBrilliance                = 1 << 7
-	UserFlagHouseBalance                   = 1 << 8
-	UserFlagEarlySupporter                 = 1 << 9
-	UserFlagTeamUser                       = 1 << 10
-	UserFlagSystem                         = 1 << 12
-	UserFlagBugHunterLevel2                = 1 << 14
-	UserFlagVerifiedBot                    = 1 << 16
-	UserFlagVerifiedBotDeveloper           = 1 << 17
-	UserFlagDiscordCertifiedModerator      = 1 << 18
+	UserFlagDiscordEmployee           UserFlags = 1 << 0
+	UserFlagDiscordPartner                      = 1 << 1
+	UserFlagHypeSquadEvents                     = 1 << 2
+	UserFlagBugHunterLevel1                     = 1 << 3
+	UserFlagHouseBravery                        = 1 << 6
+	UserFlagHouseBrilliance                     = 1 << 7
+	UserFlagHouseBalance                        = 1 << 8
+	UserFlagEarlySupporter                      = 1 << 9
+	UserFlagTeamUser                            = 1 << 10
+	UserFlagSystem                              = 1 << 12
+	UserFlagBugHunterLevel2                     = 1 << 14
+	UserFlagVerifiedBot                         = 1 << 16
+	UserFlagVerifiedBotDeveloper                = 1 << 17
+	UserFlagDiscordCertifiedModerator           = 1 << 18
 )
 
 // A User stores all data for an individual Discord user.


### PR DESCRIPTION
1. Updated links that used `http` to now use `https`
   * At least on my browser the report card image was broken. I replaced the image with the markdown generated on the [report](https://goreportcard.com/report/github.com/bwmarrin/discordgo).
2. Updated the Discord invites to use the vanity URL.
3. Ran `go fmt` 
   * Let me know if you want me to cherry-pick this change into a separate PR. (Or if you want to just push it yourself)

[Result of the README changes](https://github.com/jolheiser/discordgo/blob/b3bec7210c234808b099c3a01ba7872bd254538d/README.md)