### PR TITLE
Modify GuildEmojiEdit function of restapi.go

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1385,7 +1385,7 @@ func (s *Session) GuildEmojiCreate(guildID, name, image string, roles []string) 
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
 // name    : The Name of the Emoji.
-// roles   : The roles for which this emoji will be whitelisted, can be nil.
+// roles   : The roles for which this emoji will be whitelisted. When empty or nil will roles will be reset.
 func (s *Session) GuildEmojiEdit(guildID, emojiID, name string, roles []string) (emoji *Emoji, err error) {
 
 	data := struct {

--- a/restapi.go
+++ b/restapi.go
@@ -1390,7 +1390,7 @@ func (s *Session) GuildEmojiEdit(guildID, emojiID, name string, roles []string) 
 
 	data := struct {
 		Name  string   `json:"name"`
-		Roles []string `json:"roles,omitempty"`
+		Roles []string `json:"roles"`
 	}{name, roles}
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildEmoji(guildID, emojiID), data, EndpointGuildEmojis(guildID))

--- a/restapi.go
+++ b/restapi.go
@@ -1385,7 +1385,7 @@ func (s *Session) GuildEmojiCreate(guildID, name, image string, roles []string) 
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
 // name    : The Name of the Emoji.
-// roles   : The roles for which this emoji will be whitelisted. When empty or nil will roles will be reset.
+// roles   : The roles for which this emoji will be whitelisted, if nil or empty the roles will be reset.
 func (s *Session) GuildEmojiEdit(guildID, emojiID, name string, roles []string) (emoji *Emoji, err error) {
 
 	data := struct {


### PR DESCRIPTION
Changes function to not omit empty role information. This allows for properly resetting the roles of an emoji, otherwise it appears to be presently impossible to reset the roles (without including a role ID in the edit request).