### PR TITLE
fix typo in InviteTargetEmbeddedApplication

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -46,7 +46,7 @@ func New(token string) (s *Session, err error) {
 		LastHeartbeatAck:       time.Now().UTC(),
 	}
 
-	// Initilize the Identify Package with defaults
+	// Initialize the Identify Package with defaults
 	// These can be modified prior to calling Open()
 	s.Identify.Compress = true
 	s.Identify.LargeThreshold = 250

--- a/logging.go
+++ b/logging.go
@@ -90,7 +90,7 @@ func (v *VoiceConnection) log(msgL int, format string, a ...interface{}) {
 	msglog(msgL, 2, format, a...)
 }
 
-// printJSON is a helper function to display JSON data in a easy to read format.
+// printJSON is a helper function to display JSON data in an easy to read format.
 /* NOT USED ATM
 func printJSON(body []byte) {
 	var prettyJSON bytes.Buffer

--- a/state.go
+++ b/state.go
@@ -7,7 +7,7 @@
 
 // This file contains code related to state tracking.  If enabled, state
 // tracking will capture the initial READY packet and many other websocket
-// events and maintain an in-memory state of of guilds, channels, users, and
+// events and maintain an in-memory state of guilds, channels, users, and
 // so forth.  This information can be accessed through the Session.State struct.
 
 package discordgo

--- a/structs.go
+++ b/structs.go
@@ -59,12 +59,12 @@ type Session struct {
 	ShardCount int
 
 	// Should state tracking be enabled.
-	// State tracking is the best way for getting the the users
+	// State tracking is the best way for getting the users
 	// active guilds and the members of the guilds.
 	StateEnabled bool
 
 	// Whether or not to call event handlers synchronously.
-	// e.g false = launch event handlers in their own goroutines.
+	// e.g. false = launch event handlers in their own goroutines.
 	SyncEvents bool
 
 	// Exposed but should not be modified by User.
@@ -75,7 +75,7 @@ type Session struct {
 	// Max number of REST API retries
 	MaxRestRetries int
 
-	// Status stores the currect status of the websocket connection
+	// Status stores the current status of the websocket connection
 	// this is being tested, may stay, may go away.
 	status int32
 
@@ -222,8 +222,8 @@ type InviteTargetType uint8
 
 // Invite target types
 const (
-	InviteTargetStream             InviteTargetType = 1
-	InviteTargetEmbeddedAppliction InviteTargetType = 2
+	InviteTargetStream              InviteTargetType = 1
+	InviteTargetEmbeddedApplication InviteTargetType = 2
 )
 
 // A Invite stores all data related to a specific Discord Guild or Channel invite.


### PR DESCRIPTION
This fixes the name of `InviteTargetEmbeddedApplication` (previously `InviteTargetEmbeddedAppliction`)

as well as some minor changes to random mistyped comments.