### PR TITLE
Fix GuildTemplate struct and documentation

### DIFF
--- a/.fleet/settings.json
+++ b/.fleet/settings.json
@@ -1,0 +1,5 @@
+{
+    "go.root": "/usr/lib/go",
+    "go.path": "/home/qpixel/go",
+    "go.modules": "true",
+}

--- a/.fleet/settings.json
+++ b/.fleet/settings.json
@@ -1,5 +1,0 @@
-{
-    "go.root": "/usr/lib/go",
-    "go.path": "/home/qpixel/go",
-    "go.modules": "true",
-}

--- a/structs.go
+++ b/structs.go
@@ -952,7 +952,7 @@ type GuildTemplate struct {
 	Code string `json:"code"`
 
 	// The name of the template
-	Name *string `json:"name,omitempty"`
+	Name  `json:"name,omitempty"`
 
 	// The description for the template
 	Description *string `json:"description,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -952,7 +952,7 @@ type GuildTemplate struct {
 	Code string `json:"code"`
 
 	// The name of the template
-	Name  `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 
 	// The description for the template
 	Description *string `json:"description,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -952,10 +952,10 @@ type GuildTemplate struct {
 	Code string `json:"code"`
 
 	// The name of the template
-	Name string `json:"name"`
+	Name *string `json:"name,omitempty"`
 
 	// The description for the template
-	Description string `json:"description"`
+	Description *string `json:"description,omitempty"`
 
 	// The number of times this template has been used
 	UsageCount int `json:"usage_count"`

--- a/structs.go
+++ b/structs.go
@@ -955,7 +955,7 @@ type GuildTemplate struct {
 	Name string `json:"name"`
 
 	// The description for the template
-	Description *string `json:"description"`
+	Description string `json:"description"`
 
 	// The number of times this template has been used
 	UsageCount int `json:"usage_count"`

--- a/structs.go
+++ b/structs.go
@@ -946,7 +946,7 @@ type GuildScheduledEventUser struct {
 	Member                *Member `json:"member"`
 }
 
-// A GuildTemplate represents
+// A GuildTemplate represents a replicable template for guild creation
 type GuildTemplate struct {
 	// The unique code for the guild template
 	Code string `json:"code"`
@@ -955,10 +955,10 @@ type GuildTemplate struct {
 	Name string `json:"name"`
 
 	// The description for the template
-	Description string `json:"description"`
+	Description *string `json:"description"`
 
 	// The number of times this template has been used
-	UsageCount string `json:"usage_count"`
+	UsageCount int `json:"usage_count"`
 
 	// The ID of the user who created the template
 	CreatorID string `json:"creator_id"`


### PR DESCRIPTION
This is a fix to PR https://github.com/bwmarrin/discordgo/pull/1091. It seems that the ``UsageCount`` field was incorrectly set to a string instead of a int. This PR has been made to fix this. I've tested this fix on my own machine.

Relevant Documentation: https://discord.com/developers/docs/resources/guild-template