### PR TITLE
Add GuildID field to ApplicationCommand

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -33,6 +33,7 @@ const (
 type ApplicationCommand struct {
 	ID                string                 `json:"id,omitempty"`
 	ApplicationID     string                 `json:"application_id,omitempty"`
+	GuildID           string                 `json:"guild_id,omitempty"`
 	Version           string                 `json:"version,omitempty"`
 	Type              ApplicationCommandType `json:"type,omitempty"`
 	Name              string                 `json:"name"`


### PR DESCRIPTION
Add missing `guild_id` to `ApplicationCommand` structure. [Documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure)
