### PR TITLE
Application command options: min and max length

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -118,6 +118,10 @@ type ApplicationCommandOption struct {
 	MinValue *float64 `json:"min_value,omitempty"`
 	// Maximum value of number/integer option.
 	MaxValue float64 `json:"max_value,omitempty"`
+	// Minimum length of string option.
+	MinLength *int `json:"min_length,omitempty"`
+	// Maximum length of string option.
+	MaxLength int `json:"max_length,omitempty"`
 }
 
 // ApplicationCommandOptionChoice represents a slash command option choice.


### PR DESCRIPTION
Implement newly added `min_length` and `max_length` fields for string option type.

### Useful links
- [Documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
- [Changelog](https://discord.com/developers/docs/change-log#min-and-max-length-for-command-options)
- https://github.com/discord/discord-api-docs/pull/5143