### PR TITLE
Add permissions API endpoints for slash commands

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -152,6 +152,9 @@ var (
 	EndpointApplicationGuildCommandPermissions = func(aID, gID, cID string) string {
 		return EndpointApplicationGuildCommand(aID, gID, cID) + "/permissions"
 	}
+	EndpointApplicationGuildCommandsPermissions = func(aID, gID string) string {
+		return EndpointApplicationGuildCommands(aID, gID) + "/permissions"
+	}
 	EndpointInteraction = func(aID, iToken string) string {
 		return EndpointAPI + "interactions/" + aID + "/" + iToken
 	}

--- a/endpoints.go
+++ b/endpoints.go
@@ -149,10 +149,10 @@ var (
 	EndpointApplicationGuildCommand = func(aID, gID, cID string) string {
 		return EndpointApplicationGuildCommands(aID, gID) + "/" + cID
 	}
-	EndpointApplicationGuildCommandPermissions = func(aID, gID, cID string) string {
+	EndpointApplicationCommandPermissions = func(aID, gID, cID string) string {
 		return EndpointApplicationGuildCommand(aID, gID, cID) + "/permissions"
 	}
-	EndpointApplicationGuildCommandsPermissions = func(aID, gID string) string {
+	EndpointApplicationCommandsGuildPermissions = func(aID, gID string) string {
 		return EndpointApplicationGuildCommands(aID, gID) + "/permissions"
 	}
 	EndpointInteraction = func(aID, iToken string) string {

--- a/endpoints.go
+++ b/endpoints.go
@@ -149,6 +149,9 @@ var (
 	EndpointApplicationGuildCommand = func(aID, gID, cID string) string {
 		return EndpointApplicationGuildCommands(aID, gID) + "/" + cID
 	}
+	EndpointApplicationGuildCommandPermissions = func(aID, gID, cID string) string {
+		return EndpointApplicationGuildCommand(aID, gID, cID) + "/permissions"
+	}
 	EndpointInteraction = func(aID, iToken string) string {
 		return EndpointAPI + "interactions/" + aID + "/" + iToken
 	}

--- a/interactions.go
+++ b/interactions.go
@@ -67,15 +67,15 @@ type ApplicationCommandPermissions struct {
 
 // ApplicationCommandPermissionsList represents a list of ApplicationCommandPermissions, needed for serializing to JSON.
 type ApplicationCommandPermissionsList struct {
-	Permissions []ApplicationCommandPermissions `json:"permissions"`
+	Permissions []*ApplicationCommandPermissions `json:"permissions"`
 }
 
 // GuildApplicationCommandPermissions represents all permissions for a single guild command.
 type GuildApplicationCommandPermissions struct {
-	ID            string                          `json:"id"`
-	ApplicationID string                          `json:"application_id"`
-	GuildID       string                          `json:"guild_id"`
-	Permissions   []ApplicationCommandPermissions `json:"permissions"`
+	ID            string                           `json:"id"`
+	ApplicationID string                           `json:"application_id"`
+	GuildID       string                           `json:"guild_id"`
+	Permissions   []*ApplicationCommandPermissions `json:"permissions"`
 }
 
 // ApplicationCommandPermissionType indicates whether a permission is user or role based.
@@ -83,8 +83,8 @@ type ApplicationCommandPermissionType uint8
 
 // Application command permission types.
 const (
-	ApplicationCommandPermissionTypeRole = ApplicationCommandPermissionType(iota + 1)
-	ApplicationCommandPermissionTypeUser
+	ApplicationCommandPermissionTypeRole ApplicationCommandPermissionType = 1
+	ApplicationCommandPermissionTypeUser ApplicationCommandPermissionType = 2
 )
 
 // InteractionType indicates the type of an interaction event.

--- a/interactions.go
+++ b/interactions.go
@@ -58,6 +58,30 @@ type ApplicationCommandOptionChoice struct {
 	Value interface{} `json:"value"`
 }
 
+type ApplicationCommandPermissions struct {
+	ID         string                           `json:"id"`
+	Type       ApplicationCommandPermissionType `json:"type"`
+	Permission bool                             `json:"permission"`
+}
+
+type ApplicationCommandPermissionsList struct {
+	Permissions []ApplicationCommandPermissions `json:"permissions"`
+}
+
+type GuildApplicationCommandPermissions struct {
+	ID            string                          `json:"id"`
+	ApplicationId string                          `json:"application_id"`
+	GuildID       string                          `json:"guild_id"`
+	Permissions   []ApplicationCommandPermissions `json:"permissions"`
+}
+
+type ApplicationCommandPermissionType uint8
+
+const (
+	ApplicationCommandPermissionTypeRole = ApplicationCommandPermissionType(iota + 1)
+	ApplicationCommandPermissionTypeUser
+)
+
 // InteractionType indicates the type of an interaction event.
 type InteractionType uint8
 

--- a/interactions.go
+++ b/interactions.go
@@ -58,16 +58,19 @@ type ApplicationCommandOptionChoice struct {
 	Value interface{} `json:"value"`
 }
 
+// ApplicationCommandPermissions represents a single user or role permission for a command.
 type ApplicationCommandPermissions struct {
 	ID         string                           `json:"id"`
 	Type       ApplicationCommandPermissionType `json:"type"`
 	Permission bool                             `json:"permission"`
 }
 
+// ApplicationCommandPermissionsList represents a list of ApplicationCommandPermissions, needed for serializing to JSON.
 type ApplicationCommandPermissionsList struct {
 	Permissions []ApplicationCommandPermissions `json:"permissions"`
 }
 
+// GuildApplicationCommandPermissions represents all permissions for a single guild command.
 type GuildApplicationCommandPermissions struct {
 	ID            string                          `json:"id"`
 	ApplicationId string                          `json:"application_id"`
@@ -75,8 +78,10 @@ type GuildApplicationCommandPermissions struct {
 	Permissions   []ApplicationCommandPermissions `json:"permissions"`
 }
 
+// ApplicationCommandPermissionType indicates whether a permission is user or role based.
 type ApplicationCommandPermissionType uint8
 
+// Application command permission types.
 const (
 	ApplicationCommandPermissionTypeRole = ApplicationCommandPermissionType(iota + 1)
 	ApplicationCommandPermissionTypeUser

--- a/interactions.go
+++ b/interactions.go
@@ -73,7 +73,7 @@ type ApplicationCommandPermissionsList struct {
 // GuildApplicationCommandPermissions represents all permissions for a single guild command.
 type GuildApplicationCommandPermissions struct {
 	ID            string                          `json:"id"`
-	ApplicationId string                          `json:"application_id"`
+	ApplicationID string                          `json:"application_id"`
 	GuildID       string                          `json:"guild_id"`
 	Permissions   []ApplicationCommandPermissions `json:"permissions"`
 }

--- a/restapi.go
+++ b/restapi.go
@@ -2564,7 +2564,7 @@ func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string) (pe
 // appID       : The Application ID
 // guildID     : The guild ID containing the application command
 // cmdID       : The command ID to retrieve the permissions of
-func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (permissions GuildApplicationCommandPermissions) {
+func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (permissions *GuildApplicationCommandPermissions) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint)
@@ -2581,7 +2581,7 @@ func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (p
 // guildID     : The guild ID containing the application command
 // cmdID       : The command ID to edit the permissions of
 // permissions : An object containing a list of permissions for the application command
-func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
+func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string, permissions *ApplicationCommandPermissionsList) (err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
@@ -2593,7 +2593,7 @@ func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string
 // appID       : The Application ID
 // guildID     : The guild ID to batch edit commands of
 // permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command
-func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, permissions []GuildApplicationCommandPermissions) (err error) {
+func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, permissions []*GuildApplicationCommandPermissions) (err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)

--- a/restapi.go
+++ b/restapi.go
@@ -2576,12 +2576,12 @@ func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (p
 	return
 }
 
-// ApplicationCommandEditPermissions edits the permissions of an application command
+// ApplicationCommandPermissionsEdit edits the permissions of an application command
 // appID       : The Application ID
 // guildID     : The guild ID containing the application command
 // cmdID       : The command ID to edit the permissions of
 // permissions : An object containing a list of permissions for the application command
-func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
+func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
@@ -2589,11 +2589,11 @@ func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string
 	return
 }
 
-// ApplicationCommandBatchEditPermissions edits the permissions of a batch of commands
+// ApplicationCommandPermissionsBatchEdit edits the permissions of a batch of commands
 // appID       : The Application ID
 // guildID     : The guild ID to batch edit commands of
 // permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command
-func (s *Session) ApplicationCommandBatchEditPermissions(appID, guildID string, permissions []GuildApplicationCommandPermissions) (err error) {
+func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, permissions []GuildApplicationCommandPermissions) (err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)

--- a/restapi.go
+++ b/restapi.go
@@ -2545,8 +2545,8 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 	return
 }
 
-func (s *Session) GuildApplicationCommandPermissions(appID, guildID string) (permissions []*GuildApplicationCommandPermissions) {
-	endpoint := EndpointApplicationGuildCommandsPermissions(appID, guildID)
+func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string) (permissions []*GuildApplicationCommandPermissions) {
+	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
 	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint)
 	if err != nil {
@@ -2558,7 +2558,7 @@ func (s *Session) GuildApplicationCommandPermissions(appID, guildID string) (per
 }
 
 func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (permissions GuildApplicationCommandPermissions) {
-	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint)
 	if err != nil {
@@ -2570,15 +2570,15 @@ func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (p
 }
 
 func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
-	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
 
 	return
 }
 
-func (s *Session) ApplicationCommandEditBulkPermissions(appID, guildID, cmdID string, permissions []GuildApplicationCommandPermissions) (err error) {
-	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+func (s *Session) ApplicationCommandBatchEditPermissions(appID, guildID string, permissions []GuildApplicationCommandPermissions) (err error) {
+	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
 

--- a/restapi.go
+++ b/restapi.go
@@ -2545,6 +2545,9 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 	return
 }
 
+// GuildApplicationCommandsPermissions receives all permissions for application commands that have any permissions
+// appID       : The application ID
+// guildID     : Guild ID to retrieve all guild-specific permissions for application commands in the guild, both global and guild specific
 func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string) (permissions []*GuildApplicationCommandPermissions) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
@@ -2557,6 +2560,10 @@ func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string) (pe
 	return
 }
 
+// ApplicationCommandPermissions receives all permissions for application commands that have any permissions
+// appID       : The Application ID
+// guildID     : The guild ID containing the application command
+// cmdID       : The command ID to retrieve the permissions of
 func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (permissions GuildApplicationCommandPermissions) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
@@ -2569,6 +2576,11 @@ func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (p
 	return
 }
 
+// ApplicationCommandEditPermissions edits the permissions of an application command
+// appID       : The Application ID
+// guildID     : The guild ID containing the application command
+// cmdID       : The command ID to edit the permissions of
+// permissions : An object containing a list of permissions for the application command
 func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
@@ -2577,6 +2589,10 @@ func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string
 	return
 }
 
+// ApplicationCommandEditPermissions edits the permissions of an application command
+// appID       : The Application ID
+// guildID     : The guild ID containing the application command
+// permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command
 func (s *Session) ApplicationCommandBatchEditPermissions(appID, guildID string, permissions []GuildApplicationCommandPermissions) (err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 

--- a/restapi.go
+++ b/restapi.go
@@ -2545,6 +2545,17 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 	return
 }
 
+func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
+	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+
+	body, err := s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
+	if err != nil {
+		return
+	}
+	err = unmarshal(body, &permissions)
+	return err
+}
+
 // InteractionRespond creates the response to an interaction.
 // appID       : The application ID.
 // interaction : Interaction instance.

--- a/restapi.go
+++ b/restapi.go
@@ -2589,9 +2589,9 @@ func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string
 	return
 }
 
-// ApplicationCommandEditPermissions edits the permissions of an application command
+// ApplicationCommandBatchEditPermissions edits the permissions of a batch of commands
 // appID       : The Application ID
-// guildID     : The guild ID containing the application command
+// guildID     : The guild ID to batch edit commands of
 // permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command
 func (s *Session) ApplicationCommandBatchEditPermissions(appID, guildID string, permissions []GuildApplicationCommandPermissions) (err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)

--- a/restapi.go
+++ b/restapi.go
@@ -2545,15 +2545,44 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 	return
 }
 
-func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
-	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+func (s *Session) GuildApplicationCommandPermissions(appID, guildID string) (permissions []*GuildApplicationCommandPermissions) {
+	endpoint := EndpointApplicationGuildCommandsPermissions(appID, guildID)
 
-	body, err := s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
+	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint)
 	if err != nil {
 		return
 	}
+
 	err = unmarshal(body, &permissions)
-	return err
+	return
+}
+
+func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (permissions GuildApplicationCommandPermissions) {
+	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+
+	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &permissions)
+	return
+}
+
+func (s *Session) ApplicationCommandEditPermissions(appID, guildID, cmdID string, permissions ApplicationCommandPermissionsList) (err error) {
+	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+
+	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
+
+	return
+}
+
+func (s *Session) ApplicationCommandEditBulkPermissions(appID, guildID, cmdID string, permissions []GuildApplicationCommandPermissions) (err error) {
+	endpoint := EndpointApplicationGuildCommandPermissions(appID, guildID, cmdID)
+
+	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
+
+	return
 }
 
 // InteractionRespond creates the response to an interaction.


### PR DESCRIPTION
See main issue #942 

This adds the permissions API endpoints for application commands. I have tested these locally with success, and pushed my test version here: https://github.com/Southclaws/cj/commit/a07d1fa39ecca36f4de508800f1bb24c37a6575d
This indeed lacks the single command edit call, which is the first I implemented and later replaced with the bulk edit due to the amount of edits I'm making (and to test that one too). The commit should serve as an idea on how to work with it in the current form, to which feedback is welcome.

I have tried to keep naming as close to Discord's API naming for objects, but I'm happy to receive any feedback regarding them as well as for anything else in this PR.

Kind regards