### PR TITLE
Add replied_user to MessageAllowedMentions

### DIFF
--- a/message.go
+++ b/message.go
@@ -321,6 +321,9 @@ type MessageAllowedMentions struct {
 	// A list of user IDs to allow. This cannot be used when specifying
 	// AllowedMentionTypeUsers in the Parse slice.
 	Users []string `json:"users,omitempty"`
+
+	// For replies, whether to mention the author of the message being replied to
+	RepliedUser bool `json:"replied_user"`
 }
 
 // A MessageAttachment stores data for message attachments.


### PR DESCRIPTION
This is needed to reply without mentions.
https://discord.com/developers/docs/resources/channel#allowed-mentions-object