### PR TITLE
Payload for member edit

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -699,13 +699,8 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // GuildMemberEdit edits the roles of a member.
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
-// roles    : A list of role ID's to set on the member.
-func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err error) {
-
-	data := struct {
-		Roles []string `json:"roles"`
-	}{roles}
-
+// data     : Struct of GuildMemberEditData
+func (s *Session) GuildMemberEdit(guildID, userID string, data GuildMemberEditData) (err error) {
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	return
 }

--- a/restapi.go
+++ b/restapi.go
@@ -710,12 +710,18 @@ func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err e
 	return
 }
 
-// GuildMemberEditComplex edits the roles & nickname of a member.
+// GuildMemberEditComplex edits the nickname and roles of a member.
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
-// data     : Struct of GuildMemberEditData
-func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemberEditData) (err error) {
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+// data     : A GuildMemberEditData struct with the new nickname and roles
+func (s *Session) GuildMemberEditComplex(guildID, userID string, data GuildMemberEditData) (st *Member, err error) {
+	var body []byte
+	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	if err != nil {
+		return nil, err
+	}
+
+	err = unmarshal(body, &st)
 	return
 }
 

--- a/restapi.go
+++ b/restapi.go
@@ -700,7 +700,7 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : Struct of GuildMemberEditData
-func (s *Session) GuildMemberEdit(guildID, userID string, data GuildMemberEditData) (err error) {
+func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberEditData) (err error) {
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	return
 }

--- a/restapi.go
+++ b/restapi.go
@@ -699,8 +699,22 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // GuildMemberEdit edits the roles of a member.
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
+// roles    : A list of role ID's to set on the member.
+func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err error) {
+
+	data := struct {
+		Roles []string `json:"roles"`
+	}{roles}
+
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	return
+}
+
+// GuildMemberEditComplex edits the roles & nickname of a member.
+// guildID  : The ID of a Guild.
+// userID   : The ID of a User.
 // data     : Struct of GuildMemberEditData
-func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberEditData) (err error) {
+func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemberEditData) (err error) {
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	return
 }

--- a/restapi.go
+++ b/restapi.go
@@ -714,7 +714,7 @@ func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err e
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : A GuildMemberEditData struct with the new nickname and roles
-func (s *Session) GuildMemberEditComplex(guildID, userID string, data GuildMemberEditData) (st *Member, err error) {
+func (s *Session) GuildMemberEditComplex(guildID, userID string, data GuildMemberParams) (st *Member, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	if err != nil {

--- a/structs.go
+++ b/structs.go
@@ -1567,6 +1567,7 @@ type UserGuildSettingsEdit struct {
 }
 
 // A GuildMemberEditData stores a payload to use in Session.GuildMemberEdit
+// https://discord.com/developers/docs/resources/guild#modify-guild-member
 type GuildMemberEditData struct {
 
 	// Value to set user's nickname to

--- a/structs.go
+++ b/structs.go
@@ -1566,6 +1566,31 @@ type UserGuildSettingsEdit struct {
 	ChannelOverrides     map[string]*UserGuildSettingsChannelOverride `json:"channel_overrides"`
 }
 
+// A GuildMemberEditData stores a payload to use in Session.GuildMemberEdit
+type GuildMemberEditData struct {
+
+	// Value to set user's nickname to
+	Nick string `json:"nick,omitempty"`
+
+	// Array of role ids the member is assigned
+	Roles []string `json:"roles,omitempty"`
+
+	// 	Whether the user is muted in voice channels. Will throw a 400 error
+	//	if the user is not in a voice channel
+	Mute bool `json:"mute,omitempty"`
+
+	// Whether the user is deafened in voice channels. Will throw a 400 error
+	// if the user is not in a voice channel
+	Deaf bool `json:"deaf,omitempty"`
+
+	// Id of channel to move user to (if they are connected to voice)
+	ChannelId string `json:"channel_id,omitempty"`
+
+	// The time at which the member's timeout will expire.
+	// Time in the past or nil if the user is not timed out.
+	CommunicationDisabledUntil *time.Time `json:"communication_disabled_until"`
+}
+
 // An APIErrorMessage is an api error message returned from discord
 type APIErrorMessage struct {
 	Code    int    `json:"code"`

--- a/structs.go
+++ b/structs.go
@@ -1566,9 +1566,9 @@ type UserGuildSettingsEdit struct {
 	ChannelOverrides     map[string]*UserGuildSettingsChannelOverride `json:"channel_overrides"`
 }
 
-// A GuildMemberEditData stores a payload to use in Session.GuildMemberEditComplex
+// GuildMemberParams stores data needed to update a member
 // https://discord.com/developers/docs/resources/guild#modify-guild-member
-type GuildMemberEditData struct {
+type GuildMemberParams struct {
 
 	// Value to set user's nickname to
 	Nick string `json:"nick,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -1566,7 +1566,7 @@ type UserGuildSettingsEdit struct {
 	ChannelOverrides     map[string]*UserGuildSettingsChannelOverride `json:"channel_overrides"`
 }
 
-// A GuildMemberEditData stores a payload to use in Session.GuildMemberEdit
+// A GuildMemberEditData stores a payload to use in Session.GuildMemberEditComplex
 // https://discord.com/developers/docs/resources/guild#modify-guild-member
 type GuildMemberEditData struct {
 
@@ -1574,7 +1574,7 @@ type GuildMemberEditData struct {
 	Nick string `json:"nick,omitempty"`
 
 	// Array of role ids the member is assigned
-	Roles []string `json:"roles,omitempty"`
+	Roles *[]string `json:"roles,omitempty"`
 }
 
 // An APIErrorMessage is an api error message returned from discord

--- a/structs.go
+++ b/structs.go
@@ -1569,10 +1569,8 @@ type UserGuildSettingsEdit struct {
 // GuildMemberParams stores data needed to update a member
 // https://discord.com/developers/docs/resources/guild#modify-guild-member
 type GuildMemberParams struct {
-
 	// Value to set user's nickname to
 	Nick string `json:"nick,omitempty"`
-
 	// Array of role ids the member is assigned
 	Roles *[]string `json:"roles,omitempty"`
 }

--- a/structs.go
+++ b/structs.go
@@ -1575,21 +1575,6 @@ type GuildMemberEditData struct {
 
 	// Array of role ids the member is assigned
 	Roles []string `json:"roles,omitempty"`
-
-	// 	Whether the user is muted in voice channels. Will throw a 400 error
-	//	if the user is not in a voice channel
-	Mute bool `json:"mute,omitempty"`
-
-	// Whether the user is deafened in voice channels. Will throw a 400 error
-	// if the user is not in a voice channel
-	Deaf bool `json:"deaf,omitempty"`
-
-	// Id of channel to move user to (if they are connected to voice)
-	ChannelId string `json:"channel_id,omitempty"`
-
-	// The time at which the member's timeout will expire.
-	// Time in the past or nil if the user is not timed out.
-	CommunicationDisabledUntil *time.Time `json:"communication_disabled_until"`
 }
 
 // An APIErrorMessage is an api error message returned from discord


### PR DESCRIPTION
When editing a guild member, you can do much more than just update their roles, i.e. their nickname

[Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild-member)

This change the method signature to expose a payload struct devs can use to set what they want to change on the member. We ommit any value from the future json payload if it was not set