### PR TITLE
fix shadowed variables that were preventing errors from being returned properly

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -2536,7 +2536,7 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 // appID       : The application ID.
 // interaction : Interaction instance.
 // resp        : Response message data.
-func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) (err error) {
+func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) error {
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
 	if resp.Data != nil && len(resp.Data.Files) > 0 {
@@ -2546,9 +2546,10 @@ func (s *Session) InteractionRespond(interaction *Interaction, resp *Interaction
 		}
 
 		_, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
-	} else {
-		_, err = s.RequestWithBucketID("POST", endpoint, *resp, endpoint)
+		return err
 	}
+
+	_, err := s.RequestWithBucketID("POST", endpoint, *resp, endpoint)
 	return err
 }
 

--- a/state.go
+++ b/state.go
@@ -845,8 +845,9 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 
 		err = s.GuildRemove(t.Guild)
 	case *GuildMemberAdd:
+		var guild *Guild
 		// Updates the MemberCount of the guild.
-		guild, err := s.Guild(t.Member.GuildID)
+		guild, err = s.Guild(t.Member.GuildID)
 		if err != nil {
 			return err
 		}
@@ -861,8 +862,9 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 			err = s.MemberAdd(t.Member)
 		}
 	case *GuildMemberRemove:
+		var guild *Guild
 		// Updates the MemberCount of the guild.
-		guild, err := s.Guild(t.Member.GuildID)
+		guild, err = s.Guild(t.Member.GuildID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I pulled latest and opened it up in VS Code, and there were 3 `ineffectual assignment to err (ineffassign)` errors from the `go-golangci-lint` linter, found in `restapi.go` on line 2548, `state.go` on line 857, and `state.go` on line 873.

The "ineffectual assignment to err" means that the code is assigning a value to a variable `err`, but then the variable goes out of scope without ever being used. Looking at the code, all 3 cases are due to the `:=` assignment operator creating a second `err` variable in the local scope, instead of re-using the `err` that is a named return value.

More info: [Golang Variable Shadowing](https://rpeshkov.net/blog/golang-variable-shadowing/).
