### PR TITLE
Add omitempty to channel_id in MessageReference struct

### DIFF
--- a/message.go
+++ b/message.go
@@ -403,7 +403,7 @@ type MessageApplication struct {
 // MessageReference contains reference data sent with crossposted messages
 type MessageReference struct {
 	MessageID string `json:"message_id"`
-	ChannelID string `json:"channel_id"`
+	ChannelID string `json:"channel_id,omitempty"`
 	GuildID   string `json:"guild_id,omitempty"`
 }
 


### PR DESCRIPTION
[Per documentation](https://discord.com/developers/docs/resources/channel#message-types-replies) channel_id and guild_id are not required. GuildID is already marked as omitempty but ChannelId can be as well.