### PR TITLE
Application commands localization

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -47,6 +47,45 @@ var (
 			Description: "Basic command with files",
 		},
 		{
+			Name:        "localized-command",
+			Description: "Localized command. Description and name may vary depending on the Language setting",
+			NameLocalizations: &map[discordgo.Locale]string{
+				discordgo.ChineseCN: "本地化的命令",
+			},
+			DescriptionLocalizations: &map[discordgo.Locale]string{
+				discordgo.ChineseCN: "这是一个本地化的命令",
+			},
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        "localized-option",
+					Description: "Localized option. Description and name may vary depending on the Language setting",
+					NameLocalizations: map[discordgo.Locale]string{
+						discordgo.ChineseCN: "一个本地化的选项",
+					},
+					DescriptionLocalizations: map[discordgo.Locale]string{
+						discordgo.ChineseCN: "这是一个本地化的选项",
+					},
+					Type: discordgo.ApplicationCommandOptionInteger,
+					Choices: []*discordgo.ApplicationCommandOptionChoice{
+						{
+							Name: "First",
+							NameLocalizations: map[discordgo.Locale]string{
+								discordgo.ChineseCN: "一的",
+							},
+							Value: 1,
+						},
+						{
+							Name: "Second",
+							NameLocalizations: map[discordgo.Locale]string{
+								discordgo.ChineseCN: "二的",
+							},
+							Value: 2,
+						},
+					},
+				},
+			},
+		},
+		{
 			Name:        "options",
 			Description: "Command for demonstrating options",
 			Options: []*discordgo.ApplicationCommandOption{
@@ -195,6 +234,24 @@ var (
 					},
 				},
 			})
+		},
+		"localized-command": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			responses := map[discordgo.Locale]string{
+				discordgo.ChineseCN: "你好！ 这是一个本地化的命令",
+			}
+			response := "Hi! This is a localized message"
+			if r, ok := responses[i.Locale]; ok {
+				response = r
+			}
+			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: response,
+				},
+			})
+			if err != nil {
+				panic(err)
+			}
 		},
 		"options": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			margs := []interface{}{

--- a/interactions.go
+++ b/interactions.go
@@ -35,12 +35,14 @@ type ApplicationCommand struct {
 	Version           string                 `json:"version,omitempty"`
 	Type              ApplicationCommandType `json:"type,omitempty"`
 	Name              string                 `json:"name"`
+	NameLocalizations *map[Locale]string     `json:"name_localizations,omitempty"`
 	DefaultPermission *bool                  `json:"default_permission,omitempty"`
 
 	// NOTE: Chat commands only. Otherwise it mustn't be set.
 
-	Description string                      `json:"description,omitempty"`
-	Options     []*ApplicationCommandOption `json:"options"`
+	Description              string                      `json:"description,omitempty"`
+	DescriptionLocalizations *map[Locale]string          `json:"description_localizations,omitempty"`
+	Options                  []*ApplicationCommandOption `json:"options"`
 }
 
 // ApplicationCommandOptionType indicates the type of a slash command's option.
@@ -91,9 +93,11 @@ func (t ApplicationCommandOptionType) String() string {
 
 // ApplicationCommandOption represents an option/subcommand/subcommands group.
 type ApplicationCommandOption struct {
-	Type        ApplicationCommandOptionType `json:"type"`
-	Name        string                       `json:"name"`
-	Description string                       `json:"description,omitempty"`
+	Type                     ApplicationCommandOptionType `json:"type"`
+	Name                     string                       `json:"name"`
+	NameLocalizations        map[Locale]string            `json:"name_localizations"`
+	Description              string                       `json:"description,omitempty"`
+	DescriptionLocalizations map[Locale]string            `json:"description_localizations"`
 	// NOTE: This feature was on the API, but at some point developers decided to remove it.
 	// So I commented it, until it will be officially on the docs.
 	// Default     bool                              `json:"default"`
@@ -113,8 +117,9 @@ type ApplicationCommandOption struct {
 
 // ApplicationCommandOptionChoice represents a slash command option choice.
 type ApplicationCommandOptionChoice struct {
-	Name  string      `json:"name"`
-	Value interface{} `json:"value"`
+	Name              string            `json:"name"`
+	NameLocalizations map[Locale]string `json:"name_localizations"`
+	Value             interface{}       `json:"value"`
 }
 
 // ApplicationCommandPermissions represents a single user or role permission for a command.


### PR DESCRIPTION
This PR implements newly added localization for application commands. Enjoy!

## Useful links
- https://github.com/discord/discord-api-docs/pull/4653
- [Documentation](https://discord.com/developers/docs/interactions/application-commands#localization)