### PR TITLE
opusSender replace standard ticker with a fixed time interval sleep implementation

### DIFF
--- a/sleep_constant_time.go
+++ b/sleep_constant_time.go
@@ -1,0 +1,52 @@
+package discordgo
+
+import (
+	"fmt"
+	"time"
+)
+
+type sleepCT struct {
+	d     time.Duration // desired duration between targets
+	t     time.Time     // last time target
+	wake  time.Time     // last wake time
+	drift int64         // last wake drift microseconds
+}
+
+func NewSleepCT(d time.Duration) sleepCT {
+
+	s := sleepCT{}
+
+	s.d = d
+	s.t = time.Now()
+
+	return s
+}
+
+func (s *sleepCT) SleepNext() int64 {
+
+	now := time.Now()
+
+	// if target is zero safety net
+	if s.t.IsZero() {
+		fmt.Println("TickerCT reset")
+		s.t = now.Add(-s.d)
+	}
+
+	// Move forward the sleep target by the duration
+	s.t = s.t.Add(s.d)
+
+	// Compute the desired sleep time to reach the target
+	d := time.Until(s.t)
+
+	// Sleep
+	time.Sleep(d)
+
+	// record the wake time
+	s.wake = time.Now()
+	s.drift = s.wake.Sub(s.t).Microseconds()
+
+	// fmt.Println(s.t.UnixMilli(), d.Milliseconds(), wake.UnixMilli(), drift, pause, len(s.resume))
+
+	// return the drift for monitoring purposes
+	return s.drift
+}

--- a/sleep_constant_time_test.go
+++ b/sleep_constant_time_test.go
@@ -1,0 +1,24 @@
+package discordgo
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestChannelMessageSend tests the ChannelMessageSend() function. This should not return an error.
+func TestSleepCT(t *testing.T) {
+
+	start := time.Now()
+	// start the ticker
+	s := NewSleepCT(20 * time.Millisecond)
+	var i int64
+	for i = 0; i < 50; i++ {
+		s.SleepNext()
+	}
+	since := time.Since(start)
+	fmt.Println("SleepCT after", time.Since(start), "drifts", time.Since(start)-(1*time.Second))
+	if since < (980*time.Millisecond) || since > (1020*time.Millisecond) {
+		t.Errorf("SleepCT failed timing requirements")
+	}
+}


### PR DESCRIPTION
Hi discordgo maintainers,

While developing [Mumble-Discord-Bridge](https://github.com/Stieneee/mumble-discord-bridge) (MDB) I ran into an issue using the Go standard Ticker. The ticker will drop ticks if the goroutine reading the channel doesn't get around to reading from the channel often enough. I resolved most of the issues in the MDB by switching to a sleep implementation and tracking the timing target for each sleeping interval. I have not noticed that opusSender routine becomes the bottleneck in my application.

I wrote a short blog post about this issue that shows you a few test results if you are interested in reading more about it. 

https://tylerstiene.ca/blog/careful-gos-standard-ticker-is-not-realtime/

I believe this issue should have or will impact other users of discrodgo especially when they are experiencing higher CPU load or are running on low core count / slower VMs.

Now for this PR. I replace the ticker in opusSender with a stripped-down version of the sleep-based implementation I am using in MDB. I do not believe any other location in the code would benefit from this swap. I included a simple test to demonstrate that sleepct behaves correctly.

While this implementation guarantees a better timing consistency the one trade-off is that opusSender now evaluates on a fixed interval instead of being blocked by the opus channel. I don't imagine that users will see a noticeable increase in idle CPU load but it is possible.

I have tested this implementation and appears to work as a dependency of MDB.
