### PR TITLE
Add new ApplicationCommandOptionType: number

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -38,6 +38,7 @@ const (
 	ApplicationCommandOptionChannel         ApplicationCommandOptionType = 7
 	ApplicationCommandOptionRole            ApplicationCommandOptionType = 8
 	ApplicationCommandOptionMentionable     ApplicationCommandOptionType = 9
+	ApplicationCommandOptionNumber          ApplicationCommandOptionType = 10
 )
 
 // ApplicationCommandOption represents an option/subcommand/subcommands group.


### PR DESCRIPTION
Adds ApplicationCommandOptionType: number. As referenced here: https://github.com/discord/discord-api-docs/pull/3455. Currently only available in the canary client & API.