### PR TITLE
Add Guild Member avatar

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -88,7 +88,7 @@ var (
 	EndpointGuildBanner        = func(gID, hash string) string { return EndpointCDNBanners + gID + "/" + hash + ".png" }
 	EndpointGuildStickers      = func(gID string) string { return EndpointGuilds + gID + "/stickers" }
 	EndpointGuildSticker       = func(gID, sID string) string { return EndpointGuilds + gID + "/stickers/" + sID }
-  EndpointGuildTemplate      = func(tID string) string { return EndpointGuilds + "/templates/" + tID }
+	EndpointGuildTemplate      = func(tID string) string { return EndpointGuilds + "/templates/" + tID }
 	EndpointGuildTemplates     = func(gID string) string { return EndpointGuilds + gID + "/templates" }
 	EndpointGuildTemplateSync  = func(gID, tID string) string { return EndpointGuilds + gID + "/templates/" + tID }
 	EndpointGuildMemberAvatar  = func(gId, uID, aID string) string {

--- a/endpoints.go
+++ b/endpoints.go
@@ -40,6 +40,7 @@ var (
 	EndpointCDNSplashes     = EndpointCDN + "splashes/"
 	EndpointCDNChannelIcons = EndpointCDN + "channel-icons/"
 	EndpointCDNBanners      = EndpointCDN + "banners/"
+	EndpointCDNGuilds       = EndpointCDN + "guilds/"
 
 	EndpointVoice        = EndpointAPI + "/voice/"
 	EndpointVoiceRegions = EndpointVoice + "regions"
@@ -87,6 +88,12 @@ var (
 	EndpointGuildBanner        = func(gID, hash string) string { return EndpointCDNBanners + gID + "/" + hash + ".png" }
 	EndpointGuildStickers      = func(gID string) string { return EndpointGuilds + gID + "/stickers" }
 	EndpointGuildSticker       = func(gID, sID string) string { return EndpointGuilds + gID + "/stickers/" + sID }
+	EndpointGuildMemberAvatar  = func(gId, uID, aID string) string {
+		return EndpointCDNGuilds + gId + "/users/" + uID + "/avatars/" + aID + ".png"
+	}
+	EndpointGuildMemberAvatarAnimated = func(gId, uID, aID string) string {
+		return EndpointCDNGuilds + gId + "/users/" + uID + "/avatars/" + aID + ".gif"
+	}
 
 	EndpointChannel                             = func(cID string) string { return EndpointChannels + cID }
 	EndpointChannelThreads                      = func(cID string) string { return EndpointChannel(cID) + "/threads" }

--- a/restapi.go
+++ b/restapi.go
@@ -642,6 +642,8 @@ func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
 	}
 
 	err = unmarshal(body, &st)
+	// The returned object doesn't have the GuildID attribute so we will set it here.
+	st.GuildID = guildID
 	return
 }
 

--- a/structs.go
+++ b/structs.go
@@ -925,6 +925,9 @@ type Member struct {
 	// Whether the member is muted at a guild level.
 	Mute bool `json:"mute"`
 
+	// The avatar of the member for the guild, if any.
+	Avatar string `json:"avatar"`
+
 	// The underlying user on which the member is based.
 	User *User `json:"user"`
 
@@ -948,6 +951,20 @@ type Member struct {
 // Mention creates a member mention
 func (m *Member) Mention() string {
 	return "<@!" + m.User.ID + ">"
+}
+
+// AvatarURL returns the URL of the member's avatar
+//    size:    The size of the user's avatar as a power of two
+//             if size is an empty string, no size parameter will
+//             be added to the URL.
+func (m *Member) AvatarURL(size string) string {
+	if m.Avatar == "" {
+		return m.User.AvatarURL(size)
+	}
+	// The default/empty avatar case should be handled by the above condition
+	return avatarURL(m.Avatar, "", EndpointGuildMemberAvatar(m.GuildID, m.User.ID, m.Avatar),
+		EndpointGuildMemberAvatarAnimated(m.GuildID, m.User.ID, m.Avatar), size)
+
 }
 
 // A Settings stores data for a specific users Discord client settings.

--- a/structs.go
+++ b/structs.go
@@ -925,7 +925,7 @@ type Member struct {
 	// Whether the member is muted at a guild level.
 	Mute bool `json:"mute"`
 
-	// The avatar of the member for the guild, if any.
+	// The hash of the avatar for the guild member, if any.
 	Avatar string `json:"avatar"`
 
 	// The underlying user on which the member is based.

--- a/user.go
+++ b/user.go
@@ -1,7 +1,5 @@
 package discordgo
 
-import "strings"
-
 // UserFlags is the flags of "user" (see UserFlags* consts)
 // https://discord.com/developers/docs/resources/user#user-object-user-flags
 type UserFlags int
@@ -91,17 +89,6 @@ func (u *User) Mention() string {
 //             if size is an empty string, no size parameter will
 //             be added to the URL.
 func (u *User) AvatarURL(size string) string {
-	var URL string
-	if u.Avatar == "" {
-		URL = EndpointDefaultUserAvatar(u.Discriminator)
-	} else if strings.HasPrefix(u.Avatar, "a_") {
-		URL = EndpointUserAvatarAnimated(u.ID, u.Avatar)
-	} else {
-		URL = EndpointUserAvatar(u.ID, u.Avatar)
-	}
-
-	if size != "" {
-		return URL + "?size=" + size
-	}
-	return URL
+	return avatarURL(u.Avatar, EndpointDefaultUserAvatar(u.Discriminator),
+		EndpointUserAvatar(u.ID, u.Avatar), EndpointUserAvatarAnimated(u.ID, u.Avatar), size)
 }

--- a/util.go
+++ b/util.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/textproto"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -74,4 +75,20 @@ func MultipartBodyWithJSON(data interface{}, files []*File) (requestContentType 
 	}
 
 	return bodywriter.FormDataContentType(), body.Bytes(), nil
+}
+
+func avatarURL(avatarHash, defaultAvatarURL, staticAvatarURL, animatedAvatarURL, size string) string {
+	var URL string
+	if avatarHash == "" {
+		URL = defaultAvatarURL
+	} else if strings.HasPrefix(avatarHash, "a_") {
+		URL = animatedAvatarURL
+	} else {
+		URL = staticAvatarURL
+	}
+
+	if size != "" {
+		return URL + "?size=" + size
+	}
+	return URL
 }


### PR DESCRIPTION
Fixes https://github.com/bwmarrin/discordgo/issues/965

This PR adds support for the Guild-specific member avatar, if any.

To follow the same pattern as `*User.AvatarURL`, also add the same method for `*Member.AvatarURL` , and create an util method `avatarURL` to handle both.

Also, set the `*Member.GuildID` after the `GuildMember` requests, as this is not included with the returned object.

I have tested these changes with my own bot