### PR TITLE
Reconfigure Golangci Linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,8 @@ linters:
     - nlreturn # Recommended
     - stylecheck # Recommended
     - paralleltest
+    - predeclared
+    - goerr113 # Recommended
   # Enable presets.
   # https://golangci-lint.run/usage/linters
   presets:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,23 +1,32 @@
 linters:
-  disable-all: true
+  disable-all: false
   enable:
     # - staticcheck (used in bugs preset)
-
+    - wastedassign
+    - ineffassign
+  disable:
+    - wsl
+    - gomnd
+    - lll
+    - wrapcheck
+    - tagliatelle
+    - gochecknoglobals
+    - errcheck
   # Enable presets.
   # https://golangci-lint.run/usage/linters
   presets:
-    - style
+    #- style
     # - unused
     # - bugs
 
 linters-settings:
-  staticcheck:
-    go: "1.13"
+  # staticcheck:
+  #  go: "1.13"
 
-    checks: ["all"]
+  #  checks: ["all"]
 
-  unused:
-    go: "1.13"
+  # unused:
+  #  go: "1.13"
 
 issues:
   include:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,20 +2,23 @@ linters:
   disable-all: false
   enable:
     # - staticcheck (used in bugs preset)
-    - wastedassign
-    - ineffassign
   disable:
-    - wsl
+    - wsl # Readability
     - gomnd
     - lll
-    - wrapcheck
+    - wrapcheck # Recommended
     - tagliatelle
     - gochecknoglobals
-    - errcheck
+    - errcheck # Recommended
+    - gosimple # Recommended
+    - exhaustivestruct # Recommended
+    - nlreturn # Recommended
+    - stylecheck # Recommended
+    - paralleltest
   # Enable presets.
   # https://golangci-lint.run/usage/linters
   presets:
-    #- style
+    - style
     # - unused
     # - bugs
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,14 @@
 linters:
   disable-all: true
   enable:
-    # - staticcheck
+    # - staticcheck (used in bugs preset)
+
+  # Enable presets.
+  # https://golangci-lint.run/usage/linters
+  presets:
+    - style
     # - unused
-    - golint
+    # - bugs
 
 linters-settings:
   staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,12 @@ linters:
     - paralleltest
     - predeclared
     - goerr113 # Recommended
+    - testpackage # Recommended
+    - godox # Recommended: TODO/BUG/FIXME
+    - goprintffuncname # Recommended
+    - gocritic # Recommended
+    - forbidigo
+    
   # Enable presets.
   # https://golangci-lint.run/usage/linters
   presets:

--- a/components.go
+++ b/components.go
@@ -31,8 +31,8 @@ func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 	var v struct {
 		Type ComponentType `json:"type"`
 	}
-	err := json.Unmarshal(src, &v)
-	if err != nil {
+
+	if err := json.Unmarshal(src, &v); err != nil {
 		return err
 	}
 
@@ -54,8 +54,7 @@ func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 // MessageComponentFromJSON is a helper function for unmarshaling message components.
 func MessageComponentFromJSON(b []byte) (MessageComponent, error) {
 	var u unmarshalableMessageComponent
-	err := u.UnmarshalJSON(b)
-	if err != nil {
+	if err := u.UnmarshalJSON(b); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal into MessageComponent: %w", err)
 	}
 	return u.MessageComponent, nil

--- a/components.go
+++ b/components.go
@@ -51,7 +51,7 @@ func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, umc.MessageComponent)
 }
 
-// MessageComponentFromJSON is a helper function for unmarshaling message components
+// MessageComponentFromJSON is a helper function for unmarshaling message components.
 func MessageComponentFromJSON(b []byte) (MessageComponent, error) {
 	var u unmarshalableMessageComponent
 	err := u.UnmarshalJSON(b)
@@ -234,7 +234,7 @@ func (m TextInput) MarshalJSON() ([]byte, error) {
 // TextInputStyle is style of text in TextInput component.
 type TextInputStyle uint
 
-// Text styles
+// Text styles.
 const (
 	TextInputShort     TextInputStyle = 1
 	TextInputParagraph TextInputStyle = 2

--- a/discord.go
+++ b/discord.go
@@ -28,7 +28,6 @@ const VERSION = "0.24.0"
 // Or if it is an OAuth2 token, it must be prefixed with "Bearer "
 //		e.g. "Bearer ..."
 func New(token string) (s *Session, err error) {
-
 	// Create an empty Session interface.
 	s = &Session{
 		State:                  NewState(),

--- a/discord_test.go
+++ b/discord_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 //////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////// VARS NEEDED FOR TESTING
+////////////////////////////////////////////////////// VARS NEEDED FOR TESTING.
 var (
 	dg    *Session // Stores a global discordgo user session
 	dgBot *Session // Stores a global discordgo bot session
@@ -49,7 +49,6 @@ func TestMain(m *testing.M) {
 
 // TestNewToken tests the New() function with a Token.
 func TestNewToken(t *testing.T) {
-
 	if envOAuth2Token == "" {
 		t.Skip("Skipping New(token), DGU_TOKEN not set")
 	}
@@ -118,7 +117,6 @@ func TestOpenClose(t *testing.T) {
 }
 
 func TestAddHandler(t *testing.T) {
-
 	testHandlerCalled := int32(0)
 	testHandler := func(s *Session, m *MessageCreate) {
 		atomic.AddInt32(&testHandlerCalled, 1)
@@ -162,7 +160,6 @@ func TestAddHandler(t *testing.T) {
 }
 
 func TestRemoveHandler(t *testing.T) {
-
 	testHandlerCalled := int32(0)
 	testHandler := func(s *Session, m *MessageCreate) {
 		atomic.AddInt32(&testHandlerCalled, 1)
@@ -249,7 +246,7 @@ func TestScheduledEvents(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(users) != 0 {
-		t.Fatal("err on GuildScheduledEventUsers. Mismatch of event maybe occured")
+		t.Fatal("err on GuildScheduledEventUsers. Mismatch of event maybe occurred")
 	}
 
 	err = dgBot.GuildScheduledEventDelete(envGuild, event.ID)

--- a/endpoints.go
+++ b/endpoints.go
@@ -45,7 +45,7 @@ var (
 	EndpointVoice        = EndpointAPI + "/voice/"
 	EndpointVoiceRegions = EndpointVoice + "regions"
 
-	// TODO: EndpointUserGuildMember
+	// TODO: EndpointUserGuildMember.
 
 	EndpointUser               = func(uID string) string { return EndpointUsers + uID }
 	EndpointUserAvatar         = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".png" }
@@ -201,7 +201,7 @@ var (
 	EndpointOAuth2ApplicationsBot   = func(aID string) string { return EndpointOAuth2Applications + "/" + aID + "/bot" }
 	EndpointOAuth2ApplicationAssets = func(aID string) string { return EndpointOAuth2Applications + "/" + aID + "/assets" }
 
-	// TODO: Deprecated, remove in the next release
+	// TODO: Deprecated, remove in the next release.
 	EndpointOauth2                  = EndpointOAuth2
 	EndpointOauth2Applications      = EndpointOAuth2Applications
 	EndpointOauth2Application       = EndpointOAuth2Application

--- a/event.go
+++ b/event.go
@@ -241,7 +241,6 @@ func (s *Session) onInterface(i interface{}) {
 
 // onReady handles the ready event.
 func (s *Session) onReady(r *Ready) {
-
 	// Store the SessionID within the Session struct.
 	s.sessionID = r.SessionID
 }

--- a/events.go
+++ b/events.go
@@ -334,20 +334,20 @@ type VoiceStateUpdate struct {
 	BeforeUpdate *VoiceState `json:"-"`
 }
 
-// MessageDeleteBulk is the data for a MessageDeleteBulk event
+// MessageDeleteBulk is the data for a MessageDeleteBulk event.
 type MessageDeleteBulk struct {
 	Messages  []string `json:"ids"`
 	ChannelID string   `json:"channel_id"`
 	GuildID   string   `json:"guild_id"`
 }
 
-// WebhooksUpdate is the data for a WebhooksUpdate event
+// WebhooksUpdate is the data for a WebhooksUpdate event.
 type WebhooksUpdate struct {
 	GuildID   string `json:"guild_id"`
 	ChannelID string `json:"channel_id"`
 }
 
-// InteractionCreate is the data for a InteractionCreate event
+// InteractionCreate is the data for a InteractionCreate event.
 type InteractionCreate struct {
 	*Interaction
 }
@@ -357,14 +357,14 @@ func (i *InteractionCreate) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &i.Interaction)
 }
 
-// InviteCreate is the data for a InviteCreate event
+// InviteCreate is the data for a InviteCreate event.
 type InviteCreate struct {
 	*Invite
 	ChannelID string `json:"channel_id"`
 	GuildID   string `json:"guild_id"`
 }
 
-// InviteDelete is the data for a InviteDelete event
+// InviteDelete is the data for a InviteDelete event.
 type InviteDelete struct {
 	ChannelID string `json:"channel_id"`
 	GuildID   string `json:"guild_id"`

--- a/interactions.go
+++ b/interactions.go
@@ -18,7 +18,7 @@ const InteractionDeadline = time.Second * 3
 // ApplicationCommandType represents the type of application command.
 type ApplicationCommandType uint8
 
-// Application command types
+// Application command types.
 const (
 	// ChatApplicationCommand is default command type. They are slash commands (i.e. called directly from the chat).
 	ChatApplicationCommand ApplicationCommandType = 1
@@ -149,7 +149,7 @@ const (
 // InteractionType indicates the type of an interaction event.
 type InteractionType uint8
 
-// Interaction types
+// Interaction types.
 const (
 	InteractionPing                           InteractionType = 1
 	InteractionApplicationCommand             InteractionType = 2
@@ -366,7 +366,7 @@ type ApplicationCommandInteractionDataOption struct {
 	Focused bool `json:"focused,omitempty"`
 }
 
-// IntValue is a utility function for casting option value to integer
+// IntValue is a utility function for casting option value to integer.
 func (o ApplicationCommandInteractionDataOption) IntValue() int64 {
 	if o.Type != ApplicationCommandOptionInteger {
 		panic("IntValue called on data option of type " + o.Type.String())
@@ -374,7 +374,7 @@ func (o ApplicationCommandInteractionDataOption) IntValue() int64 {
 	return int64(o.Value.(float64))
 }
 
-// UintValue is a utility function for casting option value to unsigned integer
+// UintValue is a utility function for casting option value to unsigned integer.
 func (o ApplicationCommandInteractionDataOption) UintValue() uint64 {
 	if o.Type != ApplicationCommandOptionInteger {
 		panic("UintValue called on data option of type " + o.Type.String())
@@ -382,7 +382,7 @@ func (o ApplicationCommandInteractionDataOption) UintValue() uint64 {
 	return uint64(o.Value.(float64))
 }
 
-// FloatValue is a utility function for casting option value to float
+// FloatValue is a utility function for casting option value to float.
 func (o ApplicationCommandInteractionDataOption) FloatValue() float64 {
 	if o.Type != ApplicationCommandOptionNumber {
 		panic("FloatValue called on data option of type " + o.Type.String())
@@ -390,7 +390,7 @@ func (o ApplicationCommandInteractionDataOption) FloatValue() float64 {
 	return o.Value.(float64)
 }
 
-// StringValue is a utility function for casting option value to string
+// StringValue is a utility function for casting option value to string.
 func (o ApplicationCommandInteractionDataOption) StringValue() string {
 	if o.Type != ApplicationCommandOptionString {
 		panic("StringValue called on data option of type " + o.Type.String())
@@ -398,7 +398,7 @@ func (o ApplicationCommandInteractionDataOption) StringValue() string {
 	return o.Value.(string)
 }
 
-// BoolValue is a utility function for casting option value to bool
+// BoolValue is a utility function for casting option value to bool.
 func (o ApplicationCommandInteractionDataOption) BoolValue() bool {
 	if o.Type != ApplicationCommandOptionBoolean {
 		panic("BoolValue called on data option of type " + o.Type.String())
@@ -407,7 +407,7 @@ func (o ApplicationCommandInteractionDataOption) BoolValue() bool {
 }
 
 // ChannelValue is a utility function for casting option value to channel object.
-// s : Session object, if not nil, function additionally fetches all channel's data
+// s : Session object, if not nil, function additionally fetches all channel's data.
 func (o ApplicationCommandInteractionDataOption) ChannelValue(s *Session) *Channel {
 	if o.Type != ApplicationCommandOptionChannel {
 		panic("ChannelValue called on data option of type " + o.Type.String())
@@ -430,7 +430,7 @@ func (o ApplicationCommandInteractionDataOption) ChannelValue(s *Session) *Chann
 }
 
 // RoleValue is a utility function for casting option value to role object.
-// s : Session object, if not nil, function additionally fetches all role's data
+// s : Session object, if not nil, function additionally fetches all role's data.
 func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID string) *Role {
 	if o.Type != ApplicationCommandOptionRole && o.Type != ApplicationCommandOptionMentionable {
 		panic("RoleValue called on data option of type " + o.Type.String())
@@ -458,7 +458,7 @@ func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID strin
 }
 
 // UserValue is a utility function for casting option value to user object.
-// s : Session object, if not nil, function additionally fetches all user's data
+// s : Session object, if not nil, function additionally fetches all user's data.
 func (o ApplicationCommandInteractionDataOption) UserValue(s *Session) *User {
 	if o.Type != ApplicationCommandOptionUser && o.Type != ApplicationCommandOptionMentionable {
 		panic("UserValue called on data option of type " + o.Type.String())

--- a/interactions.go
+++ b/interactions.go
@@ -412,7 +412,10 @@ func (o ApplicationCommandInteractionDataOption) ChannelValue(s *Session) *Chann
 	if o.Type != ApplicationCommandOptionChannel {
 		panic("ChannelValue called on data option of type " + o.Type.String())
 	}
-	chanID := o.Value.(string)
+	chanID, ok := o.Value.(string)
+	if !ok {
+		panic("ChannelValue could not type assert string to channel.")
+	}
 
 	if s == nil {
 		return &Channel{ID: chanID}
@@ -435,7 +438,10 @@ func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID strin
 	if o.Type != ApplicationCommandOptionRole && o.Type != ApplicationCommandOptionMentionable {
 		panic("RoleValue called on data option of type " + o.Type.String())
 	}
-	roleID := o.Value.(string)
+	roleID, ok := o.Value.(string)
+	if !ok {
+		panic("RoleValue could not type assert string to Role.")
+	}
 
 	if s == nil || gID == "" {
 		return &Role{ID: roleID}
@@ -463,7 +469,10 @@ func (o ApplicationCommandInteractionDataOption) UserValue(s *Session) *User {
 	if o.Type != ApplicationCommandOptionUser && o.Type != ApplicationCommandOptionMentionable {
 		panic("UserValue called on data option of type " + o.Type.String())
 	}
-	userID := o.Value.(string)
+	userID, ok := o.Value.(string)
+	if !ok {
+		panic("UserValue could not type assert string to User.")
+	}
 
 	if s == nil {
 		return &User{ID: userID}

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -18,8 +18,9 @@ func TestVerifyInteraction(t *testing.T) {
 	}
 	timestamp := "1608597133"
 
+	const body = "body"
+
 	t.Run("success", func(t *testing.T) {
-		body := "body"
 		request := httptest.NewRequest("POST", "http://localhost/interaction", strings.NewReader(body))
 		request.Header.Set("X-Signature-Timestamp", timestamp)
 
@@ -35,7 +36,6 @@ func TestVerifyInteraction(t *testing.T) {
 	})
 
 	t.Run("failure/modified body", func(t *testing.T) {
-		body := "body"
 		request := httptest.NewRequest("POST", "http://localhost/interaction", strings.NewReader("WRONG"))
 		request.Header.Set("X-Signature-Timestamp", timestamp)
 
@@ -51,7 +51,6 @@ func TestVerifyInteraction(t *testing.T) {
 	})
 
 	t.Run("failure/modified timestamp", func(t *testing.T) {
-		body := "body"
 		request := httptest.NewRequest("POST", "http://localhost/interaction", strings.NewReader("WRONG"))
 		request.Header.Set("X-Signature-Timestamp", strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10))
 

--- a/locales.go
+++ b/locales.go
@@ -4,7 +4,7 @@ package discordgo
 // https://discord.com/developers/docs/reference#locales
 type Locale string
 
-// String returns the human-readable string of the locale
+// String returns the human-readable string of the locale.
 func (l Locale) String() string {
 	if name, ok := Locales[l]; ok {
 		return name
@@ -12,7 +12,7 @@ func (l Locale) String() string {
 	return Unknown.String()
 }
 
-// All defined locales in Discord
+// All defined locales in Discord.
 const (
 	EnglishUS    Locale = "en-US"
 	EnglishGB    Locale = "en-GB"

--- a/logging.go
+++ b/logging.go
@@ -26,7 +26,7 @@ const (
 	// also returned to a calling function.
 	LogWarning
 
-	// LogInformational level is used for normal non-error activity
+	// LogInformational level is used for normal non-error activity.
 	LogInformational
 
 	// LogDebug level is for very detailed non-error activity.  This is
@@ -34,7 +34,7 @@ const (
 	LogDebug
 )
 
-// Logger can be used to replace the standard logging for discordgo
+// Logger can be used to replace the standard logging for discordgo.
 var Logger func(msgL, caller int, format string, a ...interface{})
 
 // msglog provides package wide logging consistency for discordgo
@@ -44,11 +44,9 @@ var Logger func(msgL, caller int, format string, a ...interface{})
 //   format : Printf style message format
 //   a ...  : comma separated list of values to pass
 func msglog(msgL, caller int, format string, a ...interface{}) {
-
 	if Logger != nil {
 		Logger(msgL, caller, format, a...)
 	} else {
-
 		pc, file, line, _ := runtime.Caller(caller)
 
 		files := strings.Split(file, "/")
@@ -67,9 +65,8 @@ func msglog(msgL, caller int, format string, a ...interface{}) {
 // helper function that wraps msglog for the Session struct
 // This adds a check to insure the message is only logged
 // if the session log level is equal or higher than the
-// message log level
+// message log level.
 func (s *Session) log(msgL int, format string, a ...interface{}) {
-
 	if msgL > s.LogLevel {
 		return
 	}
@@ -80,9 +77,8 @@ func (s *Session) log(msgL int, format string, a ...interface{}) {
 // helper function that wraps msglog for the VoiceConnection struct
 // This adds a check to insure the message is only logged
 // if the voice connection log level is equal or higher than the
-// message log level
+// message log level.
 func (v *VoiceConnection) log(msgL int, format string, a ...interface{}) {
-
 	if msgL > v.LogLevel {
 		return
 	}

--- a/message.go
+++ b/message.go
@@ -482,18 +482,16 @@ var patternChannels = regexp.MustCompile("<#[^>]*>")
 
 // ContentWithMoreMentionsReplaced will replace all @<id> mentions with the
 // username of the mention, but also role IDs and more.
-func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, err error) {
-	content = m.Content
+func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (string, error) {
+	content := m.Content
 
 	if !s.StateEnabled {
-		content = m.ContentWithMentionsReplaced()
-		return "", nil
+		return m.ContentWithMentionsReplaced(), nil
 	}
 
 	channel, err := s.State.Channel(m.ChannelID)
 	if err != nil {
-		content = m.ContentWithMentionsReplaced()
-		return "", nil
+		return m.ContentWithMentionsReplaced(), nil
 	}
 
 	for _, user := range m.Mentions {
@@ -518,6 +516,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 		content = strings.Replace(content, "<@&"+role.ID+">", "@"+role.Name, -1)
 	}
 
+	// lint:ignore Ineffective Assign Unclear
 	content = patternChannels.ReplaceAllStringFunc(content, func(mention string) string {
 		channel, err := s.State.Channel(mention[2 : len(mention)-1])
 		if err != nil || channel.Type == ChannelTypeGuildVoice {
@@ -526,7 +525,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 
 		return "#" + channel.Name
 	})
-	return "", nil
+	return content, nil
 }
 
 // MessageInteraction contains information about the application command interaction which generated the message.

--- a/message.go
+++ b/message.go
@@ -475,7 +475,7 @@ func (m *Message) ContentWithMentionsReplaced() (content string) {
 			"<@!"+user.ID+">", "@"+user.Username,
 		).Replace(content)
 	}
-	return
+	return ""
 }
 
 var patternChannels = regexp.MustCompile("<#[^>]*>")
@@ -487,13 +487,13 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 
 	if !s.StateEnabled {
 		content = m.ContentWithMentionsReplaced()
-		return
+		return "", nil
 	}
 
 	channel, err := s.State.Channel(m.ChannelID)
 	if err != nil {
 		content = m.ContentWithMentionsReplaced()
-		return
+		return "", nil
 	}
 
 	for _, user := range m.Mentions {
@@ -526,7 +526,7 @@ func (m *Message) ContentWithMoreMentionsReplaced(s *Session) (content string, e
 
 		return "#" + channel.Name
 	})
-	return
+	return "", nil
 }
 
 // MessageInteraction contains information about the application command interaction which generated the message.

--- a/message.go
+++ b/message.go
@@ -21,7 +21,7 @@ import (
 // https://discord.com/developers/docs/resources/channel#message-object-message-types
 type MessageType int
 
-// Block contains the valid known MessageType values
+// Block contains the valid known MessageType values.
 const (
 	MessageTypeDefault                               MessageType = 0
 	MessageTypeRecipientAdd                          MessageType = 1
@@ -193,7 +193,7 @@ func (m *Message) GetCustomEmojis() []*Emoji {
 // https://discord.com/developers/docs/resources/channel#message-object-message-flags
 type MessageFlags int
 
-// Valid MessageFlags values
+// Valid MessageFlags values.
 const (
 	// MessageFlagsCrossPosted This message has been published to subscribed channels (via Channel Following).
 	MessageFlagsCrossPosted MessageFlags = 1 << 0
@@ -405,7 +405,7 @@ type MessageEmbed struct {
 // https://discord.com/developers/docs/resources/channel#embed-object-embed-types
 type EmbedType string
 
-// Block of valid EmbedTypes
+// Block of valid EmbedTypes.
 const (
 	EmbedTypeRich    EmbedType = "rich"
 	EmbedTypeImage   EmbedType = "image"
@@ -422,16 +422,16 @@ type MessageReactions struct {
 	Emoji *Emoji `json:"emoji"`
 }
 
-// MessageActivity is sent with Rich Presence-related chat embeds
+// MessageActivity is sent with Rich Presence-related chat embeds.
 type MessageActivity struct {
 	Type    MessageActivityType `json:"type"`
 	PartyID string              `json:"party_id"`
 }
 
-// MessageActivityType is the type of message activity
+// MessageActivityType is the type of message activity.
 type MessageActivityType int
 
-// Constants for the different types of Message Activity
+// Constants for the different types of Message Activity.
 const (
 	MessageActivityTypeJoin        MessageActivityType = 1
 	MessageActivityTypeSpectate    MessageActivityType = 2
@@ -439,7 +439,7 @@ const (
 	MessageActivityTypeJoinRequest MessageActivityType = 5
 )
 
-// MessageApplication is sent with Rich Presence-related chat embeds
+// MessageApplication is sent with Rich Presence-related chat embeds.
 type MessageApplication struct {
 	ID          string `json:"id"`
 	CoverImage  string `json:"cover_image"`
@@ -448,14 +448,14 @@ type MessageApplication struct {
 	Name        string `json:"name"`
 }
 
-// MessageReference contains reference data sent with crossposted messages
+// MessageReference contains reference data sent with crossposted messages.
 type MessageReference struct {
 	MessageID string `json:"message_id"`
 	ChannelID string `json:"channel_id"`
 	GuildID   string `json:"guild_id,omitempty"`
 }
 
-// Reference returns MessageReference of given message
+// Reference returns MessageReference of given message.
 func (m *Message) Reference() *MessageReference {
 	return &MessageReference{
 		GuildID:   m.GuildID,

--- a/message_test.go
+++ b/message_test.go
@@ -48,5 +48,4 @@ func TestGettingEmojisFromMessage(t *testing.T) {
 		t.Error("No emojis found.")
 		return
 	}
-
 }

--- a/oauth2.go
+++ b/oauth2.go
@@ -45,11 +45,14 @@ type Team struct {
 func (s *Session) Application(appID string) (st *Application, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointOAuth2Application(appID), nil, EndpointOAuth2Application(""))
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	err = unmarshal(body, &st)
-	return
+	if err != nil {
+		return nil, err
+	}
+	return st, nil
 }
 
 // Applications returns all applications for the authenticated user.

--- a/oauth2.go
+++ b/oauth2.go
@@ -13,16 +13,16 @@ package discordgo
 // Code specific to Discord OAuth2 Applications
 // ------------------------------------------------------------------------------------------------
 
-// The MembershipState represents whether the user is in the team or has been invited into it
+// The MembershipState represents whether the user is in the team or has been invited into it.
 type MembershipState int
 
-// Constants for the different stages of the MembershipState
+// Constants for the different stages of the MembershipState.
 const (
 	MembershipStateInvited  MembershipState = 1
 	MembershipStateAccepted MembershipState = 2
 )
 
-// A TeamMember struct stores values for a single Team Member, extending the normal User data - note that the user field is partial
+// A TeamMember struct stores values for a single Team Member, extending the normal User data - note that the user field is partial.
 type TeamMember struct {
 	User            *User           `json:"user"`
 	TeamID          string          `json:"team_id"`
@@ -30,7 +30,7 @@ type TeamMember struct {
 	Permissions     []string        `json:"permissions"`
 }
 
-// A Team struct stores the members of a Discord Developer Team as well as some metadata about it
+// A Team struct stores the members of a Discord Developer Team as well as some metadata about it.
 type Team struct {
 	ID          string        `json:"id"`
 	Name        string        `json:"name"`
@@ -43,7 +43,6 @@ type Team struct {
 // Application returns an Application structure of a specific Application
 //   appID : The ID of an Application
 func (s *Session) Application(appID string) (st *Application, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointOAuth2Application(appID), nil, EndpointOAuth2Application(""))
 	if err != nil {
 		return
@@ -53,9 +52,8 @@ func (s *Session) Application(appID string) (st *Application, err error) {
 	return
 }
 
-// Applications returns all applications for the authenticated user
+// Applications returns all applications for the authenticated user.
 func (s *Session) Applications() (st []*Application, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointOAuth2Applications, nil, EndpointOAuth2Applications)
 	if err != nil {
 		return
@@ -69,7 +67,6 @@ func (s *Session) Applications() (st []*Application, err error) {
 //    name : Name of Application / Bot
 //    uris : Redirect URIs (Not required)
 func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error) {
-
 	data := struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
@@ -87,7 +84,6 @@ func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error
 // ApplicationUpdate updates an existing Application
 //   var : desc
 func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Application, err error) {
-
 	data := struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
@@ -105,7 +101,6 @@ func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Applicat
 // ApplicationDelete deletes an existing Application
 //   appID : The ID of an Application
 func (s *Session) ApplicationDelete(appID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointOAuth2Application(appID), nil, EndpointOAuth2Application(""))
 	if err != nil {
 		return
@@ -114,16 +109,15 @@ func (s *Session) ApplicationDelete(appID string) (err error) {
 	return
 }
 
-// Asset struct stores values for an asset of an application
+// Asset struct stores values for an asset of an application.
 type Asset struct {
 	Type int    `json:"type"`
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
-// ApplicationAssets returns an application's assets
+// ApplicationAssets returns an application's assets.
 func (s *Session) ApplicationAssets(appID string) (ass []*Asset, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointOAuth2ApplicationAssets(appID), nil, EndpointOAuth2ApplicationAssets(""))
 	if err != nil {
 		return
@@ -143,7 +137,6 @@ func (s *Session) ApplicationAssets(appID string) (ass []*Asset, err error) {
 //
 // NOTE: func name may change, if I can think up something better.
 func (s *Session) ApplicationBotCreate(appID string) (st *User, err error) {
-
 	body, err := s.RequestWithBucketID("POST", EndpointOAuth2ApplicationsBot(appID), nil, EndpointOAuth2ApplicationsBot(""))
 	if err != nil {
 		return

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func ExampleApplication() {
-
 	// Authentication Token pulled from environment variable DGU_TOKEN
 	Token := os.Getenv("DGU_TOKEN")
 	if Token == "" {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -10,14 +10,14 @@ import (
 	"time"
 )
 
-// customRateLimit holds information for defining a custom rate limit
+// customRateLimit holds information for defining a custom rate limit.
 type customRateLimit struct {
 	suffix   string
 	requests int
 	reset    time.Duration
 }
 
-// RateLimiter holds all ratelimit buckets
+// RateLimiter holds all ratelimit buckets.
 type RateLimiter struct {
 	sync.Mutex
 	global           *int64
@@ -26,9 +26,8 @@ type RateLimiter struct {
 	customRateLimits []*customRateLimit
 }
 
-// NewRatelimiter returns a new RateLimiter
+// NewRatelimiter returns a new RateLimiter.
 func NewRatelimiter() *RateLimiter {
-
 	return &RateLimiter{
 		buckets: make(map[string]*Bucket),
 		global:  new(int64),
@@ -42,7 +41,7 @@ func NewRatelimiter() *RateLimiter {
 	}
 }
 
-// GetBucket retrieves or creates a bucket
+// GetBucket retrieves or creates a bucket.
 func (r *RateLimiter) GetBucket(key string) *Bucket {
 	r.Lock()
 	defer r.Unlock()
@@ -69,7 +68,7 @@ func (r *RateLimiter) GetBucket(key string) *Bucket {
 	return b
 }
 
-// GetWaitTime returns the duration you should wait for a Bucket
+// GetWaitTime returns the duration you should wait for a Bucket.
 func (r *RateLimiter) GetWaitTime(b *Bucket, minRemaining int) time.Duration {
 	// If we ran out of calls and the reset time is still ahead of us
 	// then we need to take it easy and relax a little
@@ -86,12 +85,12 @@ func (r *RateLimiter) GetWaitTime(b *Bucket, minRemaining int) time.Duration {
 	return 0
 }
 
-// LockBucket Locks until a request can be made
+// LockBucket Locks until a request can be made.
 func (r *RateLimiter) LockBucket(bucketID string) *Bucket {
 	return r.LockBucketObject(r.GetBucket(bucketID))
 }
 
-// LockBucketObject Locks an already resolved bucket until a request can be made
+// LockBucketObject Locks an already resolved bucket until a request can be made.
 func (r *RateLimiter) LockBucketObject(b *Bucket) *Bucket {
 	b.Lock()
 
@@ -103,7 +102,7 @@ func (r *RateLimiter) LockBucketObject(b *Bucket) *Bucket {
 	return b
 }
 
-// Bucket represents a ratelimit bucket, each bucket gets ratelimited individually (-global ratelimits)
+// Bucket represents a ratelimit bucket, each bucket gets ratelimited individually (-global ratelimits).
 type Bucket struct {
 	sync.Mutex
 	Key       string

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -22,7 +22,6 @@ type RateLimiter struct {
 	sync.Mutex
 	global           *int64
 	buckets          map[string]*Bucket
-	globalRateLimit  time.Duration
 	customRateLimits []*customRateLimit
 }
 
@@ -107,7 +106,6 @@ type Bucket struct {
 	sync.Mutex
 	Key       string
 	Remaining int
-	limit     int
 	reset     time.Time
 	global    *int64
 

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// This test takes ~2 seconds to run
+// This test takes ~2 seconds to run.
 func TestRatelimitReset(t *testing.T) {
 	rl := NewRatelimiter()
 
@@ -46,7 +46,7 @@ func TestRatelimitReset(t *testing.T) {
 	}
 }
 
-// This test takes ~1 seconds to run
+// This test takes ~1 seconds to run.
 func TestRatelimitGlobal(t *testing.T) {
 	rl := NewRatelimiter()
 
@@ -99,7 +99,7 @@ func BenchmarkRatelimitParallelMultiEndpoints(b *testing.B) {
 	})
 }
 
-// Does not actually send requests, but locks the bucket and releases it with made-up headers
+// Does not actually send requests, but locks the bucket and releases it with made-up headers.
 func sendBenchReq(endpoint string, rl *RateLimiter) {
 	bucket := rl.LockBucket(endpoint)
 

--- a/restapi.go
+++ b/restapi.go
@@ -172,8 +172,7 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 }
 
 func unmarshal(data []byte, v interface{}) error {
-	err := json.Unmarshal(data, v)
-	if err != nil {
+	if err := json.Unmarshal(data, v); err != nil {
 		return fmt.Errorf("%w: %s", ErrJSONUnmarshal, err)
 	}
 
@@ -329,11 +328,11 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string) (st []*UserGui
 //
 // NOTE: This function is now deprecated and will be removed in the future.
 // Please see the same function inside state.go.
-func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions int64, err error) {
+func (s *Session) UserChannelPermissions(userID, channelID string) (int64, error) {
 	// Try to just get permissions from state.
-	apermissions, err = s.State.UserChannelPermissions(userID, channelID)
+	apermissions, err := s.State.UserChannelPermissions(userID, channelID)
 	if err == nil {
-		return 0, err
+		return apermissions, err
 	}
 
 	// Otherwise try get as much data from state as possible, falling back to the network.

--- a/restapi.go
+++ b/restapi.go
@@ -28,7 +28,7 @@ import (
 	"time"
 )
 
-// All error constants
+// All error constants.
 var (
 	ErrJSONUnmarshal           = errors.New("json unmarshal")
 	ErrStatusOffline           = errors.New("You can't set your Status to offline")
@@ -39,7 +39,7 @@ var (
 	ErrUnauthorized            = errors.New("HTTP request was unauthorized. This could be because the provided token was not a bot token. Please add \"Bot \" to the start of your token. https://discord.com/developers/docs/reference#authentication-example-bot-token-authorization-header")
 )
 
-// Request is the same as RequestWithBucketID but the bucket id is the same as the urlStr
+// Request is the same as RequestWithBucketID but the bucket id is the same as the urlStr.
 func (s *Session) Request(method, urlStr string, data interface{}) (response []byte, err error) {
 	return s.RequestWithBucketID(method, urlStr, data, strings.SplitN(urlStr, "?", 2)[0])
 }
@@ -59,7 +59,7 @@ func (s *Session) RequestWithBucketID(method, urlStr string, data interface{}, b
 
 // request makes a (GET/POST/...) Requests to Discord REST API.
 // Sequence is the sequence number, if it fails with a 502 it will
-// retry with sequence+1 until it either succeeds or sequence >= session.MaxRestRetries
+// retry with sequence+1 until it either succeeds or sequence >= session.MaxRestRetries.
 func (s *Session) request(method, urlStr, contentType string, b []byte, bucketID string, sequence int) (response []byte, err error) {
 	if bucketID == "" {
 		bucketID = strings.SplitN(urlStr, "?", 2)[0]
@@ -67,7 +67,7 @@ func (s *Session) request(method, urlStr, contentType string, b []byte, bucketID
 	return s.RequestWithLockedBucket(method, urlStr, contentType, b, s.Ratelimiter.LockBucket(bucketID), sequence)
 }
 
-// RequestWithLockedBucket makes a request using a bucket that's already been locked
+// RequestWithLockedBucket makes a request using a bucket that's already been locked.
 func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b []byte, bucket *Bucket, sequence int) (response []byte, err error) {
 	if s.Debug {
 		log.Printf("API REQUEST %8s :: %s\n", method, urlStr)
@@ -124,7 +124,6 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 	}
 
 	if s.Debug {
-
 		log.Printf("API RESPONSE  STATUS :: %s\n", resp.Status)
 		for k, v := range resp.Header {
 			log.Printf("API RESPONSE  HEADER :: [%s] = %+v\n", k, v)
@@ -139,7 +138,6 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 	case http.StatusBadGateway:
 		// Retry sending request if possible
 		if sequence < s.MaxRestRetries {
-
 			s.log(LogInformational, "%s Failed (%s), Retrying...", urlStr, resp.Status)
 			response, err = s.RequestWithLockedBucket(method, urlStr, contentType, b, s.Ratelimiter.LockBucketObject(bucket), sequence+1)
 		} else {
@@ -187,9 +185,8 @@ func unmarshal(data []byte, v interface{}) error {
 // ------------------------------------------------------------------------------------------------
 
 // User returns the user details of the given userID
-// userID    : A user ID or "@me" which is a shortcut of current user ID
+// userID    : A user ID or "@me" which is a shortcut of current user ID.
 func (s *Session) User(userID string) (st *User, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointUser(userID), nil, EndpointUsers)
 	if err != nil {
 		return
@@ -200,7 +197,7 @@ func (s *Session) User(userID string) (st *User, err error) {
 }
 
 // UserAvatar is deprecated. Please use UserAvatarDecode
-// userID    : A user ID or "@me" which is a shortcut of current user ID
+// userID    : A user ID or "@me" which is a shortcut of current user ID.
 func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 	u, err := s.User(userID)
 	if err != nil {
@@ -211,7 +208,7 @@ func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 }
 
 // UserAvatarDecode returns an image.Image of a user's Avatar
-// user : The user which avatar should be retrieved
+// user : The user which avatar should be retrieved.
 func (s *Session) UserAvatarDecode(u *User) (img image.Image, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(u.ID, u.Avatar), nil, EndpointUserAvatar("", ""))
 	if err != nil {
@@ -224,7 +221,6 @@ func (s *Session) UserAvatarDecode(u *User) (img image.Image, err error) {
 
 // UserUpdate updates current user settings.
 func (s *Session) UserUpdate(username, avatar string) (st *User, err error) {
-
 	// NOTE: Avatar must be either the hash/id of existing Avatar or
 	// data:image/png;base64,BASE64_STRING_OF_NEW_AVATAR_PNG
 	// to set a new avatar.
@@ -244,7 +240,7 @@ func (s *Session) UserUpdate(username, avatar string) (st *User, err error) {
 	return
 }
 
-// UserConnections returns the user's connections
+// UserConnections returns the user's connections.
 func (s *Session) UserConnections() (conn []*UserConnection, err error) {
 	response, err := s.RequestWithBucketID("GET", EndpointUserConnections("@me"), nil, EndpointUserConnections("@me"))
 	if err != nil {
@@ -262,7 +258,6 @@ func (s *Session) UserConnections() (conn []*UserConnection, err error) {
 // UserChannelCreate creates a new User (Private) Channel with another User
 // recipientID : A user ID for the user to which this channel is opened with.
 func (s *Session) UserChannelCreate(recipientID string) (st *Channel, err error) {
-
 	data := struct {
 		RecipientID string `json:"recipient_id"`
 	}{recipientID}
@@ -281,7 +276,6 @@ func (s *Session) UserChannelCreate(recipientID string) (st *Channel, err error)
 // beforeID  : If provided all guilds returned will be before given ID.
 // afterID   : If provided all guilds returned will be after given ID.
 func (s *Session) UserGuilds(limit int, beforeID, afterID string) (st []*UserGuild, err error) {
-
 	v := url.Values{}
 
 	if limit > 0 {
@@ -314,7 +308,7 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string) (st []*UserGui
 // channelID : The ID of the channel to calculate permission for.
 //
 // NOTE: This function is now deprecated and will be removed in the future.
-// Please see the same function inside state.go
+// Please see the same function inside state.go.
 func (s *Session) UserChannelPermissions(userID, channelID string) (apermissions int64, err error) {
 	// Try to just get permissions from state.
 	apermissions, err = s.State.UserChannelPermissions(userID, channelID)
@@ -427,7 +421,7 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 // ------------------------------------------------------------------------------------------------
 
 // Guild returns a Guild structure of a specific Guild.
-// guildID   : The ID of a Guild
+// guildID   : The ID of a Guild.
 func (s *Session) Guild(guildID string) (st *Guild, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointGuild(guildID), nil, EndpointGuild(guildID))
 	if err != nil {
@@ -439,7 +433,7 @@ func (s *Session) Guild(guildID string) (st *Guild, err error) {
 }
 
 // GuildPreview returns a GuildPreview structure of a specific public Guild.
-// guildID   : The ID of a Guild
+// guildID   : The ID of a Guild.
 func (s *Session) GuildPreview(guildID string) (st *GuildPreview, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointGuildPreview(guildID), nil, EndpointGuildPreview(guildID))
 	if err != nil {
@@ -451,9 +445,8 @@ func (s *Session) GuildPreview(guildID string) (st *GuildPreview, err error) {
 }
 
 // GuildCreate creates a new Guild
-// name      : A name for the Guild (2-100 characters)
+// name      : A name for the Guild (2-100 characters).
 func (s *Session) GuildCreate(name string) (st *Guild, err error) {
-
 	data := struct {
 		Name string `json:"name"`
 	}{name}
@@ -471,7 +464,6 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 // guildID   : The ID of a Guild
 // g 		 : A GuildParams struct with the values Name, Region and VerificationLevel defined.
 func (s *Session) GuildEdit(guildID string, g GuildParams) (st *Guild, err error) {
-
 	// Bounds checking for VerificationLevel, interval: [0, 4]
 	if g.VerificationLevel != nil {
 		val := *g.VerificationLevel
@@ -510,9 +502,8 @@ func (s *Session) GuildEdit(guildID string, g GuildParams) (st *Guild, err error
 }
 
 // GuildDelete deletes a Guild.
-// guildID   : The ID of a Guild
+// guildID   : The ID of a Guild.
 func (s *Session) GuildDelete(guildID string) (st *Guild, err error) {
-
 	body, err := s.RequestWithBucketID("DELETE", EndpointGuild(guildID), nil, EndpointGuild(guildID))
 	if err != nil {
 		return
@@ -523,9 +514,8 @@ func (s *Session) GuildDelete(guildID string) (st *Guild, err error) {
 }
 
 // GuildLeave leaves a Guild.
-// guildID   : The ID of a Guild
+// guildID   : The ID of a Guild.
 func (s *Session) GuildLeave(guildID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointUserGuild("@me", guildID), nil, EndpointUserGuild("", guildID))
 	return
 }
@@ -534,7 +524,6 @@ func (s *Session) GuildLeave(guildID string) (err error) {
 // given guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildBans(guildID string) (st []*GuildBan, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildBans(guildID), nil, EndpointGuildBans(guildID))
 	if err != nil {
 		return
@@ -553,9 +542,8 @@ func (s *Session) GuildBanCreate(guildID, userID string, days int) (err error) {
 	return s.GuildBanCreateWithReason(guildID, userID, "", days)
 }
 
-// GuildBan finds ban by given guild and user id and returns GuildBan structure
+// GuildBan finds ban by given guild and user id and returns GuildBan structure.
 func (s *Session) GuildBan(guildID, userID string) (st *GuildBan, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, userID))
 	if err != nil {
 		return
@@ -572,7 +560,6 @@ func (s *Session) GuildBan(guildID, userID string) (st *GuildBan, err error) {
 // reason    : The reason for this ban
 // days      : The number of days of previous comments to delete.
 func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days int) (err error) {
-
 	uri := EndpointGuildBan(guildID, userID)
 
 	queryParams := url.Values{}
@@ -593,9 +580,8 @@ func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days 
 
 // GuildBanDelete removes the given user from the guild bans
 // guildID   : The ID of a Guild.
-// userID    : The ID of a User
+// userID    : The ID of a User.
 func (s *Session) GuildBanDelete(guildID, userID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, ""))
 	return
 }
@@ -605,7 +591,6 @@ func (s *Session) GuildBanDelete(guildID, userID string) (err error) {
 //  after    : The id of the member to return members after
 //  limit    : max number of members to return (max 1000)
 func (s *Session) GuildMembers(guildID string, after string, limit int) (st []*Member, err error) {
-
 	uri := EndpointGuildMembers(guildID)
 
 	v := url.Values{}
@@ -635,7 +620,6 @@ func (s *Session) GuildMembers(guildID string, after string, limit int) (st []*M
 //  guildID   : The ID of a Guild.
 //  userID    : The ID of a User
 func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildMember(guildID, userID), nil, EndpointGuildMember(guildID, ""))
 	if err != nil {
 		return
@@ -656,7 +640,6 @@ func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
 //  mute          : If the user is muted.
 //  deaf          : If the user is deafened.
 func (s *Session) GuildMemberAdd(accessToken, guildID, userID, nick string, roles []string, mute, deaf bool) (err error) {
-
 	data := struct {
 		AccessToken string   `json:"access_token"`
 		Nick        string   `json:"nick,omitempty"`
@@ -675,18 +658,16 @@ func (s *Session) GuildMemberAdd(accessToken, guildID, userID, nick string, role
 
 // GuildMemberDelete removes the given user from the given guild.
 // guildID   : The ID of a Guild.
-// userID    : The ID of a User
+// userID    : The ID of a User.
 func (s *Session) GuildMemberDelete(guildID, userID string) (err error) {
-
 	return s.GuildMemberDeleteWithReason(guildID, userID, "")
 }
 
 // GuildMemberDeleteWithReason removes the given user from the given guild.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-// reason    : The reason for the kick
+// reason    : The reason for the kick.
 func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (err error) {
-
 	uri := EndpointGuildMember(guildID, userID)
 	if reason != "" {
 		uri += "?reason=" + url.QueryEscape(reason)
@@ -701,7 +682,6 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // userID   : The ID of a User.
 // roles    : A list of role ID's to set on the member.
 func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err error) {
-
 	data := struct {
 		Roles []string `json:"roles"`
 	}{roles}
@@ -715,7 +695,7 @@ func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err e
 //  userID    : The ID of a User.
 //  channelID : The ID of a channel to move user to or nil to remove from voice channel
 // NOTE : I am not entirely set on the name of this function and it may change
-// prior to the final 1.0.0 release of Discordgo
+// prior to the final 1.0.0 release of Discordgo.
 func (s *Session) GuildMemberMove(guildID string, userID string, channelID *string) (err error) {
 	data := struct {
 		ChannelID *string `json:"channel_id"`
@@ -729,9 +709,8 @@ func (s *Session) GuildMemberMove(guildID string, userID string, channelID *stri
 // guildID   : The ID of a guild
 // userID    : The ID of a user
 // userID    : The ID of a user or "@me" which is a shortcut of the current user ID
-// nickname  : The nickname of the member, "" will reset their nickname
+// nickname  : The nickname of the member, "" will reset their nickname.
 func (s *Session) GuildMemberNickname(guildID, userID, nickname string) (err error) {
-
 	data := struct {
 		Nick string `json:"nick"`
 	}{nickname}
@@ -789,7 +768,6 @@ func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool) (e
 //  userID    : The ID of a User.
 //  roleID 	  : The ID of a Role to be assigned to the user.
 func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string) (err error) {
-
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""))
 
 	return
@@ -800,7 +778,6 @@ func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string) (err error)
 //  userID    : The ID of a User.
 //  roleID 	  : The ID of a Role to be removed from the user.
 func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""))
 
 	return
@@ -810,7 +787,6 @@ func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string) (err err
 // given guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildChannels(guildID string) (st []*Channel, err error) {
-
 	body, err := s.request("GET", EndpointGuildChannels(guildID), "", nil, EndpointGuildChannels(guildID), 0)
 	if err != nil {
 		return
@@ -821,7 +797,7 @@ func (s *Session) GuildChannels(guildID string) (st []*Channel, err error) {
 	return
 }
 
-// GuildChannelCreateData is provided to GuildChannelCreateComplex
+// GuildChannelCreateData is provided to GuildChannelCreateComplex.
 type GuildChannelCreateData struct {
 	Name                 string                 `json:"name"`
 	Type                 ChannelType            `json:"type"`
@@ -837,7 +813,7 @@ type GuildChannelCreateData struct {
 
 // GuildChannelCreateComplex creates a new channel in the given guild
 // guildID      : The ID of a Guild
-// data         : A data struct describing the new Channel, Name and Type are mandatory, other fields depending on the type
+// data         : A data struct describing the new Channel, Name and Type are mandatory, other fields depending on the type.
 func (s *Session) GuildChannelCreateComplex(guildID string, data GuildChannelCreateData) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildChannels(guildID), data, EndpointGuildChannels(guildID))
 	if err != nil {
@@ -851,7 +827,7 @@ func (s *Session) GuildChannelCreateComplex(guildID string, data GuildChannelCre
 // GuildChannelCreate creates a new channel in the given guild
 // guildID   : The ID of a Guild.
 // name      : Name of the channel (2-100 chars length)
-// ctype     : Type of the channel
+// ctype     : Type of the channel.
 func (s *Session) GuildChannelCreate(guildID, name string, ctype ChannelType) (st *Channel, err error) {
 	return s.GuildChannelCreateComplex(guildID, GuildChannelCreateData{
 		Name: name,
@@ -863,7 +839,6 @@ func (s *Session) GuildChannelCreate(guildID, name string, ctype ChannelType) (s
 // guildID   : The ID of a Guild.
 // channels  : Updated channels.
 func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel) (err error) {
-
 	data := make([]struct {
 		ID       string `json:"id"`
 		Position int    `json:"position"`
@@ -893,7 +868,6 @@ func (s *Session) GuildInvites(guildID string) (st []*Invite, err error) {
 // GuildRoles returns all roles for a given guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID))
 	if err != nil {
 		return
@@ -907,7 +881,6 @@ func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
 // GuildRoleCreate returns a new Guild Role.
 // guildID: The ID of a Guild.
 func (s *Session) GuildRoleCreate(guildID string) (st *Role, err error) {
-
 	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID))
 	if err != nil {
 		return
@@ -925,9 +898,8 @@ func (s *Session) GuildRoleCreate(guildID string) (st *Role, err error) {
 // color     : The color of the role (decimal, not hex).
 // hoist     : Whether to display the role's users separately.
 // perm      : The permissions for the role.
-// mention   : Whether this role is mentionable
+// mention   : Whether this role is mentionable.
 func (s *Session) GuildRoleEdit(guildID, roleID, name string, color int, hoist bool, perm int64, mention bool) (st *Role, err error) {
-
 	// Prevent sending a color int that is too big.
 	if color > 0xFFFFFF {
 		err = fmt.Errorf("color value cannot be larger than 0xFFFFFF")
@@ -956,7 +928,6 @@ func (s *Session) GuildRoleEdit(guildID, roleID, name string, color int, hoist b
 // guildID   : The ID of a Guild.
 // roles     : A list of ordered roles.
 func (s *Session) GuildRoleReorder(guildID string, roles []*Role) (st []*Role, err error) {
-
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRoles(guildID), roles, EndpointGuildRoles(guildID))
 	if err != nil {
 		return
@@ -971,7 +942,6 @@ func (s *Session) GuildRoleReorder(guildID string, roles []*Role) (st []*Role, e
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
 func (s *Session) GuildRoleDelete(guildID, roleID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildRole(guildID, roleID), nil, EndpointGuildRole(guildID, ""))
 
 	return
@@ -1014,7 +984,6 @@ func (s *Session) GuildPruneCount(guildID string, days uint32) (count uint32, er
 // guildID	: The ID of a Guild.
 // days		: The number of days to count prune for (1 or more).
 func (s *Session) GuildPrune(guildID string, days uint32) (count uint32, err error) {
-
 	count = 0
 
 	if days <= 0 {
@@ -1048,7 +1017,6 @@ func (s *Session) GuildPrune(guildID string, days uint32) (count uint32, err err
 // GuildIntegrations returns an array of Integrations for a guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildIntegrations(guildID string) (st []*Integration, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildIntegrations(guildID), nil, EndpointGuildIntegrations(guildID))
 	if err != nil {
 		return
@@ -1064,7 +1032,6 @@ func (s *Session) GuildIntegrations(guildID string) (st []*Integration, err erro
 // integrationType  : The Integration type.
 // integrationID    : The ID of an integration.
 func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID string) (err error) {
-
 	data := struct {
 		Type string `json:"type"`
 		ID   string `json:"id"`
@@ -1082,7 +1049,6 @@ func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID
 // expireGracePeriod    : Period (in seconds) where the integration will ignore lapsed subscriptions.
 // enableEmoticons	    : Whether emoticons should be synced for this integration (twitch only currently).
 func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBehavior, expireGracePeriod int, enableEmoticons bool) (err error) {
-
 	data := struct {
 		ExpireBehavior    int  `json:"expire_behavior"`
 		ExpireGracePeriod int  `json:"expire_grace_period"`
@@ -1097,7 +1063,6 @@ func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBeha
 // guildID          : The ID of a Guild.
 // integrationID    : The ID of an integration.
 func (s *Session) GuildIntegrationDelete(guildID, integrationID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildIntegration(guildID, integrationID), nil, EndpointGuildIntegration(guildID, ""))
 	return
 }
@@ -1149,7 +1114,6 @@ func (s *Session) GuildSplash(guildID string) (img image.Image, err error) {
 // GuildEmbed returns the embed for a Guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildEmbed(guildID), nil, EndpointGuildEmbed(guildID))
 	if err != nil {
 		return
@@ -1162,7 +1126,6 @@ func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
 // GuildEmbedEdit returns the embed for a Guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildEmbedEdit(guildID string, enabled bool, channelID string) (err error) {
-
 	data := GuildEmbed{enabled, channelID}
 
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildEmbed(guildID), data, EndpointGuildEmbed(guildID))
@@ -1174,9 +1137,8 @@ func (s *Session) GuildEmbedEdit(guildID string, enabled bool, channelID string)
 // userID      : If provided the log will be filtered for the given ID.
 // beforeID    : If provided all log entries returned will be before the given ID.
 // actionType  : If provided the log will be filtered for the given Action Type.
-// limit       : The number messages that can be returned. (default 50, min 1, max 100)
+// limit       : The number messages that can be returned. (default 50, min 1, max 100).
 func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, limit int) (st *GuildAuditLog, err error) {
-
 	uri := EndpointGuildAuditLogs(guildID)
 
 	v := url.Values{}
@@ -1208,7 +1170,6 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 // GuildEmojis returns all emoji
 // guildID : The ID of a Guild.
 func (s *Session) GuildEmojis(guildID string) (emoji []*Emoji, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildEmojis(guildID), nil, EndpointGuildEmojis(guildID))
 	if err != nil {
 		return
@@ -1224,7 +1185,6 @@ func (s *Session) GuildEmojis(guildID string) (emoji []*Emoji, err error) {
 // image   : The base64 encoded emoji image, has to be smaller than 256KB.
 // roles   : The roles for which this emoji will be whitelisted, can be nil.
 func (s *Session) GuildEmojiCreate(guildID, name, image string, roles []string) (emoji *Emoji, err error) {
-
 	data := struct {
 		Name  string   `json:"name"`
 		Image string   `json:"image"`
@@ -1246,7 +1206,6 @@ func (s *Session) GuildEmojiCreate(guildID, name, image string, roles []string) 
 // name    : The Name of the Emoji.
 // roles   : The roles for which this emoji will be whitelisted, can be nil.
 func (s *Session) GuildEmojiEdit(guildID, emojiID, name string, roles []string) (emoji *Emoji, err error) {
-
 	data := struct {
 		Name  string   `json:"name"`
 		Roles []string `json:"roles,omitempty"`
@@ -1265,15 +1224,13 @@ func (s *Session) GuildEmojiEdit(guildID, emojiID, name string, roles []string) 
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
 func (s *Session) GuildEmojiDelete(guildID, emojiID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildEmoji(guildID, emojiID), nil, EndpointGuildEmojis(guildID))
 	return
 }
 
 // GuildTemplate returns a GuildTemplate for the given code
-// templateCode: The Code of a GuildTemplate
+// templateCode: The Code of a GuildTemplate.
 func (s *Session) GuildTemplate(templateCode string) (st *GuildTemplate, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildTemplate(templateCode), nil, EndpointGuildTemplate(templateCode))
 	if err != nil {
 		return
@@ -1288,7 +1245,6 @@ func (s *Session) GuildTemplate(templateCode string) (st *GuildTemplate, err err
 // name: The name of the guild (2-100) characters
 // icon: base64 encoded 128x128 image for the guild icon
 func (s *Session) GuildCreateWithTemplate(templateCode, name, icon string) (st *Guild, err error) {
-
 	data := struct {
 		Name string `json:"name"`
 		Icon string `json:"icon"`
@@ -1304,9 +1260,8 @@ func (s *Session) GuildCreateWithTemplate(templateCode, name, icon string) (st *
 }
 
 // GuildTemplates returns all of GuildTemplates
-// guildID: The ID of the guild
+// guildID: The ID of the guild.
 func (s *Session) GuildTemplates(guildID string) (st []*GuildTemplate, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildTemplates(guildID), nil, EndpointGuildTemplates(guildID))
 	if err != nil {
 		return
@@ -1321,7 +1276,6 @@ func (s *Session) GuildTemplates(guildID string) (st []*GuildTemplate, err error
 // name: The name of the template (1-100 characters)
 // description: The description for the template (0-120 characters)
 func (s *Session) GuildTemplateCreate(guildID, name, description string) (st *GuildTemplate) {
-
 	data := struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
@@ -1338,9 +1292,8 @@ func (s *Session) GuildTemplateCreate(guildID, name, description string) (st *Gu
 
 // GuildTemplateSync syncs the template to the guild's current state
 // guildID: The ID of the guild
-// templateCode: The code of the template
+// templateCode: The code of the template.
 func (s *Session) GuildTemplateSync(guildID, templateCode string) (err error) {
-
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""))
 	return
 }
@@ -1351,7 +1304,6 @@ func (s *Session) GuildTemplateSync(guildID, templateCode string) (err error) {
 // name: The name of the template (1-100 characters)
 // description: The description for the template (0-120 characters)
 func (s *Session) GuildTemplateEdit(guildID, templateCode, name, description string) (st *GuildTemplate, err error) {
-
 	data := struct {
 		Name        string `json:"name,omitempty"`
 		Description string `json:"description,omitempty"`
@@ -1368,9 +1320,8 @@ func (s *Session) GuildTemplateEdit(guildID, templateCode, name, description str
 
 // GuildTemplateDelete deletes the template
 // guildID: The ID of the guild
-// templateCode: The code of the template
+// templateCode: The code of the template.
 func (s *Session) GuildTemplateDelete(guildID, templateCode string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""))
 	return
 }
@@ -1402,7 +1353,7 @@ func (s *Session) ChannelEdit(channelID, name string) (*Channel, error) {
 
 // ChannelEditComplex edits an existing channel, replacing the parameters entirely with ChannelEdit struct
 // channelID  : The ID of a Channel
-// data          : The channel struct to send
+// data          : The channel struct to send.
 func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointChannel(channelID), data, EndpointChannel(channelID))
 	if err != nil {
@@ -1414,9 +1365,8 @@ func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit) (st *C
 }
 
 // ChannelDelete deletes the given channel
-// channelID  : The ID of a Channel
+// channelID  : The ID of a Channel.
 func (s *Session) ChannelDelete(channelID string) (st *Channel, err error) {
-
 	body, err := s.RequestWithBucketID("DELETE", EndpointChannel(channelID), nil, EndpointChannel(channelID))
 	if err != nil {
 		return
@@ -1428,9 +1378,8 @@ func (s *Session) ChannelDelete(channelID string) (st *Channel, err error) {
 
 // ChannelTyping broadcasts to all members that authenticated user is typing in
 // the given channel.
-// channelID  : The ID of a Channel
+// channelID  : The ID of a Channel.
 func (s *Session) ChannelTyping(channelID string) (err error) {
-
 	_, err = s.RequestWithBucketID("POST", EndpointChannelTyping(channelID), nil, EndpointChannelTyping(channelID))
 	return
 }
@@ -1443,7 +1392,6 @@ func (s *Session) ChannelTyping(channelID string) (err error) {
 // afterID   : If provided all messages returned will be after given ID.
 // aroundID  : If provided all messages returned will be around given ID.
 func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID, aroundID string) (st []*Message, err error) {
-
 	uri := EndpointChannelMessages(channelID)
 
 	v := url.Values{}
@@ -1474,9 +1422,8 @@ func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID
 
 // ChannelMessage gets a single message by ID from a given channel.
 // channeld  : The ID of a Channel
-// messageID : the ID of a Message
+// messageID : the ID of a Message.
 func (s *Session) ChannelMessage(channelID, messageID string) (st *Message, err error) {
-
 	response, err := s.RequestWithBucketID("GET", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""))
 	if err != nil {
 		return
@@ -1592,13 +1539,13 @@ func (s *Session) ChannelMessageSendReply(channelID string, content string, refe
 // the given content.
 // channelID  : The ID of a Channel
 // messageID  : The ID of a Message
-// content    : The contents of the message
+// content    : The contents of the message.
 func (s *Session) ChannelMessageEdit(channelID, messageID, content string) (*Message, error) {
 	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetContent(content))
 }
 
 // ChannelMessageEditComplex edits an existing message, replacing it entirely with
-// the given MessageEdit struct
+// the given MessageEdit struct.
 func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err error) {
 	// TODO: Remove this when compatibility is not required.
 	if m.Embed != nil {
@@ -1627,7 +1574,7 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err er
 // ChannelMessageEditEmbed edits an existing message with embedded data.
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
-// embed     : The embed data to send
+// embed     : The embed data to send.
 func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed) (*Message, error) {
 	return s.ChannelMessageEditEmbeds(channelID, messageID, []*MessageEmbed{embed})
 }
@@ -1635,14 +1582,13 @@ func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *Me
 // ChannelMessageEditEmbeds edits an existing message with multiple embedded data.
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
-// embeds    : The embeds data to send
+// embeds    : The embeds data to send.
 func (s *Session) ChannelMessageEditEmbeds(channelID, messageID string, embeds []*MessageEmbed) (*Message, error) {
 	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetEmbeds(embeds))
 }
 
 // ChannelMessageDelete deletes a message from the Channel.
 func (s *Session) ChannelMessageDelete(channelID, messageID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""))
 	return
 }
@@ -1653,7 +1599,6 @@ func (s *Session) ChannelMessageDelete(channelID, messageID string) (err error) 
 // channelID : The ID of the channel for the messages to delete.
 // messages  : The IDs of the messages to be deleted. A slice of string IDs. A maximum of 100 messages.
 func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string) (err error) {
-
 	if len(messages) == 0 {
 		return
 	}
@@ -1679,7 +1624,6 @@ func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string)
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
 func (s *Session) ChannelMessagePin(channelID, messageID string) (err error) {
-
 	_, err = s.RequestWithBucketID("PUT", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""))
 	return
 }
@@ -1688,7 +1632,6 @@ func (s *Session) ChannelMessagePin(channelID, messageID string) (err error) {
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
 func (s *Session) ChannelMessageUnpin(channelID, messageID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""))
 	return
 }
@@ -1697,7 +1640,6 @@ func (s *Session) ChannelMessageUnpin(channelID, messageID string) (err error) {
 // within a given channel
 // channelID : The ID of a Channel.
 func (s *Session) ChannelMessagesPinned(channelID string) (st []*Message, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointChannelMessagesPins(channelID), nil, EndpointChannelMessagesPins(channelID))
 
 	if err != nil {
@@ -1727,9 +1669,8 @@ func (s *Session) ChannelFileSendWithMessage(channelID, content string, name str
 }
 
 // ChannelInvites returns an array of Invite structures for the given channel
-// channelID   : The ID of a Channel
+// channelID   : The ID of a Channel.
 func (s *Session) ChannelInvites(channelID string) (st []*Invite, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointChannelInvites(channelID), nil, EndpointChannelInvites(channelID))
 	if err != nil {
 		return
@@ -1743,7 +1684,6 @@ func (s *Session) ChannelInvites(channelID string) (st []*Invite, err error) {
 // channelID   : The ID of a Channel
 // i           : An Invite struct with the values MaxAge, MaxUses and Temporary defined.
 func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, err error) {
-
 	data := struct {
 		MaxAge    int  `json:"max_age"`
 		MaxUses   int  `json:"max_uses"`
@@ -1764,7 +1704,6 @@ func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, e
 // NOTE: This func name may changed.  Using Set instead of Create because
 // you can both create a new override or update an override with this function.
 func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType PermissionOverwriteType, allow, deny int64) (err error) {
-
 	data := struct {
 		ID    string                  `json:"id"`
 		Type  PermissionOverwriteType `json:"type"`
@@ -1779,7 +1718,6 @@ func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType Pe
 // ChannelPermissionDelete deletes a specific permission override for the given channel.
 // NOTE: Name of this func may change.
 func (s *Session) ChannelPermissionDelete(channelID, targetID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointChannelPermission(channelID, targetID), nil, EndpointChannelPermission(channelID, ""))
 	return
 }
@@ -1787,9 +1725,8 @@ func (s *Session) ChannelPermissionDelete(channelID, targetID string) (err error
 // ChannelMessageCrosspost cross posts a message in a news channel to followers
 // of the channel
 // channelID   : The ID of a Channel
-// messageID   : The ID of a Message
+// messageID   : The ID of a Message.
 func (s *Session) ChannelMessageCrosspost(channelID, messageID string) (st *Message, err error) {
-
 	endpoint := EndpointChannelMessageCrosspost(channelID, messageID)
 
 	body, err := s.RequestWithBucketID("POST", endpoint, nil, endpoint)
@@ -1803,9 +1740,8 @@ func (s *Session) ChannelMessageCrosspost(channelID, messageID string) (st *Mess
 
 // ChannelNewsFollow follows a news channel in the targetID
 // channelID   : The ID of a News Channel
-// targetID    : The ID of a Channel where the News Channel should post to
+// targetID    : The ID of a Channel where the News Channel should post to.
 func (s *Session) ChannelNewsFollow(channelID, targetID string) (st *ChannelFollow, err error) {
-
 	endpoint := EndpointChannelFollow(channelID)
 
 	data := struct {
@@ -1826,9 +1762,8 @@ func (s *Session) ChannelNewsFollow(channelID, targetID string) (st *ChannelFoll
 // ------------------------------------------------------------------------------------------------
 
 // Invite returns an Invite structure of the given invite
-// inviteID : The invite code
+// inviteID : The invite code.
 func (s *Session) Invite(inviteID string) (st *Invite, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID), nil, EndpointInvite(""))
 	if err != nil {
 		return
@@ -1839,9 +1774,8 @@ func (s *Session) Invite(inviteID string) (st *Invite, err error) {
 }
 
 // InviteWithCounts returns an Invite structure of the given invite including approximate member counts
-// inviteID : The invite code
+// inviteID : The invite code.
 func (s *Session) InviteWithCounts(inviteID string) (st *Invite, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID)+"?with_counts=true", nil, EndpointInvite(""))
 	if err != nil {
 		return
@@ -1852,9 +1786,8 @@ func (s *Session) InviteWithCounts(inviteID string) (st *Invite, err error) {
 }
 
 // InviteDelete deletes an existing invite
-// inviteID   : the code of an invite
+// inviteID   : the code of an invite.
 func (s *Session) InviteDelete(inviteID string) (st *Invite, err error) {
-
 	body, err := s.RequestWithBucketID("DELETE", EndpointInvite(inviteID), nil, EndpointInvite(""))
 	if err != nil {
 		return
@@ -1865,9 +1798,8 @@ func (s *Session) InviteDelete(inviteID string) (st *Invite, err error) {
 }
 
 // InviteAccept accepts an Invite to a Guild or Channel
-// inviteID : The invite code
+// inviteID : The invite code.
 func (s *Session) InviteAccept(inviteID string) (st *Invite, err error) {
-
 	body, err := s.RequestWithBucketID("POST", EndpointInvite(inviteID), nil, EndpointInvite(""))
 	if err != nil {
 		return
@@ -1881,9 +1813,8 @@ func (s *Session) InviteAccept(inviteID string) (st *Invite, err error) {
 // Functions specific to Discord Voice
 // ------------------------------------------------------------------------------------------------
 
-// VoiceRegions returns the voice server regions
+// VoiceRegions returns the voice server regions.
 func (s *Session) VoiceRegions() (st []*VoiceRegion, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointVoiceRegions, nil, EndpointVoiceRegions)
 	if err != nil {
 		return
@@ -1897,9 +1828,8 @@ func (s *Session) VoiceRegions() (st []*VoiceRegion, err error) {
 // Functions specific to Discord Websockets
 // ------------------------------------------------------------------------------------------------
 
-// Gateway returns the websocket Gateway address
+// Gateway returns the websocket Gateway address.
 func (s *Session) Gateway() (gateway string, err error) {
-
 	response, err := s.RequestWithBucketID("GET", EndpointGateway, nil, EndpointGateway)
 	if err != nil {
 		return
@@ -1925,9 +1855,8 @@ func (s *Session) Gateway() (gateway string, err error) {
 	return
 }
 
-// GatewayBot returns the websocket Gateway address and the recommended number of shards
+// GatewayBot returns the websocket Gateway address and the recommended number of shards.
 func (s *Session) GatewayBot() (st *GatewayBotResponse, err error) {
-
 	response, err := s.RequestWithBucketID("GET", EndpointGatewayBot, nil, EndpointGatewayBot)
 	if err != nil {
 		return
@@ -1954,7 +1883,6 @@ func (s *Session) GatewayBot() (st *GatewayBotResponse, err error) {
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
 func (s *Session) WebhookCreate(channelID, name, avatar string) (st *Webhook, err error) {
-
 	data := struct {
 		Name   string `json:"name"`
 		Avatar string `json:"avatar,omitempty"`
@@ -1973,7 +1901,6 @@ func (s *Session) WebhookCreate(channelID, name, avatar string) (st *Webhook, er
 // ChannelWebhooks returns all webhooks for a given channel.
 // channelID: The ID of a channel.
 func (s *Session) ChannelWebhooks(channelID string) (st []*Webhook, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointChannelWebhooks(channelID), nil, EndpointChannelWebhooks(channelID))
 	if err != nil {
 		return
@@ -1987,7 +1914,6 @@ func (s *Session) ChannelWebhooks(channelID string) (st []*Webhook, err error) {
 // GuildWebhooks returns all webhooks for a given guild.
 // guildID: The ID of a Guild.
 func (s *Session) GuildWebhooks(guildID string) (st []*Webhook, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointGuildWebhooks(guildID), nil, EndpointGuildWebhooks(guildID))
 	if err != nil {
 		return
@@ -2001,7 +1927,6 @@ func (s *Session) GuildWebhooks(guildID string) (st []*Webhook, err error) {
 // Webhook returns a webhook for a given ID
 // webhookID: The ID of a webhook.
 func (s *Session) Webhook(webhookID string) (st *Webhook, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointWebhook(webhookID), nil, EndpointWebhooks)
 	if err != nil {
 		return
@@ -2016,7 +1941,6 @@ func (s *Session) Webhook(webhookID string) (st *Webhook, err error) {
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
 func (s *Session) WebhookWithToken(webhookID, token string) (st *Webhook, err error) {
-
 	body, err := s.RequestWithBucketID("GET", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""))
 	if err != nil {
 		return
@@ -2032,7 +1956,6 @@ func (s *Session) WebhookWithToken(webhookID, token string) (st *Webhook, err er
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
 func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string) (st *Role, err error) {
-
 	data := struct {
 		Name      string `json:"name,omitempty"`
 		Avatar    string `json:"avatar,omitempty"`
@@ -2055,7 +1978,6 @@ func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string) (st *Ro
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
 func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string) (st *Role, err error) {
-
 	data := struct {
 		Name   string `json:"name,omitempty"`
 		Avatar string `json:"avatar,omitempty"`
@@ -2074,7 +1996,6 @@ func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string) (s
 // WebhookDelete deletes a webhook for a given ID
 // webhookID: The ID of a webhook.
 func (s *Session) WebhookDelete(webhookID string) (err error) {
-
 	_, err = s.RequestWithBucketID("DELETE", EndpointWebhook(webhookID), nil, EndpointWebhooks)
 
 	return
@@ -2084,7 +2005,6 @@ func (s *Session) WebhookDelete(webhookID string) (err error) {
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
 func (s *Session) WebhookDeleteWithToken(webhookID, token string) (st *Webhook, err error) {
-
 	body, err := s.RequestWithBucketID("DELETE", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""))
 	if err != nil {
 		return
@@ -2132,7 +2052,7 @@ func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID st
 // WebhookExecute executes a webhook.
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook
-// wait     : Waits for server confirmation of message send and ensures that the return struct is populated (it is nil otherwise)
+// wait     : Waits for server confirmation of message send and ensures that the return struct is populated (it is nil otherwise).
 func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *WebhookParams) (st *Message, err error) {
 	return s.webhookExecute(webhookID, token, wait, "", data)
 }
@@ -2149,7 +2069,7 @@ func (s *Session) WebhookThreadExecute(webhookID, token string, wait bool, threa
 // WebhookMessage gets a webhook message.
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
-// messageID : The ID of message to get
+// messageID : The ID of message to get.
 func (s *Session) WebhookMessage(webhookID, token, messageID string) (message *Message, err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
@@ -2166,7 +2086,7 @@ func (s *Session) WebhookMessage(webhookID, token, messageID string) (message *M
 // WebhookMessageEdit edits a webhook message and returns a new one.
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
-// messageID : The ID of message to edit
+// messageID : The ID of message to edit.
 func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *WebhookEdit) (st *Message, err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
@@ -2196,7 +2116,7 @@ func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *W
 // WebhookMessageDelete deletes a webhook message.
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
-// messageID : The ID of a message to edit
+// messageID : The ID of a message to edit.
 func (s *Session) WebhookMessageDelete(webhookID, token, messageID string) (err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
@@ -2209,7 +2129,6 @@ func (s *Session) WebhookMessageDelete(webhookID, token, messageID string) (err 
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
 func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error {
-
 	// emoji such as  #⃣ need to have # escaped
 	emojiID = strings.Replace(emojiID, "#", "%23", -1)
 	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, "", "", ""))
@@ -2223,7 +2142,6 @@ func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
 // userID	 : @me or ID of the user to delete the reaction for.
 func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID string) error {
-
 	// emoji such as  #⃣ need to have # escaped
 	emojiID = strings.Replace(emojiID, "#", "%23", -1)
 	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, userID), nil, EndpointMessageReaction(channelID, "", "", ""))
@@ -2235,7 +2153,6 @@ func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID st
 // channelID : The channel ID
 // messageID : The message ID.
 func (s *Session) MessageReactionsRemoveAll(channelID, messageID string) error {
-
 	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactionsAll(channelID, messageID), nil, EndpointMessageReactionsAll(channelID, messageID))
 
 	return err
@@ -2244,9 +2161,8 @@ func (s *Session) MessageReactionsRemoveAll(channelID, messageID string) error {
 // MessageReactionsRemoveEmoji deletes all reactions of a certain emoji from a message
 // channelID : The channel ID
 // messageID : The message ID
-// emojiID   : The emoji ID
+// emojiID   : The emoji ID.
 func (s *Session) MessageReactionsRemoveEmoji(channelID, messageID, emojiID string) error {
-
 	// emoji such as  #⃣ need to have # escaped
 	emojiID = strings.Replace(emojiID, "#", "%23", -1)
 	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactions(channelID, messageID, emojiID), nil, EndpointMessageReactions(channelID, messageID, emojiID))
@@ -2299,7 +2215,7 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 // MessageThreadStartComplex creates a new thread from an existing message.
 // channelID : Channel to create thread in
 // messageID : Message to start thread from
-// data : Parameters of the thread
+// data : Parameters of the thread.
 func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *ThreadStart) (ch *Channel, err error) {
 	endpoint := EndpointChannelMessageThread(channelID, messageID)
 	var body []byte
@@ -2316,7 +2232,7 @@ func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *T
 // channelID       : Channel to create thread in
 // messageID       : Message to start thread from
 // name            : Name of the thread
-// archiveDuration : Auto archive duration (in minutes)
+// archiveDuration : Auto archive duration (in minutes).
 func (s *Session) MessageThreadStart(channelID, messageID string, name string, archiveDuration int) (ch *Channel, err error) {
 	return s.MessageThreadStartComplex(channelID, messageID, &ThreadStart{
 		Name:                name,
@@ -2326,7 +2242,7 @@ func (s *Session) MessageThreadStart(channelID, messageID string, name string, a
 
 // ThreadStartComplex creates a new thread.
 // channelID : Channel to create thread in
-// data : Parameters of the thread
+// data : Parameters of the thread.
 func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart) (ch *Channel, err error) {
 	endpoint := EndpointChannelThreads(channelID)
 	var body []byte
@@ -2342,7 +2258,7 @@ func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart) (ch *C
 // ThreadStart creates a new thread.
 // channelID       : Channel to create thread in
 // name            : Name of the thread
-// archiveDuration : Auto archive duration (in minutes)
+// archiveDuration : Auto archive duration (in minutes).
 func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDuration int) (ch *Channel, err error) {
 	return s.ThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
@@ -2351,35 +2267,35 @@ func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDu
 	})
 }
 
-// ThreadJoin adds current user to a thread
+// ThreadJoin adds current user to a thread.
 func (s *Session) ThreadJoin(id string) error {
 	endpoint := EndpointThreadMember(id, "@me")
 	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint)
 	return err
 }
 
-// ThreadLeave removes current user to a thread
+// ThreadLeave removes current user to a thread.
 func (s *Session) ThreadLeave(id string) error {
 	endpoint := EndpointThreadMember(id, "@me")
 	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint)
 	return err
 }
 
-// ThreadMemberAdd adds another member to a thread
+// ThreadMemberAdd adds another member to a thread.
 func (s *Session) ThreadMemberAdd(threadID, memberID string) error {
 	endpoint := EndpointThreadMember(threadID, memberID)
 	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint)
 	return err
 }
 
-// ThreadMemberRemove removes another member from a thread
+// ThreadMemberRemove removes another member from a thread.
 func (s *Session) ThreadMemberRemove(threadID, memberID string) error {
 	endpoint := EndpointThreadMember(threadID, memberID)
 	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint)
 	return err
 }
 
-// ThreadMember returns thread member object for the specified member of a thread
+// ThreadMember returns thread member object for the specified member of a thread.
 func (s *Session) ThreadMember(threadID, memberID string) (member *ThreadMember, err error) {
 	endpoint := EndpointThreadMember(threadID, memberID)
 	var body []byte
@@ -2649,7 +2565,7 @@ func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string) (pe
 // ApplicationCommandPermissions returns all permissions of an application command
 // appID       : The Application ID
 // guildID     : The guild ID containing the application command
-// cmdID       : The command ID to retrieve the permissions of
+// cmdID       : The command ID to retrieve the permissions of.
 func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (permissions *GuildApplicationCommandPermissions, err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
@@ -2667,7 +2583,7 @@ func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (p
 // appID       : The Application ID
 // guildID     : The guild ID containing the application command
 // cmdID       : The command ID to edit the permissions of
-// permissions : An object containing a list of permissions for the application command
+// permissions : An object containing a list of permissions for the application command.
 func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string, permissions *ApplicationCommandPermissionsList) (err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
@@ -2678,7 +2594,7 @@ func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string
 // ApplicationCommandPermissionsBatchEdit edits the permissions of a batch of commands
 // appID       : The Application ID
 // guildID     : The guild ID to batch edit commands of
-// permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command
+// permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command.
 func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, permissions []*GuildApplicationCommandPermissions) (err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
@@ -2744,7 +2660,7 @@ func (s *Session) FollowupMessageCreate(appID string, interaction *Interaction, 
 // appID       : The application ID.
 // interaction : Interaction instance.
 // messageID   : The followup message ID.
-// data        : Data to update the message
+// data        : Data to update the message.
 func (s *Session) FollowupMessageEdit(appID string, interaction *Interaction, messageID string, data *WebhookEdit) (*Message, error) {
 	return s.WebhookMessageEdit(appID, interaction.Token, messageID, data)
 }
@@ -2763,7 +2679,7 @@ func (s *Session) FollowupMessageDelete(appID string, interaction *Interaction, 
 
 // GuildScheduledEvents returns an array of GuildScheduledEvent for a guild
 // guildID        : The ID of a Guild
-// userCount      : Whether to include the user count in the response
+// userCount      : Whether to include the user count in the response.
 func (s *Session) GuildScheduledEvents(guildID string, userCount bool) (st []*GuildScheduledEvent, err error) {
 	uri := EndpointGuildScheduledEvents(guildID)
 	if userCount {
@@ -2782,7 +2698,7 @@ func (s *Session) GuildScheduledEvents(guildID string, userCount bool) (st []*Gu
 // GuildScheduledEvent returns a specific GuildScheduledEvent in a guild
 // guildID        : The ID of a Guild
 // eventID        : The ID of the event
-// userCount      : Whether to include the user count in the response
+// userCount      : Whether to include the user count in the response.
 func (s *Session) GuildScheduledEvent(guildID, eventID string, userCount bool) (st *GuildScheduledEvent, err error) {
 	uri := EndpointGuildScheduledEvent(guildID, eventID)
 	if userCount {
@@ -2800,7 +2716,7 @@ func (s *Session) GuildScheduledEvent(guildID, eventID string, userCount bool) (
 
 // GuildScheduledEventCreate creates a GuildScheduledEvent for a guild and returns it
 // guildID   : The ID of a Guild
-// eventID   : The ID of the event
+// eventID   : The ID of the event.
 func (s *Session) GuildScheduledEventCreate(guildID string, event *GuildScheduledEventParams) (st *GuildScheduledEvent, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildScheduledEvents(guildID), event, EndpointGuildScheduledEvents(guildID))
 	if err != nil {
@@ -2813,7 +2729,7 @@ func (s *Session) GuildScheduledEventCreate(guildID string, event *GuildSchedule
 
 // GuildScheduledEventEdit updates a specific event for a guild and returns it.
 // guildID   : The ID of a Guild
-// eventID   : The ID of the event
+// eventID   : The ID of the event.
 func (s *Session) GuildScheduledEventEdit(guildID, eventID string, event *GuildScheduledEventParams) (st *GuildScheduledEvent, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildScheduledEvent(guildID, eventID), event, EndpointGuildScheduledEvent(guildID, eventID))
 	if err != nil {
@@ -2826,7 +2742,7 @@ func (s *Session) GuildScheduledEventEdit(guildID, eventID string, event *GuildS
 
 // GuildScheduledEventDelete deletes a specific GuildScheduledEvent in a guild
 // guildID   : The ID of a Guild
-// eventID   : The ID of the event
+// eventID   : The ID of the event.
 func (s *Session) GuildScheduledEventDelete(guildID, eventID string) (err error) {
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildScheduledEvent(guildID, eventID), nil, EndpointGuildScheduledEvent(guildID, eventID))
 	return
@@ -2838,7 +2754,7 @@ func (s *Session) GuildScheduledEventDelete(guildID, eventID string) (err error)
 // limit      : The maximum number of users to return (Max 100)
 // withMember : Whether to include the member object in the response
 // beforeID   : If is not empty all returned users entries will be before the given ID
-// afterID    : If is not empty all returned users entries will be after the given ID
+// afterID    : If is not empty all returned users entries will be after the given ID.
 func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, withMember bool, beforeID, afterID string) (st []*GuildScheduledEventUser, err error) {
 	uri := EndpointGuildScheduledEventUsers(guildID, eventID)
 

--- a/restapi_test.go
+++ b/restapi_test.go
@@ -10,7 +10,6 @@ import (
 
 // TestChannelMessageSend tests the ChannelMessageSend() function. This should not return an error.
 func TestChannelMessageSend(t *testing.T) {
-
 	if envChannel == "" {
 		t.Skip("Skipping, DG_CHANNEL not set.")
 	}
@@ -111,7 +110,6 @@ func TestUserGuilds(t *testing.T) {
 }
 
 func TestGateway(t *testing.T) {
-
 	if dg == nil {
 		t.Skip("Skipping, dg not set.")
 	}
@@ -122,7 +120,6 @@ func TestGateway(t *testing.T) {
 }
 
 func TestGatewayBot(t *testing.T) {
-
 	if dgBot == nil {
 		t.Skip("Skipping, dgBot not set.")
 	}
@@ -133,7 +130,6 @@ func TestGatewayBot(t *testing.T) {
 }
 
 func TestVoiceRegions(t *testing.T) {
-
 	if dg == nil {
 		t.Skip("Skipping, dg not set.")
 	}
@@ -144,7 +140,6 @@ func TestVoiceRegions(t *testing.T) {
 	}
 }
 func TestGuildRoles(t *testing.T) {
-
 	if envGuild == "" {
 		t.Skip("Skipping, DG_GUILD not set.")
 	}
@@ -157,11 +152,9 @@ func TestGuildRoles(t *testing.T) {
 	if err != nil {
 		t.Errorf("GuildRoles(envGuild) returned error: %+v", err)
 	}
-
 }
 
 func TestGuildMemberNickname(t *testing.T) {
-
 	if envGuild == "" {
 		t.Skip("Skipping, DG_GUILD not set.")
 	}
@@ -178,7 +171,6 @@ func TestGuildMemberNickname(t *testing.T) {
 
 // TestChannelMessageSend2 tests the ChannelMessageSend() function. This should not return an error.
 func TestChannelMessageSend2(t *testing.T) {
-
 	if envChannel == "" {
 		t.Skip("Skipping, DG_CHANNEL not set.")
 	}
@@ -195,7 +187,6 @@ func TestChannelMessageSend2(t *testing.T) {
 
 // TestGuildPruneCount tests GuildPruneCount() function. This should not return an error.
 func TestGuildPruneCount(t *testing.T) {
-
 	if envGuild == "" {
 		t.Skip("Skipping, DG_GUILD not set.")
 	}

--- a/restapi_test.go
+++ b/restapi_test.go
@@ -113,8 +113,7 @@ func TestGateway(t *testing.T) {
 	if dg == nil {
 		t.Skip("Skipping, dg not set.")
 	}
-	_, err := dg.Gateway()
-	if err != nil {
+	if _, err := dg.Gateway(); err != nil {
 		t.Errorf("Gateway() returned error: %+v", err)
 	}
 }
@@ -123,8 +122,7 @@ func TestGatewayBot(t *testing.T) {
 	if dgBot == nil {
 		t.Skip("Skipping, dgBot not set.")
 	}
-	_, err := dgBot.GatewayBot()
-	if err != nil {
+	if _, err := dgBot.GatewayBot(); err != nil {
 		t.Errorf("GatewayBot() returned error: %+v", err)
 	}
 }
@@ -134,8 +132,7 @@ func TestVoiceRegions(t *testing.T) {
 		t.Skip("Skipping, dg not set.")
 	}
 
-	_, err := dg.VoiceRegions()
-	if err != nil {
+	if _, err := dg.VoiceRegions(); err != nil {
 		t.Errorf("VoiceRegions() returned error: %+v", err)
 	}
 }
@@ -148,8 +145,7 @@ func TestGuildRoles(t *testing.T) {
 		t.Skip("Skipping, dg not set.")
 	}
 
-	_, err := dg.GuildRoles(envGuild)
-	if err != nil {
+	if _, err := dg.GuildRoles(envGuild); err != nil {
 		t.Errorf("GuildRoles(envGuild) returned error: %+v", err)
 	}
 }

--- a/state.go
+++ b/state.go
@@ -950,7 +950,7 @@ func (s *State) onReady(se *Session, r *Ready) (err error) {
 }
 
 // OnInterface handles all events related to states.
-func (s *State) OnInterface(se *Session, i interface{}) (err error) {
+func (s *State) OnInterface(se *Session, i interface{}) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -966,18 +966,18 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 
 	switch t := i.(type) {
 	case *GuildCreate:
-		err = s.GuildAdd(t.Guild)
+		return s.GuildAdd(t.Guild)
 	case *GuildUpdate:
-		err = s.GuildAdd(t.Guild)
+		return s.GuildAdd(t.Guild)
 	case *GuildDelete:
 		var old *Guild
-		old, err = s.Guild(t.ID)
+		old, err := s.Guild(t.ID)
 		if err == nil {
 			oldCopy := *old
 			t.BeforeDelete = &oldCopy
 		}
 
-		err = s.GuildRemove(t.Guild)
+		return s.GuildRemove(t.Guild)
 	case *GuildMemberAdd:
 		// Updates the MemberCount of the guild.
 		guild, err := s.Guild(t.Member.GuildID)
@@ -988,11 +988,11 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 
 		// Caches member if tracking is enabled.
 		if s.TrackMembers {
-			err = s.MemberAdd(t.Member)
+			return s.MemberAdd(t.Member)
 		}
 	case *GuildMemberUpdate:
 		if s.TrackMembers {
-			err = s.MemberAdd(t.Member)
+			return s.MemberAdd(t.Member)
 		}
 	case *GuildMemberRemove:
 		// Updates the MemberCount of the guild.
@@ -1004,52 +1004,52 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 
 		// Removes member from the cache if tracking is enabled.
 		if s.TrackMembers {
-			err = s.MemberRemove(t.Member)
+			return s.MemberRemove(t.Member)
 		}
 	case *GuildMembersChunk:
 		if s.TrackMembers {
 			for i := range t.Members {
 				t.Members[i].GuildID = t.GuildID
-				err = s.MemberAdd(t.Members[i])
+				return s.MemberAdd(t.Members[i])
 			}
 		}
 
 		if s.TrackPresences {
 			for _, p := range t.Presences {
-				err = s.PresenceAdd(t.GuildID, p)
+				return s.PresenceAdd(t.GuildID, p)
 			}
 		}
 	case *GuildRoleCreate:
 		if s.TrackRoles {
-			err = s.RoleAdd(t.GuildID, t.Role)
+			return s.RoleAdd(t.GuildID, t.Role)
 		}
 	case *GuildRoleUpdate:
 		if s.TrackRoles {
-			err = s.RoleAdd(t.GuildID, t.Role)
+			return s.RoleAdd(t.GuildID, t.Role)
 		}
 	case *GuildRoleDelete:
 		if s.TrackRoles {
-			err = s.RoleRemove(t.GuildID, t.RoleID)
+			return s.RoleRemove(t.GuildID, t.RoleID)
 		}
 	case *GuildEmojisUpdate:
 		if s.TrackEmojis {
-			err = s.EmojisAdd(t.GuildID, t.Emojis)
+			return s.EmojisAdd(t.GuildID, t.Emojis)
 		}
 	case *ChannelCreate:
 		if s.TrackChannels {
-			err = s.ChannelAdd(t.Channel)
+			return s.ChannelAdd(t.Channel)
 		}
 	case *ChannelUpdate:
 		if s.TrackChannels {
-			err = s.ChannelAdd(t.Channel)
+			return s.ChannelAdd(t.Channel)
 		}
 	case *ChannelDelete:
 		if s.TrackChannels {
-			err = s.ChannelRemove(t.Channel)
+			return s.ChannelRemove(t.Channel)
 		}
 	case *ThreadCreate:
 		if s.TrackThreads {
-			err = s.ChannelAdd(t.Channel)
+			return s.ChannelAdd(t.Channel)
 		}
 	case *ThreadUpdate:
 		if s.TrackThreads {
@@ -1058,49 +1058,49 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 				oldCopy := *old
 				t.BeforeUpdate = &oldCopy
 			}
-			err = s.ChannelAdd(t.Channel)
+			return s.ChannelAdd(t.Channel)
 		}
 	case *ThreadDelete:
 		if s.TrackThreads {
-			err = s.ChannelRemove(t.Channel)
+			return s.ChannelRemove(t.Channel)
 		}
 	case *ThreadMemberUpdate:
 		if s.TrackThreads {
-			err = s.ThreadMemberUpdate(t)
+			return s.ThreadMemberUpdate(t)
 		}
 	case *ThreadMembersUpdate:
 		if s.TrackThreadMembers {
-			err = s.ThreadMembersUpdate(t)
+			return s.ThreadMembersUpdate(t)
 		}
 	case *ThreadListSync:
 		if s.TrackThreads {
-			err = s.ThreadListSync(t)
+			return s.ThreadListSync(t)
 		}
 	case *MessageCreate:
 		if s.MaxMessageCount != 0 {
-			err = s.MessageAdd(t.Message)
+			return s.MessageAdd(t.Message)
 		}
 	case *MessageUpdate:
 		if s.MaxMessageCount != 0 {
 			var old *Message
-			old, err = s.Message(t.ChannelID, t.ID)
+			old, err := s.Message(t.ChannelID, t.ID)
 			if err == nil {
 				oldCopy := *old
 				t.BeforeUpdate = &oldCopy
 			}
 
-			err = s.MessageAdd(t.Message)
+			return s.MessageAdd(t.Message)
 		}
 	case *MessageDelete:
 		if s.MaxMessageCount != 0 {
 			var old *Message
-			old, err = s.Message(t.ChannelID, t.ID)
+			old, err := s.Message(t.ChannelID, t.ID)
 			if err == nil {
 				oldCopy := *old
 				t.BeforeDelete = &oldCopy
 			}
 
-			err = s.MessageRemove(t.Message)
+			return s.MessageRemove(t.Message)
 		}
 	case *MessageDeleteBulk:
 		if s.MaxMessageCount != 0 {
@@ -1111,13 +1111,13 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 	case *VoiceStateUpdate:
 		if s.TrackVoice {
 			var old *VoiceState
-			old, err = s.VoiceState(t.GuildID, t.UserID)
+			old, err := s.VoiceState(t.GuildID, t.UserID)
 			if err == nil {
 				oldCopy := *old
 				t.BeforeUpdate = &oldCopy
 			}
 
-			err = s.voiceStateUpdate(t)
+			return s.voiceStateUpdate(t)
 		}
 	case *PresenceUpdate:
 		if s.TrackPresences {
@@ -1125,12 +1125,11 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 		if s.TrackMembers {
 			if t.Status == StatusOffline {
-				return err
+				return nil
 			}
 
 			var m *Member
-			m, err = s.Member(t.GuildID, t.User.ID)
-
+			m, err := s.Member(t.GuildID, t.User.ID)
 			if err != nil {
 				// Member not found; this is a user coming online
 				m = &Member{
@@ -1143,7 +1142,7 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 				}
 			}
 
-			err = s.MemberAdd(m)
+			return s.MemberAdd(m)
 		}
 	}
 

--- a/state.go
+++ b/state.go
@@ -153,8 +153,7 @@ func (s *State) GuildRemove(guild *Guild) error {
 		return ErrNilState
 	}
 
-	_, err := s.Guild(guild.ID)
-	if err != nil {
+	if _, err := s.Guild(guild.ID); err != nil {
 		return err
 	}
 

--- a/state.go
+++ b/state.go
@@ -22,7 +22,7 @@ import (
 var ErrNilState = errors.New("state not instantiated, please use discordgo.New() or assign Session.State")
 
 // ErrStateNotFound is returned when the state cache
-// requested is not found
+// requested is not found.
 var ErrStateNotFound = errors.New("state cache not found")
 
 // ErrMessageIncompletePermissions is returned when the message
@@ -612,7 +612,7 @@ outer:
 	return nil
 }
 
-// ThreadMembersUpdate updates thread members list
+// ThreadMembersUpdate updates thread members list.
 func (s *State) ThreadMembersUpdate(tmu *ThreadMembersUpdate) error {
 	thread, err := s.Channel(tmu.ID)
 	if err != nil {
@@ -662,13 +662,13 @@ func (s *State) ThreadMemberUpdate(mu *ThreadMemberUpdate) error {
 }
 
 // GuildChannel gets a channel by ID from a guild.
-// This method is Deprecated, use Channel(channelID)
+// This method is Deprecated, use Channel(channelID).
 func (s *State) GuildChannel(guildID, channelID string) (*Channel, error) {
 	return s.Channel(channelID)
 }
 
 // PrivateChannel gets a private channel by ID.
-// This method is Deprecated, use Channel(channelID)
+// This method is Deprecated, use Channel(channelID).
 func (s *State) PrivateChannel(channelID string) (*Channel, error) {
 	return s.Channel(channelID)
 }
@@ -1145,7 +1145,6 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 
 			err = s.MemberAdd(m)
 		}
-
 	}
 
 	return

--- a/state.go
+++ b/state.go
@@ -519,8 +519,7 @@ func (s *State) ChannelRemove(channel *Channel) error {
 		return ErrNilState
 	}
 
-	_, err := s.Channel(channel.ID)
-	if err != nil {
+	if _, err := s.Channel(channel.ID); err != nil {
 		return err
 	}
 

--- a/state.go
+++ b/state.go
@@ -1125,7 +1125,7 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 		if s.TrackMembers {
 			if t.Status == StatusOffline {
-				return
+				return err
 			}
 
 			var m *Member
@@ -1147,7 +1147,7 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	}
 
-	return
+	return nil
 }
 
 // UserChannelPermissions returns the permission of a user in a channel.
@@ -1160,17 +1160,17 @@ func (s *State) UserChannelPermissions(userID, channelID string) (apermissions i
 
 	channel, err := s.Channel(channelID)
 	if err != nil {
-		return
+		return 0, err
 	}
 
 	guild, err := s.Guild(channel.GuildID)
 	if err != nil {
-		return
+		return 0, err
 	}
 
 	member, err := s.Member(guild.ID, userID)
 	if err != nil {
-		return
+		return 0, err
 	}
 
 	return memberPermissions(guild, channel, userID, member.Roles), nil
@@ -1189,12 +1189,12 @@ func (s *State) MessagePermissions(message *Message) (apermissions int64, err er
 
 	channel, err := s.Channel(message.ChannelID)
 	if err != nil {
-		return
+		return 0, err
 	}
 
 	guild, err := s.Guild(channel.GuildID)
 	if err != nil {
-		return
+		return 0, err
 	}
 
 	return memberPermissions(guild, channel, message.Author.ID, message.Member.Roles), nil

--- a/structs.go
+++ b/structs.go
@@ -72,10 +72,6 @@ type Session struct {
 	// Max number of REST API retries
 	MaxRestRetries int
 
-	// Status stores the currect status of the websocket connection
-	// this is being tested, may stay, may go away.
-	status int32
-
 	// Whether the Voice Websocket is ready
 	VoiceReady bool // NOTE: Deprecated.
 

--- a/structs.go
+++ b/structs.go
@@ -128,7 +128,7 @@ type Session struct {
 	wsMutex sync.Mutex
 }
 
-// Application stores values for a Discord Application
+// Application stores values for a Discord Application.
 type Application struct {
 	ID                  string   `json:"id,omitempty"`
 	Name                string   `json:"name"`
@@ -150,7 +150,7 @@ type Application struct {
 	Flags               int      `json:"flags,omitempty"`
 }
 
-// UserConnection is a Connection returned from the UserConnections endpoint
+// UserConnection is a Connection returned from the UserConnections endpoint.
 type UserConnection struct {
 	ID           string         `json:"id"`
 	Name         string         `json:"name"`
@@ -159,7 +159,7 @@ type UserConnection struct {
 	Integrations []*Integration `json:"integrations"`
 }
 
-// Integration stores integration information
+// Integration stores integration information.
 type Integration struct {
 	ID                string             `json:"id"`
 	Name              string             `json:"name"`
@@ -179,14 +179,14 @@ type Integration struct {
 // https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors
 type ExpireBehavior int
 
-// Block of valid ExpireBehaviors
+// Block of valid ExpireBehaviors.
 const (
 	ExpireBehaviorRemoveRole ExpireBehavior = 0
 	ExpireBehaviorKick       ExpireBehavior = 1
 )
 
 // IntegrationAccount is integration account information
-// sent by the UserConnections endpoint
+// sent by the UserConnections endpoint.
 type IntegrationAccount struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -217,7 +217,7 @@ type ICEServer struct {
 // https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types
 type InviteTargetType uint8
 
-// Invite target types
+// Invite target types.
 const (
 	InviteTargetStream             InviteTargetType = 1
 	InviteTargetEmbeddedAppliction InviteTargetType = 2
@@ -245,10 +245,10 @@ type Invite struct {
 	ApproximateMemberCount   int `json:"approximate_member_count"`
 }
 
-// ChannelType is the type of a Channel
+// ChannelType is the type of a Channel.
 type ChannelType int
 
-// Block contains known ChannelType values
+// Block contains known ChannelType values.
 const (
 	ChannelTypeGuildText          ChannelType = 0
 	ChannelTypeDM                 ChannelType = 1
@@ -340,12 +340,12 @@ type Channel struct {
 	Members []*ThreadMember `json:"-"`
 }
 
-// Mention returns a string which mentions the channel
+// Mention returns a string which mentions the channel.
 func (c *Channel) Mention() string {
 	return fmt.Sprintf("<#%s>", c.ID)
 }
 
-// IsThread is a helper function to determine if channel is a thread or not
+// IsThread is a helper function to determine if channel is a thread or not.
 func (c *Channel) IsThread() bool {
 	return c.Type == ChannelTypeGuildPublicThread || c.Type == ChannelTypeGuildPrivateThread || c.Type == ChannelTypeGuildNewsThread
 }
@@ -370,7 +370,7 @@ type ChannelEdit struct {
 	Invitable           bool `json:"invitable,omitempty"`
 }
 
-// A ChannelFollow holds data returned after following a news channel
+// A ChannelFollow holds data returned after following a news channel.
 type ChannelFollow struct {
 	ChannelID string `json:"channel_id"`
 	WebhookID string `json:"webhook_id"`
@@ -386,7 +386,7 @@ const (
 	PermissionOverwriteTypeMember PermissionOverwriteType = 1
 )
 
-// A PermissionOverwrite holds permission overwrite data for a Channel
+// A PermissionOverwrite holds permission overwrite data for a Channel.
 type PermissionOverwrite struct {
 	ID    string                  `json:"id"`
 	Type  PermissionOverwriteType `json:"type"`
@@ -394,7 +394,7 @@ type PermissionOverwrite struct {
 	Allow int64                   `json:"allow,string"`
 }
 
-// ThreadStart stores all parameters you can use with MessageThreadStartComplex or ThreadStartComplex
+// ThreadStart stores all parameters you can use with MessageThreadStartComplex or ThreadStartComplex.
 type ThreadStart struct {
 	Name                string      `json:"name"`
 	AutoArchiveDuration int         `json:"auto_archive_duration,omitempty"`
@@ -437,14 +437,14 @@ type ThreadsList struct {
 	HasMore bool            `json:"has_more"`
 }
 
-// AddedThreadMember holds information about the user who was added to the thread
+// AddedThreadMember holds information about the user who was added to the thread.
 type AddedThreadMember struct {
 	*ThreadMember
 	Member   *Member   `json:"member"`
 	Presence *Presence `json:"presence"`
 }
 
-// Emoji struct holds data related to Emoji's
+// Emoji struct holds data related to Emoji's.
 type Emoji struct {
 	ID            string   `json:"id"`
 	Name          string   `json:"name"`
@@ -456,12 +456,12 @@ type Emoji struct {
 	Available     bool     `json:"available"`
 }
 
-// EmojiRegex is the regex used to find and identify emojis in messages
+// EmojiRegex is the regex used to find and identify emojis in messages.
 var (
 	EmojiRegex = regexp.MustCompile(`<(a|):[A-z0-9_~]+:[0-9]{18}>`)
 )
 
-// MessageFormat returns a correctly formatted Emoji for use in Message content and embeds
+// MessageFormat returns a correctly formatted Emoji for use in Message content and embeds.
 func (e *Emoji) MessageFormat() string {
 	if e.ID != "" && e.Name != "" {
 		if e.Animated {
@@ -530,10 +530,10 @@ type StickerPack struct {
 	BannerAssetID  string     `json:"banner_asset_id"`
 }
 
-// VerificationLevel type definition
+// VerificationLevel type definition.
 type VerificationLevel int
 
-// Constants for VerificationLevel levels from 0 to 4 inclusive
+// Constants for VerificationLevel levels from 0 to 4 inclusive.
 const (
 	VerificationLevelNone     VerificationLevel = 0
 	VerificationLevelLow      VerificationLevel = 1
@@ -542,29 +542,29 @@ const (
 	VerificationLevelVeryHigh VerificationLevel = 4
 )
 
-// ExplicitContentFilterLevel type definition
+// ExplicitContentFilterLevel type definition.
 type ExplicitContentFilterLevel int
 
-// Constants for ExplicitContentFilterLevel levels from 0 to 2 inclusive
+// Constants for ExplicitContentFilterLevel levels from 0 to 2 inclusive.
 const (
 	ExplicitContentFilterDisabled            ExplicitContentFilterLevel = 0
 	ExplicitContentFilterMembersWithoutRoles ExplicitContentFilterLevel = 1
 	ExplicitContentFilterAllMembers          ExplicitContentFilterLevel = 2
 )
 
-// MfaLevel type definition
+// MfaLevel type definition.
 type MfaLevel int
 
-// Constants for MfaLevel levels from 0 to 1 inclusive
+// Constants for MfaLevel levels from 0 to 1 inclusive.
 const (
 	MfaLevelNone     MfaLevel = 0
 	MfaLevelElevated MfaLevel = 1
 )
 
-// PremiumTier type definition
+// PremiumTier type definition.
 type PremiumTier int
 
-// Constants for PremiumTier levels from 0 to 3 inclusive
+// Constants for PremiumTier levels from 0 to 3 inclusive.
 const (
 	PremiumTierNone PremiumTier = 0
 	PremiumTier1    PremiumTier = 1
@@ -837,7 +837,7 @@ type GuildScheduledEventParams struct {
 	Image string `json:"image,omitempty"`
 }
 
-// MarshalJSON is a helper function to marshal GuildScheduledEventParams
+// MarshalJSON is a helper function to marshal GuildScheduledEventParams.
 func (p GuildScheduledEventParams) MarshalJSON() ([]byte, error) {
 	type guildScheduledEventParams GuildScheduledEventParams
 
@@ -867,7 +867,7 @@ type GuildScheduledEventPrivacyLevel int
 
 const (
 	// GuildScheduledEventPrivacyLevelGuildOnly makes the scheduled
-	// event is only accessible to guild members
+	// event is only accessible to guild members.
 	GuildScheduledEventPrivacyLevelGuildOnly GuildScheduledEventPrivacyLevel = 2
 )
 
@@ -879,13 +879,13 @@ const (
 type GuildScheduledEventStatus int
 
 const (
-	// GuildScheduledEventStatusScheduled represents the current event is in scheduled state
+	// GuildScheduledEventStatusScheduled represents the current event is in scheduled state.
 	GuildScheduledEventStatusScheduled = 1
-	// GuildScheduledEventStatusActive represents the current event is in active state
+	// GuildScheduledEventStatusActive represents the current event is in active state.
 	GuildScheduledEventStatusActive = 2
-	// GuildScheduledEventStatusCompleted represents the current event is in completed state
+	// GuildScheduledEventStatusCompleted represents the current event is in completed state.
 	GuildScheduledEventStatusCompleted = 3
-	// GuildScheduledEventStatusCanceled represents the current event is in canceled state
+	// GuildScheduledEventStatusCanceled represents the current event is in canceled state.
 	GuildScheduledEventStatusCanceled = 4
 )
 
@@ -894,11 +894,11 @@ const (
 type GuildScheduledEventEntityType int
 
 const (
-	// GuildScheduledEventEntityTypeStageInstance represents a stage channel
+	// GuildScheduledEventEntityTypeStageInstance represents a stage channel.
 	GuildScheduledEventEntityTypeStageInstance = 1
-	// GuildScheduledEventEntityTypeVoice represents a voice channel
+	// GuildScheduledEventEntityTypeVoice represents a voice channel.
 	GuildScheduledEventEntityTypeVoice = 2
-	// GuildScheduledEventEntityTypeExternal represents an external event
+	// GuildScheduledEventEntityTypeExternal represents an external event.
 	GuildScheduledEventEntityTypeExternal = 3
 )
 
@@ -910,7 +910,7 @@ type GuildScheduledEventUser struct {
 	Member                *Member `json:"member"`
 }
 
-// A GuildTemplate represents
+// A GuildTemplate represents.
 type GuildTemplate struct {
 	// The unique code for the guild template
 	Code string `json:"code"`
@@ -950,7 +950,7 @@ type GuildTemplate struct {
 // https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
 type MessageNotifications int
 
-// Block containing known MessageNotifications values
+// Block containing known MessageNotifications values.
 const (
 	MessageNotificationsAllMessages  MessageNotifications = 0
 	MessageNotificationsOnlyMentions MessageNotifications = 1
@@ -960,7 +960,7 @@ const (
 // https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
 type SystemChannelFlag int
 
-// Block containing known SystemChannelFlag values
+// Block containing known SystemChannelFlag values.
 const (
 	SystemChannelFlagsSuppressJoin    SystemChannelFlag = 1 << 0
 	SystemChannelFlagsSuppressPremium SystemChannelFlag = 1 << 1
@@ -987,7 +987,7 @@ func (g *Guild) BannerURL() string {
 	return EndpointGuildBanner(g.ID, g.Banner)
 }
 
-// A UserGuild holds a brief version of a Guild
+// A UserGuild holds a brief version of a Guild.
 type UserGuild struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
@@ -996,7 +996,7 @@ type UserGuild struct {
 	Permissions int64  `json:"permissions,string"`
 }
 
-// A GuildParams stores all the data needed to update discord guild settings
+// A GuildParams stores all the data needed to update discord guild settings.
 type GuildParams struct {
 	Name                        string             `json:"name,omitempty"`
 	Region                      string             `json:"region,omitempty"`
@@ -1040,12 +1040,12 @@ type Role struct {
 	Permissions int64 `json:"permissions,string"`
 }
 
-// Mention returns a string which mentions the role
+// Mention returns a string which mentions the role.
 func (r *Role) Mention() string {
 	return fmt.Sprintf("<@&%s>", r.ID)
 }
 
-// Roles are a collection of Role
+// Roles are a collection of Role.
 type Roles []*Role
 
 func (r Roles) Len() int {
@@ -1060,7 +1060,7 @@ func (r Roles) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
-// A VoiceState stores the voice states of Guilds
+// A VoiceState stores the voice states of Guilds.
 type VoiceState struct {
 	UserID    string `json:"user_id"`
 	SessionID string `json:"session_id"`
@@ -1081,13 +1081,13 @@ type Presence struct {
 	Since      *int        `json:"since"`
 }
 
-// A TimeStamps struct contains start and end times used in the rich presence "playing .." Game
+// A TimeStamps struct contains start and end times used in the rich presence "playing .." Game.
 type TimeStamps struct {
 	EndTimestamp   int64 `json:"end,omitempty"`
 	StartTimestamp int64 `json:"start,omitempty"`
 }
 
-// UnmarshalJSON unmarshals JSON into TimeStamps struct
+// UnmarshalJSON unmarshals JSON into TimeStamps struct.
 func (t *TimeStamps) UnmarshalJSON(b []byte) error {
 	temp := struct {
 		End   float64 `json:"end,omitempty"`
@@ -1102,7 +1102,7 @@ func (t *TimeStamps) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// An Assets struct contains assets and labels used in the rich presence "playing .." Game
+// An Assets struct contains assets and labels used in the rich presence "playing .." Game.
 type Assets struct {
 	LargeImageID string `json:"large_image,omitempty"`
 	SmallImageID string `json:"small_image,omitempty"`
@@ -1151,7 +1151,7 @@ type Member struct {
 	CommunicationDisabledUntil *time.Time `json:"communication_disabled_until"`
 }
 
-// Mention creates a member mention
+// Mention creates a member mention.
 func (m *Member) Mention() string {
 	return "<@!" + m.User.ID + ">"
 }
@@ -1167,7 +1167,6 @@ func (m *Member) AvatarURL(size string) string {
 	// The default/empty avatar case should be handled by the above condition
 	return avatarURL(m.Avatar, "", EndpointGuildMemberAvatar(m.GuildID, m.User.ID, m.Avatar),
 		EndpointGuildMemberAvatarAnimated(m.GuildID, m.User.ID, m.Avatar), size)
-
 }
 
 // A Settings stores data for a specific users Discord client settings.
@@ -1189,10 +1188,10 @@ type Settings struct {
 	DeveloperMode          bool               `json:"developer_mode"`
 }
 
-// Status type definition
+// Status type definition.
 type Status string
 
-// Constants for Status with the different current available status
+// Constants for Status with the different current available status.
 const (
 	StatusOnline       Status = "online"
 	StatusIdle         Status = "idle"
@@ -1201,14 +1200,14 @@ const (
 	StatusOffline      Status = "offline"
 )
 
-// FriendSourceFlags stores ... TODO :)
+// FriendSourceFlags stores ... TODO :).
 type FriendSourceFlags struct {
 	All           bool `json:"all"`
 	MutualGuilds  bool `json:"mutual_guilds"`
 	MutualFriends bool `json:"mutual_friends"`
 }
 
-// A Relationship between the logged in user and Relationship.User
+// A Relationship between the logged in user and Relationship.User.
 type Relationship struct {
 	User *User  `json:"user"`
 	Type int    `json:"type"` // 1 = friend, 2 = blocked, 3 = incoming friend req, 4 = sent friend req
@@ -1250,7 +1249,7 @@ type ReadState struct {
 	ID            string `json:"id"`
 }
 
-// An Ack is used to ack messages
+// An Ack is used to ack messages.
 type Ack struct {
 	Token string `json:"token"`
 }
@@ -1294,7 +1293,7 @@ type AuditLogEntry struct {
 	Reason     string            `json:"reason"`
 }
 
-// AuditLogChange for an AuditLogEntry
+// AuditLogChange for an AuditLogEntry.
 type AuditLogChange struct {
 	NewValue interface{}        `json:"new_value"`
 	OldValue interface{}        `json:"old_value"`
@@ -1305,149 +1304,149 @@ type AuditLogChange struct {
 // https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key
 type AuditLogChangeKey string
 
-// Block of valid AuditLogChangeKey
+// Block of valid AuditLogChangeKey.
 const (
-	// AuditLogChangeKeyAfkChannelID is sent when afk channel changed (snowflake) - guild
+	// AuditLogChangeKeyAfkChannelID is sent when afk channel changed (snowflake) - guild.
 	AuditLogChangeKeyAfkChannelID AuditLogChangeKey = "afk_channel_id"
-	// AuditLogChangeKeyAfkTimeout is sent when afk timeout duration changed (int) - guild
+	// AuditLogChangeKeyAfkTimeout is sent when afk timeout duration changed (int) - guild.
 	AuditLogChangeKeyAfkTimeout AuditLogChangeKey = "afk_timeout"
-	// AuditLogChangeKeyAllow is sent when a permission on a text or voice channel was allowed for a role (string) - role
+	// AuditLogChangeKeyAllow is sent when a permission on a text or voice channel was allowed for a role (string) - role.
 	AuditLogChangeKeyAllow AuditLogChangeKey = "allow"
-	// AudirChangeKeyApplicationID is sent when application id of the added or removed webhook or bot (snowflake) - channel
+	// AudirChangeKeyApplicationID is sent when application id of the added or removed webhook or bot (snowflake) - channel.
 	AuditLogChangeKeyApplicationID AuditLogChangeKey = "application_id"
-	// AuditLogChangeKeyArchived is sent when thread was archived/unarchived (bool) - thread
+	// AuditLogChangeKeyArchived is sent when thread was archived/unarchived (bool) - thread.
 	AuditLogChangeKeyArchived AuditLogChangeKey = "archived"
-	// AuditLogChangeKeyAsset is sent when asset is changed (string) - sticker
+	// AuditLogChangeKeyAsset is sent when asset is changed (string) - sticker.
 	AuditLogChangeKeyAsset AuditLogChangeKey = "asset"
-	// AuditLogChangeKeyAutoArchiveDuration is sent when auto archive duration changed (int) - thread
+	// AuditLogChangeKeyAutoArchiveDuration is sent when auto archive duration changed (int) - thread.
 	AuditLogChangeKeyAutoArchiveDuration AuditLogChangeKey = "auto_archive_duration"
-	// AuditLogChangeKeyAvailable is sent when availability of sticker changed (bool) - sticker
+	// AuditLogChangeKeyAvailable is sent when availability of sticker changed (bool) - sticker.
 	AuditLogChangeKeyAvailable AuditLogChangeKey = "available"
-	// AuditLogChangeKeyAvatarHash is sent when user avatar changed (string) - user
+	// AuditLogChangeKeyAvatarHash is sent when user avatar changed (string) - user.
 	AuditLogChangeKeyAvatarHash AuditLogChangeKey = "avatar_hash"
-	// AuditLogChangeKeyBannerHash is sent when guild banner changed (string) - guild
+	// AuditLogChangeKeyBannerHash is sent when guild banner changed (string) - guild.
 	AuditLogChangeKeyBannerHash AuditLogChangeKey = "banner_hash"
-	// AuditLogChangeKeyBitrate is sent when voice channel bitrate changed (int) - channel
+	// AuditLogChangeKeyBitrate is sent when voice channel bitrate changed (int) - channel.
 	AuditLogChangeKeyBitrate AuditLogChangeKey = "bitrate"
-	// AuditLogChangeKeyChannelID is sent when channel for invite code or guild scheduled event changed (snowflake) - invite or guild scheduled event
+	// AuditLogChangeKeyChannelID is sent when channel for invite code or guild scheduled event changed (snowflake) - invite or guild scheduled event.
 	AuditLogChangeKeyChannelID AuditLogChangeKey = "channel_id"
-	// AuditLogChangeKeyCode is sent when invite code changed (string) - invite
+	// AuditLogChangeKeyCode is sent when invite code changed (string) - invite.
 	AuditLogChangeKeyCode AuditLogChangeKey = "code"
-	// AuditLogChangeKeyColor is sent when role color changed (int) - role
+	// AuditLogChangeKeyColor is sent when role color changed (int) - role.
 	AuditLogChangeKeyColor AuditLogChangeKey = "color"
-	// AuditLogChangeKeyCommunicationDisabledUntil is sent when member timeout state changed (ISO8601 timestamp) - member
+	// AuditLogChangeKeyCommunicationDisabledUntil is sent when member timeout state changed (ISO8601 timestamp) - member.
 	AuditLogChangeKeyCommunicationDisabledUntil AuditLogChangeKey = "communication_disabled_until"
-	// AuditLogChangeKeyDeaf is sent when user server deafened/undeafened (bool) - member
+	// AuditLogChangeKeyDeaf is sent when user server deafened/undeafened (bool) - member.
 	AuditLogChangeKeyDeaf AuditLogChangeKey = "deaf"
-	// AuditLogChangeKeyDefaultAutoArchiveDuration is sent when default auto archive duration for newly created threads changed (int) - channel
+	// AuditLogChangeKeyDefaultAutoArchiveDuration is sent when default auto archive duration for newly created threads changed (int) - channel.
 	AuditLogChangeKeyDefaultAutoArchiveDuration AuditLogChangeKey = "default_auto_archive_duration"
-	// AuditLogChangeKeyDefaultMessageNotification is sent when default message notification level changed (int) - guild
+	// AuditLogChangeKeyDefaultMessageNotification is sent when default message notification level changed (int) - guild.
 	AuditLogChangeKeyDefaultMessageNotification AuditLogChangeKey = "default_message_notifications"
-	// AuditLogChangeKeyDeny is sent when a permission on a text or voice channel was denied for a role (string) - role
+	// AuditLogChangeKeyDeny is sent when a permission on a text or voice channel was denied for a role (string) - role.
 	AuditLogChangeKeyDeny AuditLogChangeKey = "deny"
-	// AuditLogChangeKeyDescription is sent when description changed (string) - guild, sticker, or guild scheduled event
+	// AuditLogChangeKeyDescription is sent when description changed (string) - guild, sticker, or guild scheduled event.
 	AuditLogChangeKeyDescription AuditLogChangeKey = "description"
-	// AuditLogChangeKeyDiscoverySplashHash is sent when discovery splash changed (string) - guild
+	// AuditLogChangeKeyDiscoverySplashHash is sent when discovery splash changed (string) - guild.
 	AuditLogChangeKeyDiscoverySplashHash AuditLogChangeKey = "discovery_splash_hash"
-	// AuditLogChangeKeyEnableEmoticons is sent when integration emoticons enabled/disabled (bool) - integration
+	// AuditLogChangeKeyEnableEmoticons is sent when integration emoticons enabled/disabled (bool) - integration.
 	AuditLogChangeKeyEnableEmoticons AuditLogChangeKey = "enable_emoticons"
-	// AuditLogChangeKeyEntityType is sent when entity type of guild scheduled event was changed (int) - guild scheduled event
+	// AuditLogChangeKeyEntityType is sent when entity type of guild scheduled event was changed (int) - guild scheduled event.
 	AuditLogChangeKeyEntityType AuditLogChangeKey = "entity_type"
-	// AuditLogChangeKeyExpireBehavior is sent when integration expiring subscriber behavior changed (int) - integration
+	// AuditLogChangeKeyExpireBehavior is sent when integration expiring subscriber behavior changed (int) - integration.
 	AuditLogChangeKeyExpireBehavior AuditLogChangeKey = "expire_behavior"
-	// AuditLogChangeKeyExpireGracePeriod is sent when integration expire grace period changed (int) - integration
+	// AuditLogChangeKeyExpireGracePeriod is sent when integration expire grace period changed (int) - integration.
 	AuditLogChangeKeyExpireGracePeriod AuditLogChangeKey = "expire_grace_period"
-	// AuditLogChangeKeyExplicitContentFilter is sent when change in whose messages are scanned and deleted for explicit content in the server is made (int) - guild
+	// AuditLogChangeKeyExplicitContentFilter is sent when change in whose messages are scanned and deleted for explicit content in the server is made (int) - guild.
 	AuditLogChangeKeyExplicitContentFilter AuditLogChangeKey = "explicit_content_filter"
-	// AuditLogChangeKeyFormatType is sent when format type of sticker changed (int - sticker format type) - sticker
+	// AuditLogChangeKeyFormatType is sent when format type of sticker changed (int - sticker format type) - sticker.
 	AuditLogChangeKeyFormatType AuditLogChangeKey = "format_type"
-	// AuditLogChangeKeyGuildID is sent when guild sticker is in changed (snowflake) - sticker
+	// AuditLogChangeKeyGuildID is sent when guild sticker is in changed (snowflake) - sticker.
 	AuditLogChangeKeyGuildID AuditLogChangeKey = "guild_id"
-	// AuditLogChangeKeyHoist is sent when role is now displayed/no longer displayed separate from online users (bool) - role
+	// AuditLogChangeKeyHoist is sent when role is now displayed/no longer displayed separate from online users (bool) - role.
 	AuditLogChangeKeyHoist AuditLogChangeKey = "hoist"
-	// AuditLogChangeKeyIconHash is sent when icon changed (string) - guild or role
+	// AuditLogChangeKeyIconHash is sent when icon changed (string) - guild or role.
 	AuditLogChangeKeyIconHash AuditLogChangeKey = "icon_hash"
-	// AuditLogChangeKeyID is sent when the id of the changed entity - sometimes used in conjunction with other keys (snowflake) - any
+	// AuditLogChangeKeyID is sent when the id of the changed entity - sometimes used in conjunction with other keys (snowflake) - any.
 	AuditLogChangeKeyID AuditLogChangeKey = "id"
-	// AuditLogChangeKeyInvitable is sent when private thread is now invitable/uninvitable (bool) - thread
+	// AuditLogChangeKeyInvitable is sent when private thread is now invitable/uninvitable (bool) - thread.
 	AuditLogChangeKeyInvitable AuditLogChangeKey = "invitable"
-	// AuditLogChangeKeyInviterID is sent when person who created invite code changed (snowflake) - invite
+	// AuditLogChangeKeyInviterID is sent when person who created invite code changed (snowflake) - invite.
 	AuditLogChangeKeyInviterID AuditLogChangeKey = "inviter_id"
-	// AuditLogChangeKeyLocation is sent when channel id for guild scheduled event changed (string) - guild scheduled event
+	// AuditLogChangeKeyLocation is sent when channel id for guild scheduled event changed (string) - guild scheduled event.
 	AuditLogChangeKeyLocation AuditLogChangeKey = "location"
-	// AuditLogChangeKeyLocked is sent when thread was locked/unlocked (bool) - thread
+	// AuditLogChangeKeyLocked is sent when thread was locked/unlocked (bool) - thread.
 	AuditLogChangeKeyLocked AuditLogChangeKey = "locked"
-	// AuditLogChangeKeyMaxAge is sent when invite code expiration time changed (int) - invite
+	// AuditLogChangeKeyMaxAge is sent when invite code expiration time changed (int) - invite.
 	AuditLogChangeKeyMaxAge AuditLogChangeKey = "max_age"
-	// AuditLogChangeKeyMaxUses is sent when max number of times invite code can be used changed (int) - invite
+	// AuditLogChangeKeyMaxUses is sent when max number of times invite code can be used changed (int) - invite.
 	AuditLogChangeKeyMaxUses AuditLogChangeKey = "max_uses"
-	// AuditLogChangeKeyMentionable is sent when role is now mentionable/unmentionable (bool) - role
+	// AuditLogChangeKeyMentionable is sent when role is now mentionable/unmentionable (bool) - role.
 	AuditLogChangeKeyMentionable AuditLogChangeKey = "mentionable"
-	// AuditLogChangeKeyMfaLevel is sent when two-factor auth requirement changed (int - mfa level) - guild
+	// AuditLogChangeKeyMfaLevel is sent when two-factor auth requirement changed (int - mfa level) - guild.
 	AuditLogChangeKeyMfaLevel AuditLogChangeKey = "mfa_level"
-	// AuditLogChangeKeyMute is sent when user server muted/unmuted (bool) - member
+	// AuditLogChangeKeyMute is sent when user server muted/unmuted (bool) - member.
 	AuditLogChangeKeyMute AuditLogChangeKey = "mute"
-	// AuditLogChangeKeyName is sent when name changed (string) - any
+	// AuditLogChangeKeyName is sent when name changed (string) - any.
 	AuditLogChangeKeyName AuditLogChangeKey = "name"
-	// AuditLogChangeKeyNick is sent when user nickname changed (string) - member
+	// AuditLogChangeKeyNick is sent when user nickname changed (string) - member.
 	AuditLogChangeKeyNick AuditLogChangeKey = "nick"
-	// AuditLogChangeKeyNSFW is sent when channel nsfw restriction changed (bool) - channel
+	// AuditLogChangeKeyNSFW is sent when channel nsfw restriction changed (bool) - channel.
 	AuditLogChangeKeyNSFW AuditLogChangeKey = "nsfw"
-	// AuditLogChangeKeyOwnerID is sent when owner changed (snowflake) - guild
+	// AuditLogChangeKeyOwnerID is sent when owner changed (snowflake) - guild.
 	AuditLogChangeKeyOwnerID AuditLogChangeKey = "owner_id"
-	// AuditLogChangeKeyPermissionOverwrite is sent when permissions on a channel changed (array of channel overwrite objects) - channel
+	// AuditLogChangeKeyPermissionOverwrite is sent when permissions on a channel changed (array of channel overwrite objects) - channel.
 	AuditLogChangeKeyPermissionOverwrite AuditLogChangeKey = "permission_overwrites"
-	// AuditLogChangeKeyPermissions is sent when permissions for a role changed (string) - role
+	// AuditLogChangeKeyPermissions is sent when permissions for a role changed (string) - role.
 	AuditLogChangeKeyPermissions AuditLogChangeKey = "permissions"
-	// AuditLogChangeKeyPosition is sent when text or voice channel position changed (int) - channel
+	// AuditLogChangeKeyPosition is sent when text or voice channel position changed (int) - channel.
 	AuditLogChangeKeyPosition AuditLogChangeKey = "position"
-	// AuditLogChangeKeyPreferredLocale is sent when preferred locale changed (string) - guild
+	// AuditLogChangeKeyPreferredLocale is sent when preferred locale changed (string) - guild.
 	AuditLogChangeKeyPreferredLocale AuditLogChangeKey = "preferred_locale"
-	// AuditLogChangeKeyPrivacylevel is sent when privacy level of the stage instance changed (integer - privacy level) - stage instance or guild scheduled event
+	// AuditLogChangeKeyPrivacylevel is sent when privacy level of the stage instance changed (integer - privacy level) - stage instance or guild scheduled event.
 	AuditLogChangeKeyPrivacylevel AuditLogChangeKey = "privacy_level"
-	// AuditLogChangeKeyPruneDeleteDays is sent when number of days after which inactive and role-unassigned members are kicked changed (int) - guild
+	// AuditLogChangeKeyPruneDeleteDays is sent when number of days after which inactive and role-unassigned members are kicked changed (int) - guild.
 	AuditLogChangeKeyPruneDeleteDays AuditLogChangeKey = "prune_delete_days"
-	// AuditLogChangeKeyPulibUpdatesChannelID is sent when id of the public updates channel changed (snowflake) - guild
+	// AuditLogChangeKeyPulibUpdatesChannelID is sent when id of the public updates channel changed (snowflake) - guild.
 	AuditLogChangeKeyPulibUpdatesChannelID AuditLogChangeKey = "public_updates_channel_id"
-	// AuditLogChangeKeyRateLimitPerUser is sent when amount of seconds a user has to wait before sending another message changed (int) - channel
+	// AuditLogChangeKeyRateLimitPerUser is sent when amount of seconds a user has to wait before sending another message changed (int) - channel.
 	AuditLogChangeKeyRateLimitPerUser AuditLogChangeKey = "rate_limit_per_user"
-	// AuditLogChangeKeyRegion is sent when region changed (string) - guild
+	// AuditLogChangeKeyRegion is sent when region changed (string) - guild.
 	AuditLogChangeKeyRegion AuditLogChangeKey = "region"
-	// AuditLogChangeKeyRulesChannelID is sent when id of the rules channel changed (snowflake) - guild
+	// AuditLogChangeKeyRulesChannelID is sent when id of the rules channel changed (snowflake) - guild.
 	AuditLogChangeKeyRulesChannelID AuditLogChangeKey = "rules_channel_id"
-	// AuditLogChangeKeySplashHash is sent when invite splash page artwork changed (string) - guild
+	// AuditLogChangeKeySplashHash is sent when invite splash page artwork changed (string) - guild.
 	AuditLogChangeKeySplashHash AuditLogChangeKey = "splash_hash"
-	// AuditLogChangeKeyStatus is sent when status of guild scheduled event was changed (int - guild scheduled event status) - guild scheduled event
+	// AuditLogChangeKeyStatus is sent when status of guild scheduled event was changed (int - guild scheduled event status) - guild scheduled event.
 	AuditLogChangeKeyStatus AuditLogChangeKey = "status"
-	// AuditLogChangeKeySystemChannelID is sent when id of the system channel changed (snowflake) - guild
+	// AuditLogChangeKeySystemChannelID is sent when id of the system channel changed (snowflake) - guild.
 	AuditLogChangeKeySystemChannelID AuditLogChangeKey = "system_channel_id"
-	// AuditLogChangeKeyTags is sent when related emoji of sticker changed (string) - sticker
+	// AuditLogChangeKeyTags is sent when related emoji of sticker changed (string) - sticker.
 	AuditLogChangeKeyTags AuditLogChangeKey = "tags"
-	// AuditLogChangeKeyTemporary is sent when invite code is now temporary or never expires (bool) - invite
+	// AuditLogChangeKeyTemporary is sent when invite code is now temporary or never expires (bool) - invite.
 	AuditLogChangeKeyTemporary AuditLogChangeKey = "temporary"
-	// TODO: remove when compatibility is not required
+	// TODO: remove when compatibility is not required.
 	AuditLogChangeKeyTempoary = AuditLogChangeKeyTemporary
-	// AuditLogChangeKeyTopic is sent when text channel topic or stage instance topic changed (string) - channel or stage instance
+	// AuditLogChangeKeyTopic is sent when text channel topic or stage instance topic changed (string) - channel or stage instance.
 	AuditLogChangeKeyTopic AuditLogChangeKey = "topic"
-	// AuditLogChangeKeyType is sent when type of entity created (int or string) - any
+	// AuditLogChangeKeyType is sent when type of entity created (int or string) - any.
 	AuditLogChangeKeyType AuditLogChangeKey = "type"
-	// AuditLogChangeKeyUnicodeEmoji is sent when role unicode emoji changed (string) - role
+	// AuditLogChangeKeyUnicodeEmoji is sent when role unicode emoji changed (string) - role.
 	AuditLogChangeKeyUnicodeEmoji AuditLogChangeKey = "unicode_emoji"
-	// AuditLogChangeKeyUserLimit is sent when new user limit in a voice channel set (int) - voice channel
+	// AuditLogChangeKeyUserLimit is sent when new user limit in a voice channel set (int) - voice channel.
 	AuditLogChangeKeyUserLimit AuditLogChangeKey = "user_limit"
-	// AuditLogChangeKeyUses is sent when number of times invite code used changed (int) - invite
+	// AuditLogChangeKeyUses is sent when number of times invite code used changed (int) - invite.
 	AuditLogChangeKeyUses AuditLogChangeKey = "uses"
-	// AuditLogChangeKeyVanityURLCode is sent when guild invite vanity url changed (string) - guild
+	// AuditLogChangeKeyVanityURLCode is sent when guild invite vanity url changed (string) - guild.
 	AuditLogChangeKeyVanityURLCode AuditLogChangeKey = "vanity_url_code"
-	// AuditLogChangeKeyVerificationLevel is sent when required verification level changed (int - verification level) - guild
+	// AuditLogChangeKeyVerificationLevel is sent when required verification level changed (int - verification level) - guild.
 	AuditLogChangeKeyVerificationLevel AuditLogChangeKey = "verification_level"
-	// AuditLogChangeKeyWidgetChannelID is sent when channel id of the server widget changed (snowflake) - guild
+	// AuditLogChangeKeyWidgetChannelID is sent when channel id of the server widget changed (snowflake) - guild.
 	AuditLogChangeKeyWidgetChannelID AuditLogChangeKey = "widget_channel_id"
-	// AuditLogChangeKeyWidgetEnabled is sent when server widget enabled/disabled (bool) - guild
+	// AuditLogChangeKeyWidgetEnabled is sent when server widget enabled/disabled (bool) - guild.
 	AuditLogChangeKeyWidgetEnabled AuditLogChangeKey = "widget_enabled"
-	// AuditLogChangeKeyRoleAdd is sent when new role added (array of partial role objects) - guild
+	// AuditLogChangeKeyRoleAdd is sent when new role added (array of partial role objects) - guild.
 	AuditLogChangeKeyRoleAdd AuditLogChangeKey = "$add"
-	// AuditLogChangeKeyRoleRemove is sent when role removed (array of partial role objects) - guild
+	// AuditLogChangeKeyRoleRemove is sent when role removed (array of partial role objects) - guild.
 	AuditLogChangeKeyRoleRemove AuditLogChangeKey = "$remove"
 )
 
@@ -1468,7 +1467,7 @@ type AuditLogOptions struct {
 // https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info
 type AuditLogOptionsType string
 
-// Valid Types for AuditLogOptionsType
+// Valid Types for AuditLogOptionsType.
 const (
 	AuditLogOptionsTypeMember AuditLogOptionsType = "member"
 	AuditLogOptionsTypeRole   AuditLogOptionsType = "role"
@@ -1478,7 +1477,7 @@ const (
 // https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
 type AuditLogAction int
 
-// Block contains Discord Audit Log Action Types
+// Block contains Discord Audit Log Action Types.
 const (
 	AuditLogActionGuildUpdate AuditLogAction = 1
 
@@ -1557,7 +1556,7 @@ type UserGuildSettings struct {
 	ChannelOverrides     []*UserGuildSettingsChannelOverride `json:"channel_overrides"`
 }
 
-// A UserGuildSettingsEdit stores data for editing UserGuildSettings
+// A UserGuildSettingsEdit stores data for editing UserGuildSettings.
 type UserGuildSettingsEdit struct {
 	SupressEveryone      bool                                         `json:"suppress_everyone"`
 	Muted                bool                                         `json:"muted"`
@@ -1566,7 +1565,7 @@ type UserGuildSettingsEdit struct {
 	ChannelOverrides     map[string]*UserGuildSettingsChannelOverride `json:"channel_overrides"`
 }
 
-// An APIErrorMessage is an api error message returned from discord
+// An APIErrorMessage is an api error message returned from discord.
 type APIErrorMessage struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
@@ -1581,14 +1580,14 @@ type MessageReaction struct {
 	GuildID   string `json:"guild_id,omitempty"`
 }
 
-// GatewayBotResponse stores the data for the gateway/bot response
+// GatewayBotResponse stores the data for the gateway/bot response.
 type GatewayBotResponse struct {
 	URL               string             `json:"url"`
 	Shards            int                `json:"shards"`
 	SessionStartLimit SessionInformation `json:"session_start_limit"`
 }
 
-// SessionInformation provides the information for max concurrency sharding
+// SessionInformation provides the information for max concurrency sharding.
 type SessionInformation struct {
 	Total          int `json:"total,omitempty"`
 	Remaining      int `json:"remaining,omitempty"`
@@ -1624,7 +1623,7 @@ type Activity struct {
 	Flags         int          `json:"flags,omitempty"`
 }
 
-// UnmarshalJSON is a custom unmarshaljson to make CreatedAt a time.Time instead of an int
+// UnmarshalJSON is a custom unmarshaljson to make CreatedAt a time.Time instead of an int.
 func (activity *Activity) UnmarshalJSON(b []byte) error {
 	temp := struct {
 		Name          string       `json:"name"`
@@ -1682,7 +1681,7 @@ type Secrets struct {
 // https://discord.com/developers/docs/topics/gateway#activity-object-activity-types
 type ActivityType int
 
-// Valid ActivityType values
+// Valid ActivityType values.
 const (
 	ActivityTypeGame      ActivityType = 0
 	ActivityTypeStreaming ActivityType = 1
@@ -1715,9 +1714,9 @@ type IdentifyProperties struct {
 	ReferringDomain string `json:"$referring_domain"`
 }
 
-// Constants for the different bit offsets of text channel permissions
+// Constants for the different bit offsets of text channel permissions.
 const (
-	// Deprecated: PermissionReadMessages has been replaced with PermissionViewChannel for text and voice channels
+	// Deprecated: PermissionReadMessages has been replaced with PermissionViewChannel for text and voice channels.
 	PermissionReadMessages          = 0x0000000000000400
 	PermissionSendMessages          = 0x0000000000000800
 	PermissionSendTTSMessages       = 0x0000000000001000
@@ -1734,7 +1733,7 @@ const (
 	PermissionSendMessagesInThreads = 0x0000004000000000
 )
 
-// Constants for the different bit offsets of voice permissions
+// Constants for the different bit offsets of voice permissions.
 const (
 	PermissionVoicePrioritySpeaker = 0x0000000000000100
 	PermissionVoiceStreamVideo     = 0x0000000000000200
@@ -1756,7 +1755,7 @@ const (
 	PermissionManageEmojis    = 0x0000000040000000
 )
 
-// Constants for the different bit offsets of general permissions
+// Constants for the different bit offsets of general permissions.
 const (
 	PermissionCreateInstantInvite = 0x0000000000000001
 	PermissionKickMembers         = 0x0000000000000002
@@ -1802,7 +1801,7 @@ const (
 		PermissionManageEmojis
 )
 
-// Block contains Discord JSON Error Response codes
+// Block contains Discord JSON Error Response codes.
 const (
 	ErrCodeGeneralError = 0
 
@@ -1967,7 +1966,7 @@ const (
 // https://discord.com/developers/docs/topics/gateway#gateway-intents
 type Intent int
 
-// Constants for the different bit offsets of intents
+// Constants for the different bit offsets of intents.
 const (
 	IntentGuilds                 Intent = 1 << 0
 	IntentGuildMembers           Intent = 1 << 1
@@ -1987,7 +1986,7 @@ const (
 	IntentMessageContent         Intent = 1 << 15
 	IntentGuildScheduledEvents   Intent = 1 << 16
 
-	// TODO: remove when compatibility is not needed
+	// TODO: remove when compatibility is not needed.
 
 	IntentsGuilds                 Intent = 1 << 0
 	IntentsGuildMembers           Intent = 1 << 1

--- a/user.go
+++ b/user.go
@@ -4,7 +4,7 @@ package discordgo
 // https://discord.com/developers/docs/resources/user#user-object-user-flags
 type UserFlags int
 
-// Valid UserFlags values
+// Valid UserFlags values.
 const (
 	UserFlagDiscordEmployee           UserFlags = 1 << 0
 	UserFlagDiscordPartner            UserFlags = 1 << 1
@@ -80,12 +80,12 @@ type User struct {
 	Flags int `json:"flags"`
 }
 
-// String returns a unique identifier of the form username#discriminator
+// String returns a unique identifier of the form username#discriminator.
 func (u *User) String() string {
 	return u.Username + "#" + u.Discriminator
 }
 
-// Mention return a string which mentions the user
+// Mention return a string which mentions the user.
 func (u *User) Mention() string {
 	return "<@" + u.ID + ">"
 }

--- a/util.go
+++ b/util.go
@@ -25,7 +25,7 @@ func SnowflakeTimestamp(ID string) (t time.Time, err error) {
 
 // MultipartBodyWithJSON returns the contentType and body for a discord request
 // data  : The object to encode for payload_json in the multipart request
-// files : Files to include in the request
+// files : Files to include in the request.
 func MultipartBodyWithJSON(data interface{}, files []*File) (requestContentType string, requestBody []byte, err error) {
 	body := &bytes.Buffer{}
 	bodywriter := multipart.NewWriter(body)

--- a/voice.go
+++ b/voice.go
@@ -104,12 +104,12 @@ func (v *VoiceConnection) Speaking(b bool) (err error) {
 	if err != nil {
 		v.speaking = false
 		v.log(LogError, "Speaking() write json error, %s", err)
-		return
+		return nil
 	}
 
 	v.speaking = b
 
-	return
+	return nil
 }
 
 // ChangeChannel sends Discord a request to change channels within a Guild
@@ -129,7 +129,7 @@ func (v *VoiceConnection) ChangeChannel(channelID string, mute, deaf bool) (err 
 	v.mute = mute
 	v.speaking = false
 
-	return
+	return nil
 }
 
 // Disconnect disconnects from this voice channel and closes the websocket
@@ -279,7 +279,7 @@ func (v *VoiceConnection) open() (err error) {
 	// Don't open a websocket if one is already open
 	if v.wsConn != nil {
 		v.log(LogWarning, "refusing to overwrite non-nil websocket")
-		return
+		return nil
 	}
 
 	// TODO temp? loop to wait for the SessionID
@@ -302,7 +302,7 @@ func (v *VoiceConnection) open() (err error) {
 	if err != nil {
 		v.log(LogWarning, "error connecting to voice endpoint %s, %s", vg, err)
 		v.log(LogDebug, "voice struct: %#v\n", v)
-		return
+		return nil
 	}
 
 	type voiceHandshakeData struct {
@@ -320,7 +320,7 @@ func (v *VoiceConnection) open() (err error) {
 	err = v.wsConn.WriteJSON(data)
 	if err != nil {
 		v.log(LogWarning, "error sending init packet, %s", err)
-		return
+		return nil
 	}
 
 	v.close = make(chan struct{})
@@ -330,7 +330,7 @@ func (v *VoiceConnection) open() (err error) {
 	// then return false if not ready?
 	// but then wsListen will also err.
 
-	return
+	return nil
 }
 
 // wsListen listens on the voice websocket for messages and passes them
@@ -556,14 +556,14 @@ func (v *VoiceConnection) udpOpen() (err error) {
 	addr, err := net.ResolveUDPAddr("udp", host)
 	if err != nil {
 		v.log(LogWarning, "error resolving udp host %s, %s", host, err)
-		return
+		return nil
 	}
 
 	v.log(LogInformational, "connecting to udp addr %s", addr.String())
 	v.udpConn, err = net.DialUDP("udp", nil, addr)
 	if err != nil {
 		v.log(LogWarning, "error connecting to udp addr %s, %s", addr.String(), err)
-		return
+		return nil
 	}
 
 	// Create a 70 byte array and put the SSRC code from the Op 2 VoiceConnection event
@@ -573,7 +573,7 @@ func (v *VoiceConnection) udpOpen() (err error) {
 	_, err = v.udpConn.Write(sb)
 	if err != nil {
 		v.log(LogWarning, "udp write error to %s, %s", addr.String(), err)
-		return
+		return nil
 	}
 
 	// Create a 70 byte array and listen for the initial handshake response
@@ -584,7 +584,7 @@ func (v *VoiceConnection) udpOpen() (err error) {
 	rlen, _, err := v.udpConn.ReadFromUDP(rb)
 	if err != nil {
 		v.log(LogWarning, "udp read error, %s, %s", addr.String(), err)
-		return
+		return nil
 	}
 
 	if rlen < 70 {
@@ -614,14 +614,14 @@ func (v *VoiceConnection) udpOpen() (err error) {
 	v.wsMutex.Unlock()
 	if err != nil {
 		v.log(LogWarning, "udp write error, %#v, %s", data, err)
-		return
+		return nil
 	}
 
 	// start udpKeepAlive
 	go v.udpKeepAlive(v.udpConn, v.close, 5*time.Second)
 	// TODO: find a way to check that it fired off okay
 
-	return
+	return nil
 }
 
 // udpKeepAlive sends a udp packet to keep the udp connection open

--- a/voice.go
+++ b/voice.go
@@ -70,7 +70,7 @@ type VoiceConnection struct {
 }
 
 // VoiceSpeakingUpdateHandler type provides a function definition for the
-// VoiceSpeakingUpdate event
+// VoiceSpeakingUpdate event.
 type VoiceSpeakingUpdateHandler func(vc *VoiceConnection, vs *VoiceSpeakingUpdate)
 
 // Speaking sends a speaking notification to Discord over the voice websocket.
@@ -78,7 +78,6 @@ type VoiceSpeakingUpdateHandler func(vc *VoiceConnection, vs *VoiceSpeakingUpdat
 // once finished sending audio.
 //  b  : Send true if speaking, false if not.
 func (v *VoiceConnection) Speaking(b bool) (err error) {
-
 	v.log(LogDebug, "called (%t)", b)
 
 	type voiceSpeakingData struct {
@@ -114,9 +113,8 @@ func (v *VoiceConnection) Speaking(b bool) (err error) {
 }
 
 // ChangeChannel sends Discord a request to change channels within a Guild
-// !!! NOTE !!! This function may be removed in favour of just using ChannelVoiceJoin
+// !!! NOTE !!! This function may be removed in favour of just using ChannelVoiceJoin.
 func (v *VoiceConnection) ChangeChannel(channelID string, mute, deaf bool) (err error) {
-
 	v.log(LogInformational, "called")
 
 	data := voiceChannelJoinOp{4, voiceChannelJoinData{&v.GuildID, &channelID, mute, deaf}}
@@ -137,7 +135,6 @@ func (v *VoiceConnection) ChangeChannel(channelID string, mute, deaf bool) (err 
 // Disconnect disconnects from this voice channel and closes the websocket
 // and udp connections to Discord.
 func (v *VoiceConnection) Disconnect() (err error) {
-
 	// Send a OP4 with a nil channel to disconnect
 	v.Lock()
 	if v.sessionID != "" {
@@ -161,9 +158,8 @@ func (v *VoiceConnection) Disconnect() (err error) {
 	return
 }
 
-// Close closes the voice ws and udp connections
+// Close closes the voice ws and udp connections.
 func (v *VoiceConnection) Close() {
-
 	v.log(LogInformational, "called")
 
 	v.Lock()
@@ -232,14 +228,14 @@ type VoiceSpeakingUpdate struct {
 // ------------------------------------------------------------------------------------------------
 
 // A voiceOP4 stores the data for the voice operation 4 websocket event
-// which provides us with the NaCl SecretBox encryption key
+// which provides us with the NaCl SecretBox encryption key.
 type voiceOP4 struct {
 	SecretKey [32]byte `json:"secret_key"`
 	Mode      string   `json:"mode"`
 }
 
 // A voiceOP2 stores the data for the voice operation 2 websocket event
-// which is sort of like the voice READY packet
+// which is sort of like the voice READY packet.
 type voiceOP2 struct {
 	SSRC              uint32        `json:"ssrc"`
 	Port              int           `json:"port"`
@@ -249,9 +245,8 @@ type voiceOP2 struct {
 }
 
 // WaitUntilConnected waits for the Voice Connection to
-// become ready, if it does not become ready it returns an err
+// become ready, if it does not become ready it returns an err.
 func (v *VoiceConnection) waitUntilConnected() error {
-
 	v.log(LogInformational, "called")
 
 	i := 0
@@ -276,7 +271,6 @@ func (v *VoiceConnection) waitUntilConnected() error {
 // after VoiceChannelJoin is used and the data VOICE websocket events
 // are captured.
 func (v *VoiceConnection) open() (err error) {
-
 	v.log(LogInformational, "called")
 
 	v.Lock()
@@ -340,9 +334,8 @@ func (v *VoiceConnection) open() (err error) {
 }
 
 // wsListen listens on the voice websocket for messages and passes them
-// to the voice event handler.  This is automatically called by the Open func
+// to the voice event handler.  This is automatically called by the Open func.
 func (v *VoiceConnection) wsListen(wsConn *websocket.Conn, close <-chan struct{}) {
-
 	v.log(LogInformational, "called")
 
 	for {
@@ -374,7 +367,6 @@ func (v *VoiceConnection) wsListen(wsConn *websocket.Conn, close <-chan struct{}
 			sameConnection := v.wsConn == wsConn
 			v.RUnlock()
 			if sameConnection {
-
 				v.log(LogError, "voice endpoint %s websocket closed unexpectantly, %s", v.endpoint, err)
 
 				// Start reconnect goroutine then exit.
@@ -396,7 +388,6 @@ func (v *VoiceConnection) wsListen(wsConn *websocket.Conn, close <-chan struct{}
 // wsEvent handles any voice websocket events. This is only called by the
 // wsListen() function.
 func (v *VoiceConnection) onEvent(message []byte) {
-
 	v.log(LogDebug, "received: %s", string(message))
 
 	var e Event
@@ -406,7 +397,6 @@ func (v *VoiceConnection) onEvent(message []byte) {
 	}
 
 	switch e.Operation {
-
 	case 2: // READY
 
 		if err := json.Unmarshal(e.RawData, &v.op2); err != nil {
@@ -492,7 +482,6 @@ type voiceHeartbeatOp struct {
 // is still connected.  If you do not send these heartbeats Discord will
 // disconnect the websocket connection after a few seconds.
 func (v *VoiceConnection) wsHeartbeat(wsConn *websocket.Conn, close <-chan struct{}, i time.Duration) {
-
 	if close == nil || wsConn == nil {
 		return
 	}
@@ -542,9 +531,8 @@ type voiceUDPOp struct {
 // udpOpen opens a UDP connection to the voice server and completes the
 // initial required handshake.  This connection is left open in the session
 // and can be used to send or receive audio.  This should only be called
-// from voice.wsEvent OP2
+// from voice.wsEvent OP2.
 func (v *VoiceConnection) udpOpen() (err error) {
-
 	v.Lock()
 	defer v.Unlock()
 
@@ -637,9 +625,8 @@ func (v *VoiceConnection) udpOpen() (err error) {
 }
 
 // udpKeepAlive sends a udp packet to keep the udp connection open
-// This is still a bit of a "proof of concept"
+// This is still a bit of a "proof of concept".
 func (v *VoiceConnection) udpKeepAlive(udpConn *net.UDPConn, close <-chan struct{}, i time.Duration) {
-
 	if udpConn == nil || close == nil {
 		return
 	}
@@ -652,7 +639,6 @@ func (v *VoiceConnection) udpKeepAlive(udpConn *net.UDPConn, close <-chan struct
 	ticker := time.NewTicker(i)
 	defer ticker.Stop()
 	for {
-
 		binary.LittleEndian.PutUint64(packet, sequence)
 		sequence++
 
@@ -674,7 +660,6 @@ func (v *VoiceConnection) udpKeepAlive(udpConn *net.UDPConn, close <-chan struct
 // opusSender will listen on the given channel and send any
 // pre-encoded opus audio to Discord.  Supposedly.
 func (v *VoiceConnection) opusSender(udpConn *net.UDPConn, close <-chan struct{}, opus <-chan []byte, rate, size int) {
-
 	if udpConn == nil || close == nil {
 		return
 	}
@@ -706,7 +691,6 @@ func (v *VoiceConnection) opusSender(udpConn *net.UDPConn, close <-chan struct{}
 	ticker := time.NewTicker(time.Millisecond * time.Duration(size/(rate/1000)))
 	defer ticker.Stop()
 	for {
-
 		// Get data from chan.  If chan is closed, return.
 		select {
 		case <-close:
@@ -782,7 +766,6 @@ type Packet struct {
 // and sends them across the given channel
 // NOTE :: This function may change names later.
 func (v *VoiceConnection) opusReceiver(udpConn *net.UDPConn, close <-chan struct{}, c chan *Packet) {
-
 	if udpConn == nil || close == nil {
 		return
 	}
@@ -800,7 +783,6 @@ func (v *VoiceConnection) opusReceiver(udpConn *net.UDPConn, close <-chan struct
 			sameConnection := v.udpConn == udpConn
 			v.RUnlock()
 			if sameConnection {
-
 				v.log(LogError, "udp read error, %s, %s", v.endpoint, err)
 				v.log(LogDebug, "voice struct: %#v\n", v)
 
@@ -858,7 +840,6 @@ func (v *VoiceConnection) opusReceiver(udpConn *net.UDPConn, close <-chan struct
 // It will be cleaned up once a proven stable option is flushed out.
 // aka: this is ugly shit code, please don't judge too harshly.
 func (v *VoiceConnection) reconnect() {
-
 	v.log(LogInformational, "called")
 
 	v.Lock()
@@ -877,7 +858,6 @@ func (v *VoiceConnection) reconnect() {
 
 	wait := time.Duration(1)
 	for {
-
 		<-time.After(wait * time.Second)
 		wait *= 2
 		if wait > 600 {
@@ -909,6 +889,5 @@ func (v *VoiceConnection) reconnect() {
 		if err != nil {
 			v.log(LogError, "error sending disconnect packet, %s", err)
 		}
-
 	}
 }

--- a/voice.go
+++ b/voice.go
@@ -57,9 +57,6 @@ type VoiceConnection struct {
 	// Used to send a close signal to goroutines
 	close chan struct{}
 
-	// Used to allow blocking until connected
-	connected chan bool
-
 	// Used to pass the sessionid from onVoiceStateUpdate
 	// sessionRecv chan string UNUSED ATM
 

--- a/voice.go
+++ b/voice.go
@@ -122,7 +122,7 @@ func (v *VoiceConnection) ChangeChannel(channelID string, mute, deaf bool) (err 
 	err = v.session.wsConn.WriteJSON(data)
 	v.wsMutex.Unlock()
 	if err != nil {
-		return
+		return err
 	}
 	v.ChannelID = channelID
 	v.deaf = deaf
@@ -155,7 +155,7 @@ func (v *VoiceConnection) Disconnect() (err error) {
 	delete(v.session.VoiceConnections, v.GuildID)
 	v.session.Unlock()
 
-	return
+	return nil
 }
 
 // Close closes the voice ws and udp connections.

--- a/voice.go
+++ b/voice.go
@@ -139,6 +139,9 @@ func (v *VoiceConnection) Disconnect() (err error) {
 		v.session.wsMutex.Lock()
 		err = v.session.wsConn.WriteJSON(data)
 		v.session.wsMutex.Unlock()
+		if err != nil {
+			v.log(LogError, "error sending disconnect packet, %s", err)
+		}
 		v.sessionID = ""
 	}
 	v.Unlock()

--- a/webhook.go
+++ b/webhook.go
@@ -19,7 +19,7 @@ type Webhook struct {
 // https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types
 type WebhookType int
 
-// Valid WebhookType values
+// Valid WebhookType values.
 const (
 	WebhookTypeIncoming        WebhookType = 1
 	WebhookTypeChannelFollower WebhookType = 2

--- a/wsapi.go
+++ b/wsapi.go
@@ -29,11 +29,11 @@ import (
 var ErrWSAlreadyOpen = errors.New("web socket already opened")
 
 // ErrWSNotFound is thrown when you attempt to use a websocket
-// that doesn't exist
+// that doesn't exist.
 var ErrWSNotFound = errors.New("no websocket connection exists")
 
 // ErrWSShardBounds is thrown when you try to use a shard ID that is
-// more than the total shard count
+// more than the total shard count.
 var ErrWSShardBounds = errors.New("ShardID must be less than ShardCount")
 
 type resumePacket struct {
@@ -125,14 +125,12 @@ func (s *Session) Open() error {
 	// connection or Op 6 Resume if we are resuming an existing connection.
 	sequence := atomic.LoadInt64(s.sequence)
 	if s.sessionID == "" && sequence == 0 {
-
 		// Send Op 2 Identity Packet
 		err = s.identify()
 		if err != nil {
 			err = fmt.Errorf("error sending identify packet to gateway, %s, %s", s.gateway, err)
 			return err
 		}
-
 	} else {
 
 		// Send Op 6 Resume Packet
@@ -150,7 +148,6 @@ func (s *Session) Open() error {
 			err = fmt.Errorf("error sending gateway resume packet, %s, %s", s.gateway, err)
 			return err
 		}
-
 	}
 
 	// A basic state is a hard requirement for Voice.
@@ -208,15 +205,12 @@ func (s *Session) Open() error {
 // listen polls the websocket connection for events, it will stop when the
 // listening channel is closed, or an error occurs.
 func (s *Session) listen(wsConn *websocket.Conn, listening <-chan interface{}) {
-
 	s.log(LogInformational, "called")
 
 	for {
-
 		messageType, message, err := wsConn.ReadMessage()
 
 		if err != nil {
-
 			// Detect if we have been closed manually. If a Close() has already
 			// happened, the websocket we are listening on will be different to
 			// the current session.
@@ -225,7 +219,6 @@ func (s *Session) listen(wsConn *websocket.Conn, listening <-chan interface{}) {
 			s.RUnlock()
 
 			if sameConnection {
-
 				s.log(LogWarning, "error reading from gateway %s websocket, %s", s.gateway, err)
 				// There has been an error reading, close the websocket so that
 				// OnDisconnect event is emitted.
@@ -242,13 +235,11 @@ func (s *Session) listen(wsConn *websocket.Conn, listening <-chan interface{}) {
 		}
 
 		select {
-
 		case <-listening:
 			return
 
 		default:
 			s.onEvent(messageType, message)
-
 		}
 	}
 }
@@ -267,16 +258,13 @@ const FailedHeartbeatAcks time.Duration = 5 * time.Millisecond
 
 // HeartbeatLatency returns the latency between heartbeat acknowledgement and heartbeat send.
 func (s *Session) HeartbeatLatency() time.Duration {
-
 	return s.LastHeartbeatAck.Sub(s.LastHeartbeatSent)
-
 }
 
 // heartbeat sends regular heartbeats to Discord so it knows the client
 // is still connected.  If you do not send these heartbeats Discord will
 // disconnect the websocket connection after a few seconds.
 func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}, heartbeatIntervalMsec time.Duration) {
-
 	s.log(LogInformational, "called")
 
 	if listening == nil || wsConn == nil {
@@ -320,7 +308,7 @@ func (s *Session) heartbeat(wsConn *websocket.Conn, listening <-chan interface{}
 	}
 }
 
-// UpdateStatusData ia provided to UpdateStatusComplex()
+// UpdateStatusData ia provided to UpdateStatusComplex().
 type UpdateStatusData struct {
 	IdleSince  *int        `json:"since"`
 	Activities []*Activity `json:"activities"`
@@ -425,7 +413,7 @@ type requestGuildMembersOp struct {
 // guildID   : Single Guild ID to request members of
 // query     : String that username starts with, leave empty to return all members
 // limit     : Max number of items to return, or 0 to request all members matched
-// presences : Whether to request presences of guild members
+// presences : Whether to request presences of guild members.
 func (s *Session) RequestGuildMembers(guildID string, query string, limit int, presences bool) (err error) {
 	data := requestGuildMembersData{
 		GuildIDs:  []string{guildID},
@@ -442,7 +430,7 @@ func (s *Session) RequestGuildMembers(guildID string, query string, limit int, p
 // guildID   : Slice of guild IDs to request members of
 // query     : String that username starts with, leave empty to return all members
 // limit     : Max number of items to return, or 0 to request all members matched
-// presences : Whether to request presences of guild members
+// presences : Whether to request presences of guild members.
 func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limit int, presences bool) (err error) {
 	data := requestGuildMembersData{
 		GuildIDs:  guildIDs,
@@ -479,14 +467,12 @@ func (s *Session) requestGuildMembers(data requestGuildMembersData) (err error) 
 // If you use the AddHandler() function to register a handler for the
 // "OnEvent" event then all events will be passed to that handler.
 func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
-
 	var err error
 	var reader io.Reader
 	reader = bytes.NewBuffer(message)
 
 	// If this is a compressed message, uncompress it.
 	if messageType == websocket.BinaryMessage {
-
 		z, err2 := zlib.NewReader(reader)
 		if err2 != nil {
 			s.log(LogError, "error uncompressing websocket message, %s", err)
@@ -540,7 +526,6 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 	// Invalid Session
 	// Must respond with a Identify packet.
 	if e.Operation == 9 {
-
 		s.log(LogInformational, "sending identify packet to gateway in response to Op9")
 
 		err = s.identify()
@@ -626,7 +611,6 @@ type voiceChannelJoinOp struct {
 //    mute    : If true, you will be set to muted upon joining.
 //    deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *VoiceConnection, err error) {
-
 	s.log(LogInformational, "called")
 
 	s.RLock()
@@ -673,7 +657,6 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 //    mute    : If true, you will be set to muted upon joining.
 //    deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err error) {
-
 	s.log(LogInformational, "called")
 
 	var channelID *string
@@ -693,7 +676,6 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 
 // onVoiceStateUpdate handles Voice State Update events on the data websocket.
 func (s *Session) onVoiceStateUpdate(st *VoiceStateUpdate) {
-
 	// If we don't have a connection for the channel, don't bother
 	if st.ChannelID == "" {
 		return
@@ -726,7 +708,6 @@ func (s *Session) onVoiceStateUpdate(st *VoiceStateUpdate) {
 // to a voice channel.  In that case, need to re-establish connection to
 // the new region endpoint.
 func (s *Session) onVoiceServerUpdate(st *VoiceServerUpdate) {
-
 	s.log(LogInformational, "called")
 
 	s.RLock()
@@ -761,7 +742,7 @@ type identifyOp struct {
 	Data Identify `json:"d"`
 }
 
-// identify sends the identify packet to the gateway
+// identify sends the identify packet to the gateway.
 func (s *Session) identify() error {
 	s.log(LogDebug, "called")
 
@@ -781,7 +762,6 @@ func (s *Session) identify() error {
 	// can be deprecated and their usage moved to the Session.Identify
 	// struct
 	if s.ShardCount > 1 {
-
 		if s.ShardID >= s.ShardCount {
 			return ErrWSShardBounds
 		}
@@ -800,13 +780,11 @@ func (s *Session) identify() error {
 }
 
 func (s *Session) reconnect() {
-
 	s.log(LogInformational, "called")
 
 	var err error
 
 	if s.ShouldReconnectOnError {
-
 		wait := time.Duration(1)
 
 		for {
@@ -824,14 +802,12 @@ func (s *Session) reconnect() {
 				s.RLock()
 				defer s.RUnlock()
 				for _, v := range s.VoiceConnections {
-
 					s.log(LogInformational, "reconnecting voice connection to guild %s", v.GuildID)
 					go v.reconnect()
 
 					// This is here just to prevent violently spamming the
 					// voice reconnects
 					time.Sleep(1 * time.Second)
-
 				}
 				return
 			}
@@ -855,16 +831,15 @@ func (s *Session) reconnect() {
 }
 
 // Close closes a websocket and stops all listening/heartbeat goroutines.
-// TODO: Add support for Voice WS/UDP
+// TODO: Add support for Voice WS/UDP.
 func (s *Session) Close() error {
 	return s.CloseWithCode(websocket.CloseNormalClosure)
 }
 
 // CloseWithCode closes a websocket using the provided closeCode and stops all
 // listening/heartbeat goroutines.
-// TODO: Add support for Voice WS/UDP connections
+// TODO: Add support for Voice WS/UDP connections.
 func (s *Session) CloseWithCode(closeCode int) (err error) {
-
 	s.log(LogInformational, "called")
 	s.Lock()
 
@@ -880,7 +855,6 @@ func (s *Session) CloseWithCode(closeCode int) (err error) {
 	// this should force stop any reconnecting voice channels too
 
 	if s.wsConn != nil {
-
 		s.log(LogInformational, "sending close frame")
 		// To cleanly close a connection, a client should send a close
 		// frame and wait for the server to close the connection.

--- a/wsapi.go
+++ b/wsapi.go
@@ -678,6 +678,9 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 	s.wsMutex.Lock()
 	err = s.wsConn.WriteJSON(data)
 	s.wsMutex.Unlock()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -413,14 +413,17 @@ type requestGuildMembersOp struct {
 // query     : String that username starts with, leave empty to return all members
 // limit     : Max number of items to return, or 0 to request all members matched
 // presences : Whether to request presences of guild members.
-func (s *Session) RequestGuildMembers(guildID string, query string, limit int, presences bool) (err error) {
+func (s *Session) RequestGuildMembers(guildID string, query string, limit int, presences bool) error {
 	data := requestGuildMembersData{
 		GuildIDs:  []string{guildID},
 		Query:     query,
 		Limit:     limit,
 		Presences: presences,
 	}
-	err = s.requestGuildMembers(data)
+
+	if err := s.requestGuildMembers(data); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -430,14 +433,16 @@ func (s *Session) RequestGuildMembers(guildID string, query string, limit int, p
 // query     : String that username starts with, leave empty to return all members
 // limit     : Max number of items to return, or 0 to request all members matched
 // presences : Whether to request presences of guild members.
-func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limit int, presences bool) (err error) {
+func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limit int, presences bool) error {
 	data := requestGuildMembersData{
 		GuildIDs:  guildIDs,
 		Query:     query,
 		Limit:     limit,
 		Presences: presences,
 	}
-	err = s.requestGuildMembers(data)
+	if err := s.requestGuildMembers(data); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -453,6 +458,9 @@ func (s *Session) requestGuildMembers(data requestGuildMembersData) (err error) 
 	s.wsMutex.Lock()
 	err = s.wsConn.WriteJSON(requestGuildMembersOp{8, data})
 	s.wsMutex.Unlock()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/wsapi.go
+++ b/wsapi.go
@@ -132,7 +132,6 @@ func (s *Session) Open() error {
 			return err
 		}
 	} else {
-
 		// Send Op 6 Resume Packet
 		p := resumePacket{}
 		p.Op = 6
@@ -422,7 +421,7 @@ func (s *Session) RequestGuildMembers(guildID string, query string, limit int, p
 		Presences: presences,
 	}
 	err = s.requestGuildMembers(data)
-	return
+	return nil
 }
 
 // RequestGuildMembersBatch requests guild members from the gateway
@@ -439,7 +438,7 @@ func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limi
 		Presences: presences,
 	}
 	err = s.requestGuildMembers(data)
-	return
+	return nil
 }
 
 func (s *Session) requestGuildMembers(data requestGuildMembersData) (err error) {
@@ -455,7 +454,7 @@ func (s *Session) requestGuildMembers(data requestGuildMembersData) (err error) 
 	err = s.wsConn.WriteJSON(requestGuildMembersOp{8, data})
 	s.wsMutex.Unlock()
 
-	return
+	return nil
 }
 
 // onEvent is the "event handler" for all messages received on the
@@ -634,7 +633,7 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 
 	err = s.ChannelVoiceJoinManual(gID, cID, mute, deaf)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// doesn't exactly work perfect yet.. TODO
@@ -642,10 +641,10 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 	if err != nil {
 		s.log(LogWarning, "error waiting for voice to connect, %s", err)
 		voice.Close()
-		return
+		return nil, err
 	}
 
-	return
+	return voice, nil
 }
 
 // ChannelVoiceJoinManual initiates a voice session to a voice channel, but does not complete it.
@@ -671,7 +670,7 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 	s.wsMutex.Lock()
 	err = s.wsConn.WriteJSON(data)
 	s.wsMutex.Unlock()
-	return
+	return nil
 }
 
 // onVoiceStateUpdate handles Voice State Update events on the data websocket.
@@ -882,5 +881,5 @@ func (s *Session) CloseWithCode(closeCode int) (err error) {
 	s.log(LogInformational, "emit disconnect event")
 	s.handleEvent(disconnectEventType, &Disconnect{})
 
-	return
+	return nil
 }


### PR DESCRIPTION
These aren't technically breaking changes because no code logic is _supposed to be_ changed. However, there may be errors in translation. These improvements are beneficial over the long term for a more maintainable (and contributor-friendly) code base.

## Style
Removed over 200 occurrences of nakedreturns. A lot of unhandled errors _(that are now handled)_. A lot of setting errors (inside the if statement) before returning (as opposed to simply returning the error).

I placed recommendations for disabled linters in `.golangci.yml`. Edits by maintainers is allowed (as usual).