### PR TITLE
Make voice's websocket's open() publically callable

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -275,7 +275,7 @@ func (v *VoiceConnection) waitUntilConnected() error {
 // Open opens a voice connection.  This should be called
 // after VoiceChannelJoin is used and the data VOICE websocket events
 // are captured.
-func (v *VoiceConnection) open() (err error) {
+func (v *VoiceConnection) Open() (err error) {
 
 	v.log(LogInformational, "called")
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -750,7 +750,7 @@ func (s *Session) onVoiceServerUpdate(st *VoiceServerUpdate) {
 	voice.Unlock()
 
 	// Open a connection to the voice server
-	err := voice.open()
+	err := voice.Open()
 	if err != nil {
 		s.log(LogError, "onVoiceServerUpdate voice.open, %s", err)
 	}


### PR DESCRIPTION
This change allows a user to call open() on a VoiceConnection with variables that they supplied.

This allows for the user to handle voice connections in a separate process, with values handed via an out of process method. Handling voice communications out of process allows for better scalability of the bot.