### PR TITLE
Use `MessageFlags` as the type for `Flags` in `InteractionResponseData` and `WebhookParams`  

### DIFF
--- a/examples/components/main.go
+++ b/examples/components/main.go
@@ -122,7 +122,7 @@ var (
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Content: "This is the way.",
-						Flags:   1 << 6,
+						Flags:   discordgo.MessageFlagsEphemeral,
 					},
 				}
 			default:
@@ -130,7 +130,7 @@ var (
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Content: "It is not the way to go.",
-						Flags:   1 << 6,
+						Flags:   discordgo.MessageFlagsEphemeral,
 					},
 				}
 			}
@@ -157,7 +157,7 @@ var (
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Content: "Here is your stackoverflow URL: " + fmt.Sprintf(stackoverflowFormat, strings.Join(data.Values, "+")),
-					Flags:   1 << 6,
+					Flags:   discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {
@@ -209,7 +209,7 @@ var (
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Content: "Are you comfortable with buttons and other message components?",
-					Flags:   1 << 6,
+					Flags:   discordgo.MessageFlagsEphemeral,
 					// Buttons and other components are specified in Components field.
 					Components: []discordgo.MessageComponent{
 						// ActionRow is a container of all buttons within the same row.
@@ -269,7 +269,7 @@ var (
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Content: "Now let's take a look on selects. This is single item select menu.",
-						Flags:   1 << 6,
+						Flags:   discordgo.MessageFlagsEphemeral,
 						Components: []discordgo.MessageComponent{
 							discordgo.ActionsRow{
 								Components: []discordgo.MessageComponent{

--- a/examples/components/main.go
+++ b/examples/components/main.go
@@ -40,7 +40,7 @@ var (
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Content: "Huh. I see, maybe some of these resources might help you?",
-					Flags:   1 << 6,
+					Flags:   discordgo.MessageFlagsEphemeral,
 					Components: []discordgo.MessageComponent{
 						discordgo.ActionsRow{
 							Components: []discordgo.MessageComponent{
@@ -83,7 +83,7 @@ var (
 				Data: &discordgo.InteractionResponseData{
 					Content: "Great! If you wanna know more or just have questions, feel free to visit Discord Devs and Discord Gophers server. " +
 						"But now, when you know how buttons work, let's move onto select menus (execute `/selects single`)",
-					Flags: 1 << 6,
+					Flags: discordgo.MessageFlagsEphemeral,
 					Components: []discordgo.MessageComponent{
 						discordgo.ActionsRow{
 							Components: []discordgo.MessageComponent{
@@ -142,7 +142,7 @@ var (
 			_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 				Content: "Anyways, now when you know how to use single select menus, let's see how multi select menus work. " +
 					"Try calling `/selects multi` command.",
-				Flags: 1 << 6,
+				Flags: discordgo.MessageFlagsEphemeral,
 			})
 			if err != nil {
 				panic(err)
@@ -196,7 +196,7 @@ var (
 						},
 					},
 				},
-				Flags: 1 << 6,
+				Flags: discordgo.MessageFlagsEphemeral,
 			})
 			if err != nil {
 				panic(err)
@@ -320,7 +320,7 @@ var (
 					Data: &discordgo.InteractionResponseData{
 						Content: "The tastiest things are left for the end. Let's see how the multi-item select menu works: " +
 							"try generating your own stackoverflow search link",
-						Flags: 1 << 6,
+						Flags: discordgo.MessageFlagsEphemeral,
 						Components: []discordgo.MessageComponent{
 							discordgo.ActionsRow{
 								Components: []discordgo.MessageComponent{

--- a/examples/context_menus/main.go
+++ b/examples/context_menus/main.go
@@ -74,7 +74,7 @@ var (
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Content: "Operation rickroll has begun",
-					Flags:   1 << 6,
+					Flags:   discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {
@@ -108,7 +108,7 @@ var (
 					Content: searchLink(
 						i.ApplicationCommandData().Resolved.Messages[i.ApplicationCommandData().TargetID].Content,
 						"https://google.com/search?q=%s", "+"),
-					Flags: 1 << 6,
+					Flags: discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {
@@ -122,7 +122,7 @@ var (
 					Content: searchLink(
 						i.ApplicationCommandData().Resolved.Messages[i.ApplicationCommandData().TargetID].Content,
 						"https://stackoverflow.com/search?q=%s", "+"),
-					Flags: 1 << 6,
+					Flags: discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {
@@ -136,7 +136,7 @@ var (
 					Content: searchLink(
 						i.ApplicationCommandData().Resolved.Messages[i.ApplicationCommandData().TargetID].Content,
 						"https://pkg.go.dev/search?q=%s", "+"),
-					Flags: 1 << 6,
+					Flags: discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {
@@ -150,7 +150,7 @@ var (
 					Content: searchLink(
 						i.ApplicationCommandData().Resolved.Messages[i.ApplicationCommandData().TargetID].Content,
 						"https://discord.js.org/#/docs/main/stable/search?query=%s", "+"),
-					Flags: 1 << 6,
+					Flags: discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {
@@ -164,7 +164,7 @@ var (
 					Content: searchLink(
 						i.ApplicationCommandData().Resolved.Messages[i.ApplicationCommandData().TargetID].Content,
 						"https://discordpy.readthedocs.io/en/stable/search.html?q=%s", "+"),
-					Flags: 1 << 6,
+					Flags: discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {

--- a/examples/context_menus/main.go
+++ b/examples/context_menus/main.go
@@ -87,7 +87,7 @@ var (
 			if err != nil {
 				_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 					Content: fmt.Sprintf("Mission failed. Cannot send a message to this user: %q", err.Error()),
-					Flags:   1 << 6,
+					Flags:   discordgo.MessageFlagsEphemeral,
 				})
 				if err != nil {
 					panic(err)

--- a/examples/modals/main.go
+++ b/examples/modals/main.go
@@ -99,7 +99,7 @@ func main() {
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Content: "Thank you for taking your time to fill this survey",
-					Flags:   1 << 6,
+					Flags:   discordgo.MessageFlagsEphemeral,
 				},
 			})
 			if err != nil {

--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -503,7 +503,7 @@ var (
 					// Note: this isn't documented, but you can use that if you want to.
 					// This flag just allows you to create messages visible only for the caller of the command
 					// (user who triggered the command)
-					Flags:   1 << 6,
+					Flags:   discordgo.MessageFlagsEphemeral,
 					Content: "Surprise!",
 				},
 			})

--- a/interactions.go
+++ b/interactions.go
@@ -534,8 +534,10 @@ type InteractionResponseData struct {
 	Components      []MessageComponent      `json:"components"`
 	Embeds          []*MessageEmbed         `json:"embeds"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
-	Flags           uint64                  `json:"flags,omitempty"`
 	Files           []*File                 `json:"-"`
+
+	// NOTE: only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set
+	Flags MessageFlags `json:"flags,omitempty"`
 
 	// NOTE: autocomplete interaction only.
 	Choices []*ApplicationCommandOptionChoice `json:"choices,omitempty"`

--- a/interactions.go
+++ b/interactions.go
@@ -536,7 +536,7 @@ type InteractionResponseData struct {
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Files           []*File                 `json:"-"`
 
-	// NOTE: only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set
+	// NOTE: only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set.
 	Flags MessageFlags `json:"flags,omitempty"`
 
 	// NOTE: autocomplete interaction only.

--- a/webhook.go
+++ b/webhook.go
@@ -35,8 +35,8 @@ type WebhookParams struct {
 	Components      []MessageComponent      `json:"components"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
-	// NOTE: Works only for followup messages.
-	Flags uint64 `json:"flags,omitempty"`
+	// NOTE: Works only for followup messages and only MessageFlagsSuppressEmbeds can be set
+	Flags MessageFlags `json:"flags,omitempty"`
 }
 
 // WebhookEdit stores data for editing of a webhook message.

--- a/webhook.go
+++ b/webhook.go
@@ -35,7 +35,8 @@ type WebhookParams struct {
 	Components      []MessageComponent      `json:"components"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
-	// NOTE: Works only for followup messages and only MessageFlagsSuppressEmbeds can be set
+	// Only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set.
+	// MessageFlagsEphemeral can only be set when using Followup Message Create endpoint.
 	Flags MessageFlags `json:"flags,omitempty"`
 }
 


### PR DESCRIPTION
According to the Discord documentation, the values for `InteractionResponseData.Flags` and `WebhookParams.Flags` are just a subset of the standard `MessageFlags`:

https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages
https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params
https://discord.com/developers/docs/resources/channel#message-object-message-flags

So use that type instead and put a note indicating the valid subset of flags for each of them. 

This is a breaking change, as the type is changing, so any code that is setting those flags will need to change to use the `MessageFlags` values instead, as it was done in the examples.