### PR TITLE
make WebhookEdit fields pointers

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -476,10 +476,11 @@ var (
 				return
 			}
 			time.AfterFunc(time.Second*5, func() {
+				content := content + "\n\nWell, now you know how to create and edit responses. " +
+					"But you still don't know how to delete them... so... wait 10 seconds and this " +
+					"message will be deleted."
 				_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-					Content: content + "\n\nWell, now you know how to create and edit responses. " +
-						"But you still don't know how to delete them... so... wait 10 seconds and this " +
-						"message will be deleted.",
+					Content: &content,
 				})
 				if err != nil {
 					s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
@@ -517,8 +518,9 @@ var (
 			}
 			time.Sleep(time.Second * 5)
 
+			content := "Now the original message is gone and after 10 seconds this message will ~~self-destruct~~ be deleted."
 			s.FollowupMessageEdit(i.Interaction, msg.ID, &discordgo.WebhookEdit{
-				Content: "Now the original message is gone and after 10 seconds this message will ~~self-destruct~~ be deleted.",
+				Content: &content,
 			})
 
 			time.Sleep(time.Second * 10)

--- a/webhook.go
+++ b/webhook.go
@@ -41,9 +41,9 @@ type WebhookParams struct {
 
 // WebhookEdit stores data for editing of a webhook message.
 type WebhookEdit struct {
-	Content         string                  `json:"content,omitempty"`
-	Components      []MessageComponent      `json:"components"`
-	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
+	Content         *string                 `json:"content,omitempty"`
+	Components      *[]MessageComponent     `json:"components,omitempty"`
+	Embeds          *[]*MessageEmbed        `json:"embeds,omitempty"`
 	Files           []*File                 `json:"-"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 }


### PR DESCRIPTION
These need to be pointers to allow removing embeds, content, and components from an existing message.

omitempty was added to components to allow keeping the existing components on a message when calling WebhookEdit

