### PR TITLE
Add SessionStartLimit to GatewayBotResponse struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1107,8 +1107,17 @@ type MessageReaction struct {
 
 // GatewayBotResponse stores the data for the gateway/bot response
 type GatewayBotResponse struct {
-	URL    string `json:"url"`
-	Shards int    `json:"shards"`
+	URL               string             `json:"url"`
+	Shards            int                `json:"shards"`
+	SessionStartLimit SessionInformation `json:"session_start_limit"`
+}
+
+// SessionInformation provides the information for max concurrency sharding
+type SessionInformation struct {
+	Total          int `json:"total,omitempty"`
+	Remaining      int `json:"remaining,omitempty"`
+	ResetAfter     int `json:"reset_after,omitempty"`
+	MaxConcurrency int `json:"max_concurrency,omitempty"`
 }
 
 // GatewayStatusUpdate is sent by the client to indicate a presence or status update


### PR DESCRIPTION
Current GatewayBotResponse struct is missing the information required for max concurrency sharding: https://discord.com/developers/docs/topics/gateway#get-gateway-bot-json-response