### PR TITLE
add interaction field to message struct

### DIFF
--- a/message.go
+++ b/message.go
@@ -529,13 +529,13 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 	return
 }
 
-// MessageInteraction contains information about the application command interaction which generated a message
+// MessageInteraction contains information about the application command interaction which generated the message.
 type MessageInteraction struct {
 	ID   string          `json:"id"`
 	Type InteractionType `json:"type"`
 	Name string          `json:"name"`
 	User *User           `json:"user"`
 
-	// Member is only present when the interaction is from a guild
+	// Member is only present when the interaction is from a guild.
 	Member *Member `json:"member"`
 }

--- a/message.go
+++ b/message.go
@@ -534,6 +534,6 @@ type MessageInteraction struct {
 	ID     string          `json:"id"`
 	Type   InteractionType `json:"type"`
 	Name   string          `json:"name"`
-	User   User            `json:"user"`
+	User   *User            `json:"user"`
 	Member *Member         `json:"member"`
 }

--- a/message.go
+++ b/message.go
@@ -531,9 +531,11 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 
 // MessageInteraction contains information about the application command interaction which generated a message
 type MessageInteraction struct {
-	ID     string          `json:"id"`
-	Type   InteractionType `json:"type"`
-	Name   string          `json:"name"`
-	User   *User            `json:"user"`
-	Member *Member         `json:"member"`
+	ID   string          `json:"id"`
+	Type InteractionType `json:"type"`
+	Name string          `json:"name"`
+	User *User           `json:"user"`
+
+	// Member is only present when the interaction is from a guild
+	Member *Member `json:"member"`
 }

--- a/message.go
+++ b/message.go
@@ -135,9 +135,9 @@ type Message struct {
 	// If the field exists but is null, the referenced message was deleted.
 	ReferencedMessage *Message `json:"referenced_message"`
 
-	// MessageInteraction is sent on the message object when the message is a response to an Interaction without an existing message.
-	// This means responses to Message Components do not include this property,
-	// instead including a MessageReference as components always exist on preexisting messages.
+	// Is sent when the message is a response to an Interaction, without an existing message.
+	// This means responses to message component interactions do not include this property,
+	// instead including a MessageReference, as components exist on preexisting messages.
 	Interaction *MessageInteraction `json:"interaction"`
 
 	// The flags of the message, which describe extra features of a message.

--- a/message.go
+++ b/message.go
@@ -529,7 +529,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 	return
 }
 
-// MessageInteraction contains information about the application command interaction which generated this message
+// MessageInteraction contains information about the application command interaction which generated a message
 type MessageInteraction struct {
 	ID     string          `json:"id"`
 	Type   InteractionType `json:"type"`

--- a/message.go
+++ b/message.go
@@ -135,6 +135,11 @@ type Message struct {
 	// If the field exists but is null, the referenced message was deleted.
 	ReferencedMessage *Message `json:"referenced_message"`
 
+	// MessageInteraction is sent on the message object when the message is a response to an Interaction without an existing message.
+	// This means responses to Message Components do not include this property,
+	// instead including a MessageReference as components always exist on preexisting messages.
+	Interaction *MessageInteraction `json:"interaction"`
+
 	// The flags of the message, which describe extra features of a message.
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the flag.
@@ -522,4 +527,13 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 		return "#" + channel.Name
 	})
 	return
+}
+
+// MessageInteraction contains information about the application command interaction which generated this message
+type MessageInteraction struct {
+	ID     string          `json:"id"`
+	Type   InteractionType `json:"type"`
+	Name   string          `json:"name"`
+	User   User            `json:"user"`
+	Member *Member         `json:"member"`
 }


### PR DESCRIPTION
This pr adds the interaction field to the message struct 
https://discord.com/developers/docs/resources/channel#message-object-message-structure

there is another pr for this which seems to be dead and is wrongly implemented https://github.com/bwmarrin/discordgo/pull/929