### PR TITLE
Integrate handling of interactions via outgoing webhooks

### DIFF
--- a/events.go
+++ b/events.go
@@ -381,6 +381,7 @@ type WebhooksUpdate struct {
 // InteractionCreate is the data for a InteractionCreate event
 type InteractionCreate struct {
 	*Interaction
+	Respond func(response *InteractionResponse) error `json:"-"`
 }
 
 // UnmarshalJSON is a helper function to unmarshal Interaction object.

--- a/examples/http_interactions/main.go
+++ b/examples/http_interactions/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+var (
+	GuildID   = flag.String("guild", "", "Test guild ID. If not passed - bot registers commands globally")
+	AppID     = flag.String("app", "", "Discord app ID")
+	BotToken  = flag.String("token", "", "Bot access token")
+	PublicKey = flag.String("publickey", "", "Public key for verifying requests")
+)
+
+func init() { flag.Parse() }
+
+func main() {
+	s, err := discordgo.New("Bot " + *BotToken)
+	if err != nil {
+		log.Fatalf("Invalid bot parameters: %v", err)
+	}
+
+	hexDecodedKey, err := hex.DecodeString(*PublicKey)
+	if err != nil {
+		log.Fatal("Invalid public key: ", err)
+	}
+	s.PublicKey = hexDecodedKey
+
+	if _, err = s.ApplicationCommandBulkOverwrite(*AppID, *GuildID, []*discordgo.ApplicationCommand{
+		{
+			Name:        "ping",
+			Description: "Ping command",
+		},
+	}); err != nil {
+		log.Fatalf("Failed to register commands: %v", err)
+	}
+
+	s.AddHandler(handleInteraction)
+
+	http.Handle("/", s)
+
+	if err = http.ListenAndServe(":5678", nil); err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}
+
+func handleInteraction(s *discordgo.Session, e *discordgo.InteractionCreate) {
+	if e.Type != discordgo.InteractionApplicationCommand {
+		return
+	}
+	data := e.ApplicationCommandData()
+
+	switch data.Name {
+	case "ping":
+		if err := e.Respond(&discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "pong",
+			},
+		}); err != nil {
+			log.Print("Failed to respond to interaction: ", err)
+		}
+	}
+}

--- a/http.go
+++ b/http.go
@@ -1,0 +1,113 @@
+package discordgo
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var (
+	ErrInteractionExpired          = errors.New("interaction expired")
+	ErrInteractionAlreadyRepliedTo = errors.New("interaction was already replied to")
+)
+
+type replyStatus int
+
+const (
+	replyStatusReplied replyStatus = iota + 1
+	replyStatusTimedOut
+)
+
+func (s *Session) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !VerifyInteraction(r, s.PublicKey) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	var i *InteractionCreate
+
+	if err := json.NewDecoder(r.Body).Decode(&i); err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+	}
+
+	// we can always respond to ping with pong
+	if i.Type == InteractionPing {
+		s.log(LogDebug, "received http ping")
+		if err := json.NewEncoder(w).Encode(InteractionResponse{
+			Type: InteractionResponsePong,
+		}); err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	responseChannel := make(chan *InteractionResponse)
+	defer close(responseChannel)
+	errorChannel := make(chan error)
+	defer close(errorChannel)
+
+	var (
+		status replyStatus
+		mu     sync.Mutex
+	)
+
+	i.Respond = func(response *InteractionResponse) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if status == replyStatusTimedOut {
+			return ErrInteractionExpired
+		}
+
+		if status == replyStatusReplied {
+			return ErrInteractionAlreadyRepliedTo
+		}
+
+		status = replyStatusReplied
+		responseChannel <- response
+		return <-errorChannel
+	}
+
+	go s.handleEvent(interactionCreateEventType, i)
+
+	var (
+		body        []byte
+		contentType string
+		err         error
+	)
+
+	// interactions can be replied to within 3 seconds, wait 4 to be safe
+	timer := time.NewTimer(time.Second * 4)
+	defer timer.Stop()
+	select {
+	case resp := <-responseChannel:
+		if resp.Data != nil && len(resp.Data.Files) > 0 {
+			contentType, body, err = MultipartBodyWithJSON(resp, resp.Data.Files)
+		} else {
+			contentType = "application/json"
+			body, err = json.Marshal(*resp)
+		}
+		if err != nil {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			errorChannel <- err
+			return
+		}
+
+	case <-timer.C:
+		mu.Lock()
+		defer mu.Unlock()
+		status = replyStatusTimedOut
+
+		s.log(LogWarning, "interaction timed out")
+
+		http.Error(w, "interaction timed out", http.StatusRequestTimeout)
+		return
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	if _, err = w.Write(body); err != nil {
+		errorChannel <- err
+	}
+}

--- a/http.go
+++ b/http.go
@@ -9,7 +9,10 @@ import (
 )
 
 var (
-	ErrInteractionExpired          = errors.New("interaction expired")
+	// ErrInteractionExpired is returned when you try to reply to an interaction after 3s
+	ErrInteractionExpired = errors.New("interaction expired")
+
+	// ErrInteractionAlreadyRepliedTo is returned when you try to reply to an interaction multiple times
 	ErrInteractionAlreadyRepliedTo = errors.New("interaction was already replied to")
 )
 
@@ -20,6 +23,7 @@ const (
 	replyStatusTimedOut
 )
 
+// ServeHTTP handles the heavy lifting of parsing the interaction request and sending the response
 func (s *Session) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !VerifyInteraction(r, s.PublicKey) {
 		http.Error(w, "Forbidden", http.StatusForbidden)

--- a/structs.go
+++ b/structs.go
@@ -12,6 +12,7 @@
 package discordgo
 
 import (
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -129,6 +130,8 @@ type Session struct {
 
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
+
+	PublicKey ed25519.PublicKey
 }
 
 // Application stores values for a Discord Application


### PR DESCRIPTION
This pr adds a lightweight hopefully flexible enough implementation of handling interactions via outgoing webhooks

discord docs: https://discord.com/developers/docs/interactions/receiving-and-responding#receiving-an-interaction

how it works:
- `discordgo.Session` implements the `http.Handler` interface(like this you can choose whatever webserver you want)
- `session.ServeHTTP` verifies if the interaction comes from discord
- fires a normal interaction create event with an extra `Respond` field which holds a function which can be used to the http request discord sent
- timeout(not responding within 3s) is handled by discordgo(logs at warning level)
- multiple calls to respond return an error

todo:
- useful docs

if you have any thoughts about this implementation let me know!