### PR TITLE
fix: check if opus created

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -829,7 +829,12 @@ func (v *VoiceConnection) opusReceiver(udpConn *net.UDPConn, close <-chan struct
 		p.SSRC = binary.BigEndian.Uint32(recvbuf[8:12])
 		// decrypt opus data
 		copy(nonce[:], recvbuf[0:12])
-		p.Opus, _ = secretbox.Open(nil, recvbuf[12:rlen], &nonce, &v.op4.SecretKey)
+
+		if opus, ok := secretbox.Open(nil, recvbuf[12:rlen], &nonce, &v.op4.SecretKey); ok {
+			p.Opus = opus
+		} else {
+			return
+		}
 
 		// extension bit set, and not a RTCP packet
 		if ((recvbuf[0] & 0x10) == 0x10) && ((recvbuf[1] & 0x80) == 0) {


### PR DESCRIPTION
Occasionally it causes panic when secretbox.open failed.
Below in the code we read `extlen := binary.BigEndian.Uint16(p.Opus[2:4])`
But opus can be nil.
I encountered this problem myself.