### PR TITLE
Updated RequestGuildMembers method and GuildMembersChunk event struct

### DIFF
--- a/events.go
+++ b/events.go
@@ -187,11 +187,13 @@ type GuildEmojisUpdate struct {
 
 // A GuildMembersChunk is the data for a GuildMembersChunk event.
 type GuildMembersChunk struct {
-	GuildID    string      `json:"guild_id"`
-	Members    []*Member   `json:"members"`
-	ChunkIndex int         `json:"chunk_index"`
-	ChunkCount int         `json:"chunk_count"`
-	Presences  []*Presence `json:"presences,omitempty"`
+	GuildID    string        `json:"guild_id"`
+	Members    []*Member     `json:"members"`
+	ChunkIndex int           `json:"chunk_index"`
+	ChunkCount int           `json:"chunk_count"`
+	NotFound   []json.Number `json:"not_found,omitempty"`
+	Presences  []*Presence   `json:"presences,omitempty"`
+	Nonce      string        `json:"nonce,omitempty"`
 }
 
 // GuildIntegrationsUpdate is the data for a GuildIntegrationsUpdate event.

--- a/events.go
+++ b/events.go
@@ -187,13 +187,13 @@ type GuildEmojisUpdate struct {
 
 // A GuildMembersChunk is the data for a GuildMembersChunk event.
 type GuildMembersChunk struct {
-	GuildID    string        `json:"guild_id"`
-	Members    []*Member     `json:"members"`
-	ChunkIndex int           `json:"chunk_index"`
-	ChunkCount int           `json:"chunk_count"`
-	NotFound   []json.Number `json:"not_found,omitempty"`
-	Presences  []*Presence   `json:"presences,omitempty"`
-	Nonce      string        `json:"nonce,omitempty"`
+	GuildID    string      `json:"guild_id"`
+	Members    []*Member   `json:"members"`
+	ChunkIndex int         `json:"chunk_index"`
+	ChunkCount int         `json:"chunk_count"`
+	NotFound   []string    `json:"not_found,omitempty"`
+	Presences  []*Presence `json:"presences,omitempty"`
+	Nonce      string      `json:"nonce,omitempty"`
 }
 
 // GuildIntegrationsUpdate is the data for a GuildIntegrationsUpdate event.

--- a/wsapi.go
+++ b/wsapi.go
@@ -409,12 +409,12 @@ func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
 }
 
 type requestGuildMembersData struct {
-	GuildIDs  []string       `json:"guild_id"`
-	Query     *string        `json:"query,omitempty"`
-	UserIDs   *[]json.Number `json:"user_ids,omitempty"`
-	Limit     int            `json:"limit"`
-	Nonce     string         `json:"nonce,omitempty"`
-	Presences bool           `json:"presences"`
+	GuildIDs  []string  `json:"guild_id"`
+	Query     *string   `json:"query,omitempty"`
+	UserIDs   *[]string `json:"user_ids,omitempty"`
+	Limit     int       `json:"limit"`
+	Nonce     string    `json:"nonce,omitempty"`
+	Presences bool      `json:"presences"`
 }
 
 type requestGuildMembersOp struct {
@@ -471,16 +471,9 @@ func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limi
 // nonce     : Nonce to identify the Guild Members Chunk response
 // presences : Whether to request presences of guild members
 func (s *Session) RequestGuildMembersBatchList(guildIDs []string, userIDs []string, limit int, nonce string, presences bool) (err error) {
-	// []json.Number is used here to prevent retry loop in
-	// 'ready' callback caused by non-digit characters
-	newUserIDs := make([]json.Number, len(userIDs))
-	for i, userID := range userIDs {
-		newUserIDs[i] = json.Number(userID)
-	}
-
 	data := requestGuildMembersData{
 		GuildIDs:  guildIDs,
-		UserIDs:   &newUserIDs,
+		UserIDs:   &userIDs,
 		Limit:     limit,
 		Nonce:     nonce,
 		Presences: presences,

--- a/wsapi.go
+++ b/wsapi.go
@@ -409,12 +409,12 @@ func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
 }
 
 type requestGuildMembersData struct {
-	GuildIDs  []string      `json:"guild_id"`
-	Query     *string       `json:"query,omitempty"`
-	UserIDs   []json.Number `json:"user_ids,omitempty"`
-	Limit     int           `json:"limit"`
-	Nonce     string        `json:"nonce,omitempty"`
-	Presences bool          `json:"presences"`
+	GuildIDs  []string       `json:"guild_id"`
+	Query     *string        `json:"query,omitempty"`
+	UserIDs   *[]json.Number `json:"user_ids,omitempty"`
+	Limit     int            `json:"limit"`
+	Nonce     string         `json:"nonce,omitempty"`
+	Presences bool           `json:"presences"`
 }
 
 type requestGuildMembersOp struct {
@@ -471,10 +471,6 @@ func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limi
 // nonce     : Nonce to identify the Guild Members Chunk response
 // presences : Whether to request presences of guild members
 func (s *Session) RequestGuildMembersBatchList(guildIDs []string, userIDs []string, limit int, nonce string, presences bool) (err error) {
-	if len(userIDs) == 0 {
-		return
-	}
-
 	// []json.Number is used here to prevent retry loop in
 	// 'ready' callback caused by non-digit characters
 	newUserIDs := make([]json.Number, len(userIDs))
@@ -484,7 +480,7 @@ func (s *Session) RequestGuildMembersBatchList(guildIDs []string, userIDs []stri
 
 	data := requestGuildMembersData{
 		GuildIDs:  guildIDs,
-		UserIDs:   newUserIDs,
+		UserIDs:   &newUserIDs,
 		Limit:     limit,
 		Nonce:     nonce,
 		Presences: presences,

--- a/wsapi.go
+++ b/wsapi.go
@@ -409,10 +409,12 @@ func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
 }
 
 type requestGuildMembersData struct {
-	GuildIDs  []string `json:"guild_id"`
-	Query     string   `json:"query"`
-	Limit     int      `json:"limit"`
-	Presences bool     `json:"presences"`
+	GuildIDs  []string  `json:"guild_id"`
+	Query     *string   `json:"query,omitempty"`
+	Limit     int       `json:"limit"`
+	Presences bool      `json:"presences"`
+	UserIDs   *[]string `json:"user_ids,omitempty"`
+	Nonce     string    `json:"nonce,omitempty"`
 }
 
 type requestGuildMembersOp struct {
@@ -426,12 +428,22 @@ type requestGuildMembersOp struct {
 // query     : String that username starts with, leave empty to return all members
 // limit     : Max number of items to return, or 0 to request all members matched
 // presences : Whether to request presences of guild members
-func (s *Session) RequestGuildMembers(guildID string, query string, limit int, presences bool) (err error) {
+// userIDs   : Used to specify which users you wish to fetch
+// nonce     : Nonce to identify the Guild Members Chunk response
+func (s *Session) RequestGuildMembers(guildID, query string, limit int, presences bool, userIDs *[]string, nonce string) (err error) {
+	// One of query or user_ids
+	var queryPt *string
+	if userIDs == nil {
+		queryPt = &query
+	}
+
 	data := requestGuildMembersData{
 		GuildIDs:  []string{guildID},
-		Query:     query,
+		Query:     queryPt,
 		Limit:     limit,
 		Presences: presences,
+		UserIDs:   userIDs,
+		Nonce:     nonce,
 	}
 	err = s.requestGuildMembers(data)
 	return
@@ -446,7 +458,7 @@ func (s *Session) RequestGuildMembers(guildID string, query string, limit int, p
 func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limit int, presences bool) (err error) {
 	data := requestGuildMembersData{
 		GuildIDs:  guildIDs,
-		Query:     query,
+		Query:     &query,
 		Limit:     limit,
 		Presences: presences,
 	}

--- a/wsapi.go
+++ b/wsapi.go
@@ -409,6 +409,7 @@ func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
 }
 
 type requestGuildMembersData struct {
+	// TODO: Deprecated. Use string instead of []string
 	GuildIDs  []string  `json:"guild_id"`
 	Query     *string   `json:"query,omitempty"`
 	UserIDs   *[]string `json:"user_ids,omitempty"`
@@ -436,7 +437,7 @@ func (s *Session) RequestGuildMembers(guildID, query string, limit int, nonce st
 // RequestGuildMembersList requests guild members from the gateway
 // The gateway responds with GuildMembersChunk events
 // guildID   : Single Guild ID to request members of
-// userIDs   : Used to specify which users you wish to fetch
+// userIDs   : IDs of users to fetch
 // limit     : Max number of items to return, or 0 to request all members matched
 // nonce     : Nonce to identify the Guild Members Chunk response
 // presences : Whether to request presences of guild members
@@ -451,6 +452,8 @@ func (s *Session) RequestGuildMembersList(guildID string, userIDs []string, limi
 // limit     : Max number of items to return, or 0 to request all members matched
 // nonce     : Nonce to identify the Guild Members Chunk response
 // presences : Whether to request presences of guild members
+//
+// NOTE: this function is deprecated, please use RequestGuildMembers instead
 func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limit int, nonce string, presences bool) (err error) {
 	data := requestGuildMembersData{
 		GuildIDs:  guildIDs,
@@ -466,10 +469,12 @@ func (s *Session) RequestGuildMembersBatch(guildIDs []string, query string, limi
 // RequestGuildMembersBatchList requests guild members from the gateway
 // The gateway responds with GuildMembersChunk events
 // guildID   : Slice of guild IDs to request members of
-// userIDs   : Used to specify which users you wish to fetch
+// userIDs   : IDs of users to fetch
 // limit     : Max number of items to return, or 0 to request all members matched
 // nonce     : Nonce to identify the Guild Members Chunk response
 // presences : Whether to request presences of guild members
+//
+// NOTE: this function is deprecated, please use RequestGuildMembersList instead
 func (s *Session) RequestGuildMembersBatchList(guildIDs []string, userIDs []string, limit int, nonce string, presences bool) (err error) {
 	data := requestGuildMembersData{
 		GuildIDs:  guildIDs,


### PR DESCRIPTION
I'm not sure if the "guild_id" field should be an array because according to the [documentation](https://discord.com/developers/docs/topics/gateway#request-guild-members-guild-request-members-structure), it should be a string. The endpoint accepts both array and string without errors.