### PR TITLE
Removed appID comment from InteractionRespond method which does not have this parameter

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -2687,7 +2687,6 @@ func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, 
 }
 
 // InteractionRespond creates the response to an interaction.
-// appID       : The application ID.
 // interaction : Interaction instance.
 // resp        : Response message data.
 func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) (err error) {


### PR DESCRIPTION
The comment for the InteractionRespond method mentions an appID despite the lack of an appID parameter. Likely copy paste. This change removes mention of the appID. 

![image](https://user-images.githubusercontent.com/2343437/156898296-f37a8472-5dca-4d06-bd89-a6d74a03b9ec.png)
