### PR TITLE
Discord API v9

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -14,7 +14,7 @@ package discordgo
 import "strconv"
 
 // APIVersion is the Discord API version used for the REST and Websocket API.
-var APIVersion = "8"
+var APIVersion = "9"
 
 // Known Discord API Endpoints.
 var (
@@ -116,6 +116,16 @@ var (
 	EndpointChannelMessagePin         = func(cID, mID string) string { return EndpointChannel(cID) + "/pins/" + mID }
 	EndpointChannelMessageCrosspost   = func(cID, mID string) string { return EndpointChannel(cID) + "/messages/" + mID + "/crosspost" }
 	EndpointChannelFollow             = func(cID string) string { return EndpointChannel(cID) + "/followers" }
+
+	EndpointChannelStartThreadWithMessage           = func(cID string, mID string) string { return EndpointChannels + cID + "/messages/" + mID + "/threads" }
+	EndpointChannelStartThreadWithoutMessage        = func(cID string) string { return EndpointChannels + cID + "/threads" }
+	EndpointChannelThread                           = func(cID string) string { return EndpointChannels + cID + "/thread-members/@me" }
+	EndpointChannelMember                           = func(cID string, uID string) string { return EndpointChannels + cID + "/thread-members/" + uID }
+	EndpointChannelListMembers                      = func(cID string) string { return EndpointChannels + cID + "/thread-members" }
+	EndpointChannelListActiveThreads                = func(cID string) string { return EndpointChannels + cID + "/threads/active" }
+	EndpointChannelListPublicArchivedThreads        = func(cID string) string { return EndpointChannels + cID + "/threads/archived/public" }
+	EndpointChannelListPrivateArchivedThreads       = func(cID string) string { return EndpointChannels + cID + "/threads/archived/private" }
+	EndpointChannelListJoinedPrivateArchivedThreads = func(cID string) string { return EndpointChannels + cID + "/users/@me/threads/archived/private" }
 
 	EndpointGroupIcon = func(cID, hash string) string { return EndpointCDNChannelIcons + cID + "/" + hash + ".png" }
 

--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -44,6 +44,12 @@ const (
 	relationshipAddEventType          = "RELATIONSHIP_ADD"
 	relationshipRemoveEventType       = "RELATIONSHIP_REMOVE"
 	resumedEventType                  = "RESUMED"
+	threadCreateEventType             = "THREAD_CREATE"
+	threadDeleteEventType             = "THREAD_DELETE"
+	threadListSyncEventType           = "THREAD_LIST_SYNC"
+	threadMemberUpdateEventType       = "THREAD_MEMBER_UPDATE"
+	threadMembersUpdateEventType      = "THREAD_MEMBERS_UPDATE"
+	threadUpdateEventType             = "THREAD_UPDATE"
 	typingStartEventType              = "TYPING_START"
 	userGuildSettingsUpdateEventType  = "USER_GUILD_SETTINGS_UPDATE"
 	userNoteUpdateEventType           = "USER_NOTE_UPDATE"
@@ -774,6 +780,126 @@ func (eh resumedEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
+// threadCreateEventHandler is an event handler for ThreadCreate events.
+type threadCreateEventHandler func(*Session, *ThreadCreate)
+
+// Type returns the event type for ThreadCreate events.
+func (eh threadCreateEventHandler) Type() string {
+	return threadCreateEventType
+}
+
+// New returns a new instance of ThreadCreate.
+func (eh threadCreateEventHandler) New() interface{} {
+	return &ThreadCreate{}
+}
+
+// Handle is the handler for ThreadCreate events.
+func (eh threadCreateEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*ThreadCreate); ok {
+		eh(s, t)
+	}
+}
+
+// threadDeleteEventHandler is an event handler for ThreadDelete events.
+type threadDeleteEventHandler func(*Session, *ThreadDelete)
+
+// Type returns the event type for ThreadDelete events.
+func (eh threadDeleteEventHandler) Type() string {
+	return threadDeleteEventType
+}
+
+// New returns a new instance of ThreadDelete.
+func (eh threadDeleteEventHandler) New() interface{} {
+	return &ThreadDelete{}
+}
+
+// Handle is the handler for ThreadDelete events.
+func (eh threadDeleteEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*ThreadDelete); ok {
+		eh(s, t)
+	}
+}
+
+// threadListSyncEventHandler is an event handler for ThreadListSync events.
+type threadListSyncEventHandler func(*Session, *ThreadListSync)
+
+// Type returns the event type for ThreadListSync events.
+func (eh threadListSyncEventHandler) Type() string {
+	return threadListSyncEventType
+}
+
+// New returns a new instance of ThreadListSync.
+func (eh threadListSyncEventHandler) New() interface{} {
+	return &ThreadListSync{}
+}
+
+// Handle is the handler for ThreadListSync events.
+func (eh threadListSyncEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*ThreadListSync); ok {
+		eh(s, t)
+	}
+}
+
+// threadMemberUpdateEventHandler is an event handler for ThreadMemberUpdate events.
+type threadMemberUpdateEventHandler func(*Session, *ThreadMemberUpdate)
+
+// Type returns the event type for ThreadMemberUpdate events.
+func (eh threadMemberUpdateEventHandler) Type() string {
+	return threadMemberUpdateEventType
+}
+
+// New returns a new instance of ThreadMemberUpdate.
+func (eh threadMemberUpdateEventHandler) New() interface{} {
+	return &ThreadMemberUpdate{}
+}
+
+// Handle is the handler for ThreadMemberUpdate events.
+func (eh threadMemberUpdateEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*ThreadMemberUpdate); ok {
+		eh(s, t)
+	}
+}
+
+// threadMembersUpdateEventHandler is an event handler for ThreadMembersUpdate events.
+type threadMembersUpdateEventHandler func(*Session, *ThreadMembersUpdate)
+
+// Type returns the event type for ThreadMembersUpdate events.
+func (eh threadMembersUpdateEventHandler) Type() string {
+	return threadMembersUpdateEventType
+}
+
+// New returns a new instance of ThreadMembersUpdate.
+func (eh threadMembersUpdateEventHandler) New() interface{} {
+	return &ThreadMembersUpdate{}
+}
+
+// Handle is the handler for ThreadMembersUpdate events.
+func (eh threadMembersUpdateEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*ThreadMembersUpdate); ok {
+		eh(s, t)
+	}
+}
+
+// threadUpdateEventHandler is an event handler for ThreadUpdate events.
+type threadUpdateEventHandler func(*Session, *ThreadUpdate)
+
+// Type returns the event type for ThreadUpdate events.
+func (eh threadUpdateEventHandler) Type() string {
+	return threadUpdateEventType
+}
+
+// New returns a new instance of ThreadUpdate.
+func (eh threadUpdateEventHandler) New() interface{} {
+	return &ThreadUpdate{}
+}
+
+// Handle is the handler for ThreadUpdate events.
+func (eh threadUpdateEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*ThreadUpdate); ok {
+		eh(s, t)
+	}
+}
+
 // typingStartEventHandler is an event handler for TypingStart events.
 type typingStartEventHandler func(*Session, *TypingStart)
 
@@ -1012,6 +1138,18 @@ func handlerForInterface(handler interface{}) EventHandler {
 		return relationshipRemoveEventHandler(v)
 	case func(*Session, *Resumed):
 		return resumedEventHandler(v)
+	case func(*Session, *ThreadCreate):
+		return threadCreateEventHandler(v)
+	case func(*Session, *ThreadDelete):
+		return threadDeleteEventHandler(v)
+	case func(*Session, *ThreadListSync):
+		return threadListSyncEventHandler(v)
+	case func(*Session, *ThreadMemberUpdate):
+		return threadMemberUpdateEventHandler(v)
+	case func(*Session, *ThreadMembersUpdate):
+		return threadMembersUpdateEventHandler(v)
+	case func(*Session, *ThreadUpdate):
+		return threadUpdateEventHandler(v)
 	case func(*Session, *TypingStart):
 		return typingStartEventHandler(v)
 	case func(*Session, *UserGuildSettingsUpdate):
@@ -1067,6 +1205,12 @@ func init() {
 	registerInterfaceProvider(relationshipAddEventHandler(nil))
 	registerInterfaceProvider(relationshipRemoveEventHandler(nil))
 	registerInterfaceProvider(resumedEventHandler(nil))
+	registerInterfaceProvider(threadCreateEventHandler(nil))
+	registerInterfaceProvider(threadDeleteEventHandler(nil))
+	registerInterfaceProvider(threadListSyncEventHandler(nil))
+	registerInterfaceProvider(threadMemberUpdateEventHandler(nil))
+	registerInterfaceProvider(threadMembersUpdateEventHandler(nil))
+	registerInterfaceProvider(threadUpdateEventHandler(nil))
 	registerInterfaceProvider(typingStartEventHandler(nil))
 	registerInterfaceProvider(userGuildSettingsUpdateEventHandler(nil))
 	registerInterfaceProvider(userNoteUpdateEventHandler(nil))

--- a/events.go
+++ b/events.go
@@ -288,22 +288,27 @@ type InteractionCreate struct {
 	*Interaction
 }
 
+// ThreadCreate is the data for a ThreadCreate event
 type ThreadCreate struct {
 	*Channel
 }
 
+// ThreadUpdate is the data for a ThreadUpdate event
 type ThreadUpdate struct {
 	*Channel
 }
 
+// ThreadDelete is the data for a ThreadDelete event
 type ThreadDelete struct {
 	*Channel
 }
 
+// ThreadMemberUpdate is the data for a ThreadMemberUpdate event
 type ThreadMemberUpdate struct {
 	*ThreadMember
 }
 
+// ThreadMembersUpdate is the data for a ThreadMembersUpdate event
 type ThreadMembersUpdate struct {
 	ID               string          `json:"id"`
 	GuildID          string          `json:"guild_id"`
@@ -312,6 +317,7 @@ type ThreadMembersUpdate struct {
 	RemovedMemberIDs []string        `json:"removed_member_ids"`
 }
 
+// ThreadListSync is the data for a ThreadListSync event
 type ThreadListSync struct {
 	GuildID    string         `json:"guild_id"`
 	ChannelIDs []string       `json:"channel_ids,omitempty"`

--- a/events.go
+++ b/events.go
@@ -288,6 +288,37 @@ type InteractionCreate struct {
 	*Interaction
 }
 
+type ThreadCreate struct {
+	*Channel
+}
+
+type ThreadUpdate struct {
+	*Channel
+}
+
+type ThreadDelete struct {
+	*Channel
+}
+
+type ThreadMemberUpdate struct {
+	*ThreadMember
+}
+
+type ThreadMembersUpdate struct {
+	ID               string          `json:"id"`
+	GuildID          string          `json:"guild_id"`
+	MemberCount      int             `json:"member_count"`
+	AddedMembers     []*ThreadMember `json:"added_members"`
+	RemovedMemberIDs []string        `json:"removed_member_ids"`
+}
+
+type ThreadListSync struct {
+	GuildID    string         `json:"guild_id"`
+	ChannelIDs []string       `json:"channel_ids,omitempty"`
+	Threads    []Channel      `json:"threads"`
+	Members    []ThreadMember `json:"members"`
+}
+
 // UnmarshalJSON is a helper function to unmarshal Interaction object.
 func (i *InteractionCreate) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &i.Interaction)

--- a/message.go
+++ b/message.go
@@ -127,6 +127,9 @@ type Message struct {
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the flag.
 	Flags MessageFlags `json:"flags"`
+
+	// An array of Sticker objects, if any were sent.
+	StickerItems []*Sticker `json:"sticker_items"`
 }
 
 // UnmarshalJSON is a helper function to unmarshal the Message.
@@ -184,6 +187,29 @@ type File struct {
 	Name        string
 	ContentType string
 	Reader      io.Reader
+}
+
+// StickerType is the file format of the Sticker.
+type StickerType int
+
+const (
+	StickerTypePNG    StickerType = 1
+	StickerTypeAPNG   StickerType = 2
+	StickerTypeLottie StickerType = 3
+)
+
+// Sticker represents a sticker object that can be sent in a Message.
+type Sticker struct {
+	ID          string      `json:"id"`
+	PackID      *string     `json:"pack_id,omitempty"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Tags        string      `json:"tags"`
+	FormatType  StickerType `json:"format_type"`
+	Available   *bool       `json:"available,omitempty"`
+	GuildID     *string     `json:"guild_id,omitempty"`
+	User        *User       `json:"user,omitempty"`
+	SortValue   *int        `json:"sort_value,omitempty"`
 }
 
 // MessageSend stores all parameters you can send with ChannelMessageSendComplex.

--- a/message.go
+++ b/message.go
@@ -22,23 +22,28 @@ type MessageType int
 
 // Block contains the valid known MessageType values
 const (
-	MessageTypeDefault                               MessageType = 0
-	MessageTypeRecipientAdd                          MessageType = 1
-	MessageTypeRecipientRemove                       MessageType = 2
-	MessageTypeCall                                  MessageType = 3
-	MessageTypeChannelNameChange                     MessageType = 4
-	MessageTypeChannelIconChange                     MessageType = 5
-	MessageTypeChannelPinnedMessage                  MessageType = 6
-	MessageTypeGuildMemberJoin                       MessageType = 7
-	MessageTypeUserPremiumGuildSubscription          MessageType = 8
-	MessageTypeUserPremiumGuildSubscriptionTierOne   MessageType = 9
-	MessageTypeUserPremiumGuildSubscriptionTierTwo   MessageType = 10
-	MessageTypeUserPremiumGuildSubscriptionTierThree MessageType = 11
-	MessageTypeChannelFollowAdd                      MessageType = 12
-	MessageTypeGuildDiscoveryDisqualified            MessageType = 14
-	MessageTypeGuildDiscoveryRequalified             MessageType = 15
-	MessageTypeReply                                 MessageType = 19
-	MessageTypeApplicationCommand                    MessageType = 20
+	MessageTypeDefault                                 MessageType = 0
+	MessageTypeRecipientAdd                            MessageType = 1
+	MessageTypeRecipientRemove                         MessageType = 2
+	MessageTypeCall                                    MessageType = 3
+	MessageTypeChannelNameChange                       MessageType = 4
+	MessageTypeChannelIconChange                       MessageType = 5
+	MessageTypeChannelPinnedMessage                    MessageType = 6
+	MessageTypeGuildMemberJoin                         MessageType = 7
+	MessageTypeUserPremiumGuildSubscription            MessageType = 8
+	MessageTypeUserPremiumGuildSubscriptionTierOne     MessageType = 9
+	MessageTypeUserPremiumGuildSubscriptionTierTwo     MessageType = 10
+	MessageTypeUserPremiumGuildSubscriptionTierThree   MessageType = 11
+	MessageTypeChannelFollowAdd                        MessageType = 12
+	MessageTypeGuildDiscoveryDisqualified              MessageType = 14
+	MessageTypeGuildDiscoveryRequalified               MessageType = 15
+	MessageTypeGuildDiscoveryGracePeriodInitialWarning MessageType = 16
+	MessageTypeGuildDiscoveryGracePeriodFinalWarning   MessageType = 17
+	MessageTypeThreadCreated                           MessageType = 18
+	MessageTypeReply                                   MessageType = 19
+	MessageTypeApplicationCommand                      MessageType = 20
+	MessageTypeThreadStarterMessage                    MessageType = 21
+	MessageTypeGuildInviteReminder                     MessageType = 22
 )
 
 // A Message stores all data related to a specific Discord message.
@@ -127,6 +132,17 @@ type Message struct {
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the flag.
 	Flags MessageFlags `json:"flags"`
+
+	// Available only for messages that are a reply or thread starter message.
+	// This is the message that is being referenced. Null if the originating message
+	// was deleted or if it wasn't loaded.
+	ReferencedMessage *Message `json:"referenced_message"`
+
+	// The message's response to an Interaction.
+	Interaction *Interaction `json:"interaction"`
+
+	// The thread that was started from this message.
+	Thread *Channel `json:"thread"`
 
 	// An array of Sticker objects, if any were sent.
 	StickerItems []*Sticker `json:"sticker_items"`

--- a/message.go
+++ b/message.go
@@ -208,6 +208,7 @@ type File struct {
 // StickerType is the file format of the Sticker.
 type StickerType int
 
+// Defines all known Sticker types.
 const (
 	StickerTypePNG    StickerType = 1
 	StickerTypeAPNG   StickerType = 2

--- a/structs.go
+++ b/structs.go
@@ -366,6 +366,7 @@ type ThreadMetadata struct {
 // ArchiveDuration represents the increments of time at which a thread auto-archives, in seconds.
 type ArchiveDuration int
 
+// Defines the increments at which a thread archives due to inactivity.
 const (
 	ArchiveDuration1Hour ArchiveDuration = 60
 	ArchiveDuration1Day  ArchiveDuration = ArchiveDuration1Hour * 24


### PR DESCRIPTION
This PR implements [threads](https://discord.com/developers/docs/topics/threads), the new message type, as well as the new gateway events.

I am not entirely sure about how to cache threads (if that's even necessary), so if anyone has any idea, let me know.