### PR TITLE
Add Invite Create/Delete

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -29,6 +29,8 @@ const (
 	guildRoleUpdateEventType          = "GUILD_ROLE_UPDATE"
 	guildUpdateEventType              = "GUILD_UPDATE"
 	interactionCreateEventType        = "INTERACTION_CREATE"
+	inviteCreateEventType             = "INVITE_CREATE"
+	inviteDeleteEventType             = "INVITE_DELETE"
 	messageAckEventType               = "MESSAGE_ACK"
 	messageCreateEventType            = "MESSAGE_CREATE"
 	messageDeleteEventType            = "MESSAGE_DELETE"
@@ -481,6 +483,46 @@ func (eh interactionCreateEventHandler) New() interface{} {
 // Handle is the handler for InteractionCreate events.
 func (eh interactionCreateEventHandler) Handle(s *Session, i interface{}) {
 	if t, ok := i.(*InteractionCreate); ok {
+		eh(s, t)
+	}
+}
+
+// inviteCreateEventHandler is an event handler for InviteCreate events.
+type inviteCreateEventHandler func(*Session, *InviteCreate)
+
+// Type returns the event type for InviteCreate events.
+func (eh inviteCreateEventHandler) Type() string {
+	return inviteCreateEventType
+}
+
+// New returns a new instance of InviteCreate.
+func (eh inviteCreateEventHandler) New() interface{} {
+	return &InviteCreate{}
+}
+
+// Handle is the handler for InviteCreate events.
+func (eh inviteCreateEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*InviteCreate); ok {
+		eh(s, t)
+	}
+}
+
+// inviteDeleteEventHandler is an event handler for InviteDelete events.
+type inviteDeleteEventHandler func(*Session, *InviteDelete)
+
+// Type returns the event type for InviteDelete events.
+func (eh inviteDeleteEventHandler) Type() string {
+	return inviteDeleteEventType
+}
+
+// New returns a new instance of InviteDelete.
+func (eh inviteDeleteEventHandler) New() interface{} {
+	return &InviteDelete{}
+}
+
+// Handle is the handler for InviteDelete events.
+func (eh inviteDeleteEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*InviteDelete); ok {
 		eh(s, t)
 	}
 }
@@ -1108,6 +1150,10 @@ func handlerForInterface(handler interface{}) EventHandler {
 		return guildUpdateEventHandler(v)
 	case func(*Session, *InteractionCreate):
 		return interactionCreateEventHandler(v)
+	case func(*Session, *InviteCreate):
+		return inviteCreateEventHandler(v)
+	case func(*Session, *InviteDelete):
+		return inviteDeleteEventHandler(v)
 	case func(*Session, *MessageAck):
 		return messageAckEventHandler(v)
 	case func(*Session, *MessageCreate):
@@ -1191,6 +1237,8 @@ func init() {
 	registerInterfaceProvider(guildRoleUpdateEventHandler(nil))
 	registerInterfaceProvider(guildUpdateEventHandler(nil))
 	registerInterfaceProvider(interactionCreateEventHandler(nil))
+	registerInterfaceProvider(inviteCreateEventHandler(nil))
+	registerInterfaceProvider(inviteDeleteEventHandler(nil))
 	registerInterfaceProvider(messageAckEventHandler(nil))
 	registerInterfaceProvider(messageCreateEventHandler(nil))
 	registerInterfaceProvider(messageDeleteEventHandler(nil))

--- a/events.go
+++ b/events.go
@@ -341,3 +341,17 @@ type InteractionCreate struct {
 func (i *InteractionCreate) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &i.Interaction)
 }
+
+// InviteCreate is the data for a InviteCreate event
+type InviteCreate struct {
+	*Invite
+	ChannelID string `json:"channel_id"`
+	GuildID   string `json:"guild_id"`
+}
+
+// InviteDelete is the data for a InviteDelete event
+type InviteDelete struct {
+	ChannelID string `json:"channel_id"`
+	GuildID   string `json:"guild_id"`
+	Code      string `json:"code"`
+}

--- a/message.go
+++ b/message.go
@@ -121,7 +121,7 @@ type Message struct {
 	Activity *MessageActivity `json:"activity"`
 
 	// Is sent with Rich Presence-related chat embeds
-	Application *MessageApplication `json:"application"`
+	Application *Application `json:"application"`
 
 	// MessageReference contains reference data sent with crossposted or reply messages.
 	// This does not contain the reference *to* this message; this is for when *this* message references another.
@@ -433,7 +433,9 @@ const (
 	MessageActivityTypeJoinRequest MessageActivityType = 5
 )
 
+// TODO: Remove this when compatibility is not required
 // MessageApplication is sent with Rich Presence-related chat embeds
+// Deprecated: See type Application
 type MessageApplication struct {
 	ID          string `json:"id"`
 	CoverImage  string `json:"cover_image"`

--- a/message.go
+++ b/message.go
@@ -121,7 +121,7 @@ type Message struct {
 	Activity *MessageActivity `json:"activity"`
 
 	// Is sent with Rich Presence-related chat embeds
-	Application *Application `json:"application"`
+	Application *MessageApplication `json:"application"`
 
 	// MessageReference contains reference data sent with crossposted or reply messages.
 	// This does not contain the reference *to* this message; this is for when *this* message references another.
@@ -433,9 +433,9 @@ const (
 	MessageActivityTypeJoinRequest MessageActivityType = 5
 )
 
-// TODO: Remove this when compatibility is not required
 // MessageApplication is sent with Rich Presence-related chat embeds
-// Deprecated: See type Application
+// This is used instead of Application to reduce the amount of memory consumption
+// of message objects
 type MessageApplication struct {
 	ID          string `json:"id"`
 	CoverImage  string `json:"cover_image"`

--- a/message.go
+++ b/message.go
@@ -434,8 +434,6 @@ const (
 )
 
 // MessageApplication is sent with Rich Presence-related chat embeds
-// This is used instead of Application to reduce the amount of memory consumption
-// of message objects
 type MessageApplication struct {
 	ID          string `json:"id"`
 	CoverImage  string `json:"cover_image"`

--- a/oauth2.go
+++ b/oauth2.go
@@ -71,9 +71,10 @@ func (s *Session) Applications() (st []*Application, err error) {
 func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error) {
 
 	data := struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-	}{ap.Name, ap.Description}
+		Name         string    `json:"name"`
+		Description  string    `json:"description"`
+		RedirectURIs *[]string `json:"redirect_uris,omitempty"`
+	}{ap.Name, ap.Description, ap.RedirectURIs}
 
 	body, err := s.RequestWithBucketID("POST", EndpointOAuth2Applications, data, EndpointOAuth2Applications)
 	if err != nil {
@@ -89,9 +90,10 @@ func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error
 func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Application, err error) {
 
 	data := struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-	}{ap.Name, ap.Description}
+		Name         string    `json:"name"`
+		Description  string    `json:"description"`
+		RedirectURIs *[]string `json:"redirect_uris,omitempty"`
+	}{ap.Name, ap.Description, ap.RedirectURIs}
 
 	body, err := s.RequestWithBucketID("PUT", EndpointOAuth2Application(appID), data, EndpointOAuth2Application(""))
 	if err != nil {

--- a/oauth2.go
+++ b/oauth2.go
@@ -40,23 +40,6 @@ type Team struct {
 	Members     []*TeamMember `json:"members"`
 }
 
-// An Application struct stores values for a Discord OAuth2 Application
-type Application struct {
-	ID                  string    `json:"id,omitempty"`
-	Name                string    `json:"name"`
-	Description         string    `json:"description,omitempty"`
-	Icon                string    `json:"icon,omitempty"`
-	Secret              string    `json:"secret,omitempty"`
-	RedirectURIs        *[]string `json:"redirect_uris,omitempty"`
-	BotRequireCodeGrant bool      `json:"bot_require_code_grant,omitempty"`
-	BotPublic           bool      `json:"bot_public,omitempty"`
-	RPCApplicationState int       `json:"rpc_application_state,omitempty"`
-	Flags               int       `json:"flags,omitempty"`
-	Owner               *User     `json:"owner"`
-	Bot                 *User     `json:"bot"`
-	Team                *Team     `json:"team"`
-}
-
 // Application returns an Application structure of a specific Application
 //   appID : The ID of an Application
 func (s *Session) Application(appID string) (st *Application, err error) {
@@ -88,10 +71,9 @@ func (s *Session) Applications() (st []*Application, err error) {
 func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error) {
 
 	data := struct {
-		Name         string    `json:"name"`
-		Description  string    `json:"description"`
-		RedirectURIs *[]string `json:"redirect_uris,omitempty"`
-	}{ap.Name, ap.Description, ap.RedirectURIs}
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}{ap.Name, ap.Description}
 
 	body, err := s.RequestWithBucketID("POST", EndpointOAuth2Applications, data, EndpointOAuth2Applications)
 	if err != nil {
@@ -107,10 +89,9 @@ func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error
 func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Application, err error) {
 
 	data := struct {
-		Name         string    `json:"name"`
-		Description  string    `json:"description"`
-		RedirectURIs *[]string `json:"redirect_uris,omitempty"`
-	}{ap.Name, ap.Description, ap.RedirectURIs}
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}{ap.Name, ap.Description}
 
 	body, err := s.RequestWithBucketID("PUT", EndpointOAuth2Application(appID), data, EndpointOAuth2Application(""))
 	if err != nil {

--- a/oauth2.go
+++ b/oauth2.go
@@ -71,10 +71,9 @@ func (s *Session) Applications() (st []*Application, err error) {
 func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error) {
 
 	data := struct {
-		Name         string    `json:"name"`
-		Description  string    `json:"description"`
-		RedirectURIs *[]string `json:"redirect_uris,omitempty"`
-	}{ap.Name, ap.Description, ap.RedirectURIs}
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}{ap.Name, ap.Description}
 
 	body, err := s.RequestWithBucketID("POST", EndpointOAuth2Applications, data, EndpointOAuth2Applications)
 	if err != nil {
@@ -90,10 +89,9 @@ func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error
 func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Application, err error) {
 
 	data := struct {
-		Name         string    `json:"name"`
-		Description  string    `json:"description"`
-		RedirectURIs *[]string `json:"redirect_uris,omitempty"`
-	}{ap.Name, ap.Description, ap.RedirectURIs}
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}{ap.Name, ap.Description}
 
 	body, err := s.RequestWithBucketID("PUT", EndpointOAuth2Application(appID), data, EndpointOAuth2Application(""))
 	if err != nil {

--- a/structs.go
+++ b/structs.go
@@ -249,8 +249,8 @@ type Invite struct {
 	ApproximateMemberCount   int `json:"approximate_member_count"`
 }
 
-// TODO: Remove this when compatibility is not required
 // TargetUserType is the type of the target user
+// TODO: Remove this when compatibility is not required
 // Deprecated: see InviteTargetType
 type TargetUserType int
 

--- a/structs.go
+++ b/structs.go
@@ -197,8 +197,8 @@ type InviteTargetType uint8
 
 // Invite target types
 const (
-	InviteStream             InviteTargetType = 1
-	InviteEmbeddedAppliction InviteTargetType = 2
+	InviteTargetStream             InviteTargetType = 1
+	InviteTargetEmbeddedAppliction InviteTargetType = 2
 )
 
 // A Invite stores all data related to a specific Discord Guild or Channel invite.

--- a/structs.go
+++ b/structs.go
@@ -128,6 +128,28 @@ type Session struct {
 	wsMutex sync.Mutex
 }
 
+// Application stores values for a Discord Application
+type Application struct {
+	ID                  string   `json:"id,omitempty"`
+	Name                string   `json:"name"`
+	Icon                string   `json:"icon,omitempty"`
+	Description         string   `json:"description,omitempty"`
+	RPCOrigins          []string `json:"rpc_origins,omitempty"`
+	BotPublic           bool     `json:"bot_public,omitempty"`
+	BotRequireCodeGrant bool     `json:"bot_require_code_grant,omitempty"`
+	TermsOfServiceURL   string   `json:"terms_of_service_url"`
+	PrivacyProxyURL     string   `json:"privacy_policy_url"`
+	Owner               *User    `json:"owner"`
+	Summary             string   `json:"summary"`
+	VerifyKey           string   `json:"verify_key"`
+	Team                *Team    `json:"team"`
+	GuildID             string   `json:"guild_id"`
+	PrimarySKUID        string   `json:"primary_sku_id"`
+	Slug                string   `json:"slug"`
+	CoverImage          string   `json:"cover_image"`
+	Flags               int      `json:"flags,omitempty"`
+}
+
 // UserConnection is a Connection returned from the UserConnections endpoint
 type UserConnection struct {
 	ID           string         `json:"id"`
@@ -203,19 +225,20 @@ const (
 
 // A Invite stores all data related to a specific Discord Guild or Channel invite.
 type Invite struct {
-	Guild          *Guild           `json:"guild"`
-	Channel        *Channel         `json:"channel"`
-	Inviter        *User            `json:"inviter"`
-	Code           string           `json:"code"`
-	CreatedAt      time.Time        `json:"created_at"`
-	MaxAge         int              `json:"max_age"`
-	Uses           int              `json:"uses"`
-	MaxUses        int              `json:"max_uses"`
-	Revoked        bool             `json:"revoked"`
-	Temporary      bool             `json:"temporary"`
-	Unique         bool             `json:"unique"`
-	TargetUser     *User            `json:"target_user"`
-	TargetUserType InviteTargetType `json:"target_type"`
+	Guild             *Guild           `json:"guild"`
+	Channel           *Channel         `json:"channel"`
+	Inviter           *User            `json:"inviter"`
+	Code              string           `json:"code"`
+	CreatedAt         time.Time        `json:"created_at"`
+	MaxAge            int              `json:"max_age"`
+	Uses              int              `json:"uses"`
+	MaxUses           int              `json:"max_uses"`
+	Revoked           bool             `json:"revoked"`
+	Temporary         bool             `json:"temporary"`
+	Unique            bool             `json:"unique"`
+	TargetUser        *User            `json:"target_user"`
+	TargetType        InviteTargetType `json:"target_type"`
+	TargetApplication *Application     `json:"target_application"`
 
 	// will only be filled when using InviteWithCounts
 	ApproximatePresenceCount int `json:"approximate_presence_count"`

--- a/structs.go
+++ b/structs.go
@@ -191,35 +191,36 @@ type ICEServer struct {
 	Credential string `json:"credential"`
 }
 
+// InviteTargetType indicates the type of target of an invite
+// https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
+type InviteTargetType uint8
+
+// Invite target types
+const (
+	InviteStream             InviteTargetType = 1
+	InviteEmbeddedAppliction InviteTargetType = 2
+)
+
 // A Invite stores all data related to a specific Discord Guild or Channel invite.
 type Invite struct {
-	Guild          *Guild         `json:"guild"`
-	Channel        *Channel       `json:"channel"`
-	Inviter        *User          `json:"inviter"`
-	Code           string         `json:"code"`
-	CreatedAt      time.Time      `json:"created_at"`
-	MaxAge         int            `json:"max_age"`
-	Uses           int            `json:"uses"`
-	MaxUses        int            `json:"max_uses"`
-	Revoked        bool           `json:"revoked"`
-	Temporary      bool           `json:"temporary"`
-	Unique         bool           `json:"unique"`
-	TargetUser     *User          `json:"target_user"`
-	TargetUserType TargetUserType `json:"target_user_type"`
+	Guild          *Guild           `json:"guild"`
+	Channel        *Channel         `json:"channel"`
+	Inviter        *User            `json:"inviter"`
+	Code           string           `json:"code"`
+	CreatedAt      time.Time        `json:"created_at"`
+	MaxAge         int              `json:"max_age"`
+	Uses           int              `json:"uses"`
+	MaxUses        int              `json:"max_uses"`
+	Revoked        bool             `json:"revoked"`
+	Temporary      bool             `json:"temporary"`
+	Unique         bool             `json:"unique"`
+	TargetUser     *User            `json:"target_user"`
+	TargetUserType InviteTargetType `json:"target_type"`
 
 	// will only be filled when using InviteWithCounts
 	ApproximatePresenceCount int `json:"approximate_presence_count"`
 	ApproximateMemberCount   int `json:"approximate_member_count"`
 }
-
-// TargetUserType is the type of the target user
-// https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
-type TargetUserType int
-
-// Block contains known TargetUserType values
-const (
-	TargetUserTypeStream TargetUserType = 1
-)
 
 // ChannelType is the type of a Channel
 type ChannelType int

--- a/structs.go
+++ b/structs.go
@@ -148,10 +148,6 @@ type Application struct {
 	Slug                string   `json:"slug"`
 	CoverImage          string   `json:"cover_image"`
 	Flags               int      `json:"flags,omitempty"`
-
-	// TODO: Remove this when compatibility is not required
-	// Deprecated
-	RedirectURIs *[]string `json:"-"`
 }
 
 // UserConnection is a Connection returned from the UserConnections endpoint
@@ -248,17 +244,6 @@ type Invite struct {
 	ApproximatePresenceCount int `json:"approximate_presence_count"`
 	ApproximateMemberCount   int `json:"approximate_member_count"`
 }
-
-// TargetUserType is the type of the target user
-// TODO: Remove this when compatibility is not required
-// Deprecated: see InviteTargetType
-type TargetUserType int
-
-// Block contains known TargetUserType values
-// Deprecated: see InviteTargetType
-const (
-	TargetUserTypeStream TargetUserType = 1
-)
 
 // ChannelType is the type of a Channel
 type ChannelType int

--- a/structs.go
+++ b/structs.go
@@ -148,6 +148,10 @@ type Application struct {
 	Slug                string   `json:"slug"`
 	CoverImage          string   `json:"cover_image"`
 	Flags               int      `json:"flags,omitempty"`
+
+	// TODO: Remove this when compatibility is not required
+	// Deprecated
+	RedirectURIs *[]string `json:"-"`
 }
 
 // UserConnection is a Connection returned from the UserConnections endpoint
@@ -244,6 +248,17 @@ type Invite struct {
 	ApproximatePresenceCount int `json:"approximate_presence_count"`
 	ApproximateMemberCount   int `json:"approximate_member_count"`
 }
+
+// TODO: Remove this when compatibility is not required
+// TargetUserType is the type of the target user
+// Deprecated: see InviteTargetType
+type TargetUserType int
+
+// Block contains known TargetUserType values
+// Deprecated: see InviteTargetType
+const (
+	TargetUserTypeStream TargetUserType = 1
+)
 
 // ChannelType is the type of a Channel
 type ChannelType int


### PR DESCRIPTION
Fixes #1104 

See [this PR](https://github.com/discordeno/discordeno/issues/640) and the linked one for the change of target_user_type -> target_type

I moved the Application struct, and i noticed that there were some fields not on the discord documentation, nor in the git history of the docs repo. Does the oauth2/applications/<id> endpoint still exist? all i can find is [this](https://discord.com/developers/docs/topics/oauth2#get-current-bot-application-information). 