### PR TITLE
Add default permission to application commands

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -39,6 +39,20 @@ type ApplicationCommand struct {
 	Version     string `json:"version,omitempty"`
 	// NOTE: Chat commands only. Otherwise it mustn't be set.
 	Options []*ApplicationCommandOption `json:"options"`
+	// Discord defaults permission to true, so we invert it in MarshalJSON
+	DefaultPermissionDisabled bool `json:"-"`
+}
+
+// MarshalJSON is a method for marshaling ApplicationCommand to a JSON object.
+func (a ApplicationCommand) MarshalJSON() ([]byte, error) {
+	type applicationCommand ApplicationCommand
+	return json.Marshal(struct {
+		applicationCommand
+		DefaultPermission bool `json:"default_permission"`
+	}{
+		applicationCommand: applicationCommand(a),
+		DefaultPermission:  !a.DefaultPermissionDisabled,
+	})
 }
 
 // ApplicationCommandOptionType indicates the type of a slash command's option.


### PR DESCRIPTION
This adds default permissions to application commands, as I noticed it was discussed in #943 

Since Discord defaults to `true`, I decided it would be easiest (and non-breaking) to invert the field when marshaling.  
This also means we don't need to deal with a null-bool implementation or deal with `omitempty`.

### Reference
[Discord Docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure)

default_permission? | boolean (default `true`) | whether the command is enabled by default when the app is added to a guild
-- | -- | --