### PR TITLE
remove omiteempty for SelectMenu MinValues

### DIFF
--- a/components.go
+++ b/components.go
@@ -171,7 +171,7 @@ type SelectMenu struct {
 	// The text which will be shown in the menu if there's no default options or all options was deselected and component was closed.
 	Placeholder string `json:"placeholder"`
 	// This value determines the minimal amount of selected items in the menu.
-	MinValues int `json:"min_values,omitempty"`
+	MinValues int `json:"min_values"`
 	// This value determines the maximal amount of selected items in the menu.
 	// If MaxValues or MinValues are greater than one then the user can select multiple items in the component.
 	MaxValues int                `json:"max_values,omitempty"`


### PR DESCRIPTION
0 is a valid value for MinValues, it can be used to allow a user to remove all options on a select menu that defaults to having items selected.

this would change the behavior of the SelectMenu component, instead of defaulting to `1` (this is what discord defaults to if you dont provide a MinValues) it would default to 0 because we would always be passing min_values to discord. If this is not desirable I could instead make MinValues a pointer, I think like this is easier to use for most people though.