### PR TITLE
Add get guild stickers support

### DIFF
--- a/message.go
+++ b/message.go
@@ -192,51 +192,6 @@ type File struct {
 	Reader      io.Reader
 }
 
-// StickerFormat is the file format of the Sticker.
-type StickerFormat int
-
-// Defines all known Sticker types.
-const (
-	StickerFormatTypePNG    StickerFormat = 1
-	StickerFormatTypeAPNG   StickerFormat = 2
-	StickerFormatTypeLottie StickerFormat = 3
-)
-
-// StickerType is the type of sticker.
-type StickerType int
-
-// Defines Sticker types.
-const (
-	StickerTypeStandard StickerType = 1
-	StickerTypeGuild    StickerType = 2
-)
-
-// Sticker represents a sticker object that can be sent in a Message.
-type Sticker struct {
-	ID          string        `json:"id"`
-	PackID      string        `json:"pack_id"`
-	Name        string        `json:"name"`
-	Description string        `json:"description"`
-	Tags        string        `json:"tags"`
-	Type        StickerType   `json:"type"`
-	FormatType  StickerFormat `json:"format_type"`
-	Available   bool          `json:"available"`
-	GuildID     string        `json:"guild_id"`
-	User        *User         `json:"user"`
-	SortValue   int           `json:"sort_value"`
-}
-
-// StickerPack represents a pack of standard stickers.
-type StickerPack struct {
-	ID             string    `json:"id"`
-	Stickers       []Sticker `json:"stickers"`
-	Name           string    `json:"name"`
-	SKUID          string    `json:"sku_id"`
-	CoverStickerID string    `json:"cover_sticker_id"`
-	Description    string    `json:"description"`
-	BannerAssetID  string    `json:"banner_asset_id"`
-}
-
 // MessageSend stores all parameters you can send with ChannelMessageSendComplex.
 type MessageSend struct {
 	Content         string                  `json:"content,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -419,13 +419,13 @@ type Sticker struct {
 
 // StickerPack represents a pack of standard stickers.
 type StickerPack struct {
-	ID             string    `json:"id"`
-	Stickers       []Sticker `json:"stickers"`
-	Name           string    `json:"name"`
-	SKUID          string    `json:"sku_id"`
-	CoverStickerID string    `json:"cover_sticker_id"`
-	Description    string    `json:"description"`
-	BannerAssetID  string    `json:"banner_asset_id"`
+	ID             string     `json:"id"`
+	Stickers       []*Sticker `json:"stickers"`
+	Name           string     `json:"name"`
+	SKUID          string     `json:"sku_id"`
+	CoverStickerID string     `json:"cover_sticker_id"`
+	Description    string     `json:"description"`
+	BannerAssetID  string     `json:"banner_asset_id"`
 }
 
 // VerificationLevel type definition

--- a/structs.go
+++ b/structs.go
@@ -383,6 +383,51 @@ func (e *Emoji) APIName() string {
 	return e.ID
 }
 
+// StickerFormat is the file format of the Sticker.
+type StickerFormat int
+
+// Defines all known Sticker types.
+const (
+	StickerFormatTypePNG    StickerFormat = 1
+	StickerFormatTypeAPNG   StickerFormat = 2
+	StickerFormatTypeLottie StickerFormat = 3
+)
+
+// StickerType is the type of sticker.
+type StickerType int
+
+// Defines Sticker types.
+const (
+	StickerTypeStandard StickerType = 1
+	StickerTypeGuild    StickerType = 2
+)
+
+// Sticker represents a sticker object that can be sent in a Message.
+type Sticker struct {
+	ID          string        `json:"id"`
+	PackID      string        `json:"pack_id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Tags        string        `json:"tags"`
+	Type        StickerType   `json:"type"`
+	FormatType  StickerFormat `json:"format_type"`
+	Available   bool          `json:"available"`
+	GuildID     string        `json:"guild_id"`
+	User        *User         `json:"user"`
+	SortValue   int           `json:"sort_value"`
+}
+
+// StickerPack represents a pack of standard stickers.
+type StickerPack struct {
+	ID             string    `json:"id"`
+	Stickers       []Sticker `json:"stickers"`
+	Name           string    `json:"name"`
+	SKUID          string    `json:"sku_id"`
+	CoverStickerID string    `json:"cover_sticker_id"`
+	Description    string    `json:"description"`
+	BannerAssetID  string    `json:"banner_asset_id"`
+}
+
 // VerificationLevel type definition
 type VerificationLevel int
 
@@ -485,6 +530,9 @@ type Guild struct {
 
 	// A list of the custom emojis present in the guild.
 	Emojis []*Emoji `json:"emojis"`
+
+	// A list of the custom stickers present in the guild.
+	Stickers []*Sticker `json:"stickers"`
 
 	// A list of the members in the guild.
 	// This field is only present in GUILD_CREATE events and websocket


### PR DESCRIPTION
This PR add stickers field to Guild, and move some Sticker code to structs.go.

Ref: [https://discord.com/developers/docs/resources/guild](https://discord.com/developers/docs/resources/guild)