### PR TITLE
Allow setting bool fields of `ChannelEdit` to false

### DIFF
--- a/examples/threads/main.go
+++ b/examples/threads/main.go
@@ -48,9 +48,11 @@ func main() {
 			games[m.ChannelID] = time.Now()
 			<-time.After(timeout)
 			if time.Since(games[m.ChannelID]) >= timeout {
+				archived := true
+				locked := true
 				_, err := s.ChannelEditComplex(m.ChannelID, &discordgo.ChannelEdit{
-					Archived: true,
-					Locked:   true,
+					Archived: &archived,
+					Locked:   &locked,
 				})
 				if err != nil {
 					panic(err)

--- a/structs.go
+++ b/structs.go
@@ -360,7 +360,7 @@ func (c *Channel) IsThread() bool {
 type ChannelEdit struct {
 	Name                 string                 `json:"name,omitempty"`
 	Topic                string                 `json:"topic,omitempty"`
-	NSFW                 bool                   `json:"nsfw,omitempty"`
+	NSFW                 *bool                  `json:"nsfw,omitempty"`
 	Position             int                    `json:"position"`
 	Bitrate              int                    `json:"bitrate,omitempty"`
 	UserLimit            int                    `json:"user_limit,omitempty"`
@@ -370,10 +370,10 @@ type ChannelEdit struct {
 
 	// NOTE: threads only
 
-	Archived            bool `json:"archived,omitempty"`
-	AutoArchiveDuration int  `json:"auto_archive_duration,omitempty"`
-	Locked              bool `json:"locked,bool"`
-	Invitable           bool `json:"invitable,omitempty"`
+	Archived            *bool `json:"archived,omitempty"`
+	AutoArchiveDuration int   `json:"auto_archive_duration,omitempty"`
+	Locked              *bool `json:"locked,omitempty"`
+	Invitable           *bool `json:"invitable,omitempty"`
 }
 
 // A ChannelFollow holds data returned after following a news channel


### PR DESCRIPTION
Setting e.g. `ChannelEdit.Archived = false` is currently not possible as Go will treat a `false` value as empty and will omit the `archived` property from the resulting JSON object. The same goes for `Locked`, `NSFW` and `Invitable`.