### PR TITLE
Add BeforeDelete to GuildDelete struct

### DIFF
--- a/events.go
+++ b/events.go
@@ -86,6 +86,7 @@ type GuildUpdate struct {
 // GuildDelete is the data for a GuildDelete event.
 type GuildDelete struct {
 	*Guild
+	BeforeDelete *Guild `json:"-"`
 }
 
 // GuildBanAdd is the data for a GuildBanAdd event.

--- a/state.go
+++ b/state.go
@@ -836,6 +836,13 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 	case *GuildUpdate:
 		err = s.GuildAdd(t.Guild)
 	case *GuildDelete:
+		var old *Guild
+		old, err = s.Guild(t.ID)
+		if err == nil {
+			oldCopy := *old
+			t.BeforeDelete = &oldCopy
+		}
+
 		err = s.GuildRemove(t.Guild)
 	case *GuildMemberAdd:
 		// Updates the MemberCount of the guild.

--- a/structs.go
+++ b/structs.go
@@ -1202,8 +1202,8 @@ const (
 	ActivityTypeGame      ActivityType = 0
 	ActivityTypeStreaming ActivityType = 1
 	ActivityTypeListening ActivityType = 2
-	//	ActivityTypeWatching // not valid in this use case?
-	ActivityTypeCustom ActivityType = 4
+	ActivityTypeWatching  ActivityType = 3
+	ActivityTypeCustom    ActivityType = 4
 )
 
 // Identify is sent during initial handshake with the discord gateway.


### PR DESCRIPTION
Added functionality to be able to access a Guild copy in the GuildDelete event, just like with MessageDelete.