### PR TITLE
Use Logger in restapi.go

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -109,7 +109,7 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 	defer func() {
 		err2 := resp.Body.Close()
 		if err2 != nil {
-			log.Println("error closing resp body")
+			s.log(LogDebug, "error closing resp body")
 		}
 	}()
 


### PR DESCRIPTION
There are way more occurences of `log.Print(...)` in `restapi.go`

I'm just not sure how to go about for fixing those. They are not so important because they are hidden behind the `Session.Debug` flag anyway. They  are basically for printing out whole http requests to the console.

I played around with introducing a new `LogLevel` `LogTrace` and not using the `Session.Debug` flag for deciding, whether those messages should be logged or not.
We could keep `Session.Debug` for api compatibility, but it would still be a behavioral change ... so not sure, what you would like there.