### PR TITLE
Feature/add http

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,0 +1,58 @@
+package discordgo
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+)
+
+type WebhookServer struct {
+	sess      *Session
+	publicKey ed25519.PublicKey
+}
+
+func NewWebhookServer(sess *Session, pubKeyString string) *WebhookServer {
+	key, err := hex.DecodeString(pubKeyString)
+	if err != nil {
+		log.Fatal("couldn't parse public key string")
+	}
+	return &WebhookServer{sess: sess, publicKey: key}
+}
+
+func (s *WebhookServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	//	if ok := VerifyInteraction(r, s.publicKey); !ok {
+	//		http.Error(w, "invalid request signature", http.StatusUnauthorized)
+	//		return
+	//	}
+	var interaction Interaction
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("could not read request body: %v", err)
+		http.Error(w, "could not read request body", http.StatusInternalServerError)
+		return
+	}
+	err = interaction.UnmarshalJSON(data)
+	if err != nil {
+		http.Error(w, "could not parse interaction", http.StatusBadRequest)
+		log.Printf("could not parse request interaction: %v", err)
+		return
+	}
+	if interaction.Type == InteractionPing {
+		response := InteractionResponse{Type: InteractionResponsePong}
+
+		b, err := json.Marshal(response)
+		if err != nil {
+			log.Printf("could not marshal response: %v", err)
+			return
+		}
+		w.Write(b)
+		return
+	}
+	for _, eh := range s.sess.handlers[interaction.Type.String()] {
+		go eh.eventHandler.Handle(s.sess, interaction)
+	}
+
+}

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,65 @@
+package discordgo
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func signRequest(key ed25519.PrivateKey, r *http.Request) error {
+	timestamp := time.Now().Unix()
+	r.Header.Set("X-Signature-Timestamp", fmt.Sprint(timestamp))
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body. err: %w", err)
+	}
+	var msg bytes.Buffer
+	msg.WriteString(fmt.Sprint(timestamp))
+	msg.WriteString(string(body))
+
+	signature := ed25519.Sign(key, msg.Bytes())
+	r.Header.Set("X-Signature-Ed25519", hex.EncodeToString(signature[:ed25519.SignatureSize]))
+
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+	return nil
+}
+
+func TestServeHTTP(t *testing.T) {
+	pubkey, privkey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Errorf("error generating signing keypair: %s", err)
+	}
+	mux := NewInteractionsHTTPServer(dg, hex.EncodeToString(pubkey))
+
+	testHandlerCalled := int32(0)
+	testHandler := func(s *Session, ic *InteractionCreate) {
+		atomic.AddInt32(&testHandlerCalled, 1)
+	}
+	mux.HandleFunc("basic", testHandler)
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(InteractionCreate{
+		&Interaction{ID: "fake",
+			Type: InteractionApplicationCommand,
+			Data: ApplicationCommandInteractionData{Name: "basic"},
+		}})
+	request, _ := http.NewRequest(http.MethodPost, "/", b)
+	response := httptest.NewRecorder()
+	err = signRequest(privkey, request)
+	if err != nil {
+		t.Fatalf("failed to sign request. err: %v", err)
+	}
+
+	mux.ServeHTTP(response, request)
+
+	if atomic.LoadInt32(&testHandlerCalled) != 1 {
+		t.Fatalf("testHandler was not called once.")
+	}
+}


### PR DESCRIPTION
This PR adds support for receiving outgoing webhooks over HTTP.

It works by implementing the http.ServeHTTP method so users can pass it to any standard http server as to allow users to have routes outside of the discord interactions.

Sample usage:

```
package main

import (
	"fmt"
	"log"
	"net/http"
	"os"

	"github.com/bwmarrin/discordgo"
)

var s *discordgo.Session
var AppId string
var GuildId string
var BotToken string
var PublicKey string

func init() {
	AppId = os.Getenv("APP_ID")
	GuildId = os.Getenv("GUILD_ID")
	BotToken = os.Getenv("BOT_TOKEN")
	PublicKey = os.Getenv("PUBLIC_KEY")

	var err error
	s, err = discordgo.New(fmt.Sprint("Bot ", BotToken))
	if err != nil {
		log.Fatalf("error starting: %v", err)
	}

}

func main() {
	_, ok := s.ApplicationCommandCreate(AppId, GuildId, &discordgo.ApplicationCommand{
		Name:        "test",
		Description: "test_command",
	})
	if ok != nil {
		log.Fatalf("cannot create command: %v", ok)
	}
	mux := discordgo.NewWebhookServer(s, PublicKey)
	mux.AddHandler("test", func(s *discordgo.Session, i *discordgo.Interaction) {
		s.InteractionRespond(i, &discordgo.InteractionResponse{
			Type: discordgo.InteractionResponseChannelMessageWithSource,
			Data: &discordgo.InteractionResponseData{
				Content: "test works",
			},
		})
	})
	log.Fatal(http.ListenAndServe(":8080", mux))
}

```

I threw this together pretty quickly, so I know there could be some cleanup, but wanted to get a PR open and get feedback and make sure this was something useful to the project before investing more time.