### PR TITLE
feat: Add 2 more status.discord.com endpoints

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -20,6 +20,8 @@ var APIVersion = "8"
 var (
 	EndpointStatus     = "https://status.discord.com/api/v2/"
 	EndpointSm         = EndpointStatus + "scheduled-maintenances/"
+	EndpointSm         = EndpointStatus + "scheduled-maintenances.json"
+	EndpointSm         = EndpointStatus + "components.json"
 	EndpointSmActive   = EndpointSm + "active.json"
 	EndpointSmUpcoming = EndpointSm + "upcoming.json"
 


### PR DESCRIPTION
1. https://status.discord.com/api/v2/scheduled-maintenances.json
2. https://status.discord.com/api/v2/components.json

This all seems pointless, but well dgo has status endpoints that people barely use, so might as well as add these :^)