### PR TITLE
fix: Fix debug message printing when debug is disabled.

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -108,7 +108,7 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 	}
 	defer func() {
 		err2 := resp.Body.Close()
-		if err2 != nil {
+		if s.Debug && err2 != nil {
 			log.Println("error closing resp body")
 		}
 	}()


### PR DESCRIPTION
This message was happening a lot here, the thing is that when successfully read, the ioutil closes the body. So it will always trigger an error.

Also I think that message was mean't to be enabled only in debug. So I added the debug flag check :D 