### PR TITLE
Fix build error of examples/voice_receive

### DIFF
--- a/examples/voice_receive/main.go
+++ b/examples/voice_receive/main.go
@@ -75,7 +75,7 @@ func main() {
 	defer s.Close()
 
 	// We only really care about receiving voice state updates.
-	s.Identify.Intents = discordgo.IntentsGuildVoiceStates
+	s.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuildVoiceStates)
 
 	err = s.Open()
 	if err != nil {


### PR DESCRIPTION
examples/voice_receive cannot be built.
MakeIntent did not have been used to initialize Intents.

```
./discordgo/examples/voice_receive
$ go build  
# github.com/bwmarrin/discordgo/examples/voice_receive
./main.go:78:21: cannot use discordgo.IntentsGuildVoiceStates (type discordgo.Intent) as type *discordgo.Intent in assignment
```