### PR TITLE
Add `Dialer` property to `Session`

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"runtime"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 // VERSION of DiscordGo, follows Semantic Versioning. (http://semver.org/)
@@ -41,6 +43,7 @@ func New(token string) (s *Session, err error) {
 		ShardCount:             1,
 		MaxRestRetries:         3,
 		Client:                 &http.Client{Timeout: (20 * time.Second)},
+		Dialer:                 websocket.DefaultDialer,
 		UserAgent:              "DiscordBot (https://github.com/bwmarrin/discordgo, v" + VERSION + ")",
 		sequence:               new(int64),
 		LastHeartbeatAck:       time.Now().UTC(),

--- a/structs.go
+++ b/structs.go
@@ -95,6 +95,9 @@ type Session struct {
 	// The http client used for REST requests
 	Client *http.Client
 
+	// The dialer used for WebSocket connection
+	Dialer *websocket.Dialer
+
 	// The user agent used for REST APIs
 	UserAgent string
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -77,7 +77,7 @@ func (s *Session) Open() error {
 	s.log(LogInformational, "connecting to gateway %s", s.gateway)
 	header := http.Header{}
 	header.Add("accept-encoding", "zlib")
-	s.wsConn, _, err = websocket.DefaultDialer.Dial(s.gateway, header)
+	s.wsConn, _, err = s.Dialer.Dial(s.gateway, header)
 	if err != nil {
 		s.log(LogError, "error connecting to gateway %s, %s", s.gateway, err)
 		s.gateway = "" // clear cached gateway


### PR DESCRIPTION
A little attempt to make this pull request.
Why would I need such an update? For example, if I would be able to pass custom `Dialer`, then I could use proxy ([click](https://stackoverflow.com/questions/33585587/creating-a-go-socks5-client)).
```go
dialSocksProxy, _:= proxy.SOCKS5("tcp", "proxy_ip", nil, proxy.Direct)
s, _:= discordgo.New("token")
s.Dialer = &websocket.Dialer{Dial: dialSocksProxy.Dial}
```
Sorry if I'm wrong. I'll be very happy to hear where exactly I made a mistake, if there's one.