### PR TITLE
Remove broken links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See Documentation and Examples below for more detailed information.
 Because of that there may be major changes to library in the future.
 
 The DiscordGo code is fairly well documented at this point and is currently
-the only documentation available.
+the only documentation available. Go reference (below) presents that information in a nice format.
 
 - [![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo) 
 - Hand crafted documentation coming eventually.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DiscordGo
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo) [![Go Report Card](https://goreportcard.com/badge/github.com/bwmarrin/discordgo)](https://goreportcard.com/report/github.com/bwmarrin/discordgo) [![Build Status](https://travis-ci.com/bwmarrin/discordgo.svg?branch=master)](https://travis-ci.com/bwmarrin/discordgo) [![Discord Gophers](https://img.shields.io/badge/Discord%20Gophers-%23discordgo-blue.svg)](https://discord.gg/golang) [![Discord API](https://img.shields.io/badge/Discord%20API-%23go_discordgo-blue.svg)](https://discord.com/invite/discord-api)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo) [![Go Report Card](https://goreportcard.com/badge/github.com/bwmarrin/discordgo)](https://goreportcard.com/report/github.com/bwmarrin/discordgo) [![CI](https://github.com/bwmarrin/discordgo/actions/workflows/ci.yml/badge.svg)](https://github.com/bwmarrin/discordgo/actions/workflows/ci.yml) [![Discord Gophers](https://img.shields.io/badge/Discord%20Gophers-%23discordgo-blue.svg)](https://discord.gg/golang) [![Discord API](https://img.shields.io/badge/Discord%20API-%23go_discordgo-blue.svg)](https://discord.com/invite/discord-api)
 
 <img align="right" alt="DiscordGo logo" src="docs/img/discordgo.svg" width="400">
 
@@ -61,11 +61,9 @@ See Documentation and Examples below for more detailed information.
 Because of that there may be major changes to library in the future.
 
 The DiscordGo code is fairly well documented at this point and is currently
-the only documentation available.  Both GoDoc and GoWalker (below) present
-that information in a nice format.
+the only documentation available.
 
-- [![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo)
-- [![Go Walker](https://gowalker.org/api/v1/badge)](https://gowalker.org/github.com/bwmarrin/discordgo) 
+- [![Go Reference](https://pkg.go.dev/badge/github.com/bwmarrin/discordgo.svg)](https://pkg.go.dev/github.com/bwmarrin/discordgo) 
 - Hand crafted documentation coming eventually.
 
 


### PR DESCRIPTION
1. Remove the Travis Badge as that pipeline doesn't exist anymore, replace it with the Github Actions CI workflow badge
2.  Remove the Go Walker link, Go Walker doesn't seem to work anymore