### PR TITLE
Fix slash commands example

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -17,6 +17,7 @@ import (
 var (
 	GuildID        = flag.String("guild", "", "Test guild ID. If not passed - bot registers commands globally")
 	BotToken       = flag.String("token", "", "Bot access token")
+	AppID          = flag.String("app", "", "Application ID")
 	RemoveCommands = flag.Bool("rmcmd", true, "Remove all commands after shutdowning or not")
 )
 
@@ -556,7 +557,7 @@ func main() {
 	log.Println("Adding commands...")
 	registeredCommands := make([]*discordgo.ApplicationCommand, len(commands))
 	for i, v := range commands {
-		cmd, err := s.ApplicationCommandCreate(s.State.User.ID, *GuildID, v)
+		cmd, err := s.ApplicationCommandCreate(*AppID, *GuildID, v)
 		if err != nil {
 			log.Panicf("Cannot create '%v' command: %v", v.Name, err)
 		}
@@ -576,13 +577,13 @@ func main() {
 		// // We are doing this from the returned commands on line 375, because using
 		// // this will delete all the commands, which might not be desirable, so we
 		// // are deleting only the commands that we added.
-		// registeredCommands, err := s.ApplicationCommands(s.State.User.ID, *GuildID)
+		// registeredCommands, err := s.ApplicationCommands(*AppID, *GuildID)
 		// if err != nil {
 		// 	log.Fatalf("Could not fetch registered commands: %v", err)
 		// }
 
 		for _, v := range registeredCommands {
-			err := s.ApplicationCommandDelete(s.State.User.ID, *GuildID, v.ID)
+			err := s.ApplicationCommandDelete(*AppID, *GuildID, v.ID)
 			if err != nil {
 				log.Panicf("Cannot delete '%v' command: %v", v.Name, err)
 			}


### PR DESCRIPTION
Add Application ID command flag to use it to create and delete
application commands.

[`Session.ApplicationCommandCreate()`](https://github.com/bwmarrin/discordgo/blob/a7f037862343f3ed29da9543b9ea4f8c57810620/restapi.go#L2717) and [`Session.ApplicationCommandDelete()`](https://github.com/bwmarrin/discordgo/blob/a7f037862343f3ed29da9543b9ea4f8c57810620/restapi.go#L2777) requires Application ID as a first
argument instead of a Bot's user ID