### PR TITLE
Make processing of voice related events optional

### DIFF
--- a/event.go
+++ b/event.go
@@ -229,9 +229,13 @@ func (s *Session) onInterface(i interface{}) {
 	case *GuildUpdate:
 		setGuildIds(t.Guild)
 	case *VoiceServerUpdate:
-		go s.onVoiceServerUpdate(t)
+		if !s.DisableVoiceHandlers {
+			go s.onVoiceServerUpdate(t)
+		}
 	case *VoiceStateUpdate:
-		go s.onVoiceStateUpdate(t)
+		if !s.DisableVoiceHandlers {
+			go s.onVoiceStateUpdate(t)
+		}
 	}
 	err := s.State.OnInterface(s, i)
 	if err != nil {

--- a/structs.go
+++ b/structs.go
@@ -85,6 +85,9 @@ type Session struct {
 	// Stores a mapping of guild id's to VoiceConnections
 	VoiceConnections map[string]*VoiceConnection
 
+	// Switch to enable processing of voice related messages
+	DisableVoiceHandlers bool
+
 	// Managed state object, updated internally with events when
 	// StateEnabled is true.
 	State *State


### PR DESCRIPTION
As part of a design to make discord bots that interact with voice more scalable, it is helpful to be able to have a custom handler for voice related messages. The idea is like this:

Voice related processing is quite heavy compared to other processing, so it makes sense to have this as a separate workload that can scale seperately. To implement this, the voice related UDP and websocket connection should be handled in another process. But you still need the token and endpoint that Discord gives you. So it would make sense to be able to request a voice channel join, but have the actual voice stuff handled by another program. This change allows for this to happen by allowing the user to optionally disable the internal voice related handlers. The user can then register their own handler without discordgo stepping on what they are doing. Since the default value for a bool is false, if the user does not set the new variable, then processing continues as normal, making this a non-breaking change.