### PR TITLE
REST methods cleanup

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -1045,29 +1045,16 @@ func (s *Session) GuildRoleCreate(guildID string) (st *Role, err error) {
 	return
 }
 
-// GuildRoleEdit updates an existing Guild Role with new values
+// GuildRoleEdit updates an existing Guild Role and updated Role data.
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
-// name      : The name of the Role.
-// color     : The color of the role (decimal, not hex).
-// hoist     : Whether to display the role's users separately.
-// perm      : The permissions for the role.
-// mention   : Whether this role is mentionable
-func (s *Session) GuildRoleEdit(guildID, roleID, name string, color int, hoist bool, perm int64, mention bool) (st *Role, err error) {
+// data 		 : Updated Role data.
+func (s *Session) GuildRoleEdit(guildID, roleID string, data *RoleParams) (st *Role, err error) {
 
 	// Prevent sending a color int that is too big.
-	if color > 0xFFFFFF {
-		err = fmt.Errorf("color value cannot be larger than 0xFFFFFF")
-		return nil, err
+	if data.Color != nil && *data.Color > 0xFFFFFF {
+		return nil, fmt.Errorf("color value cannot be larger than 0xFFFFFF")
 	}
-
-	data := struct {
-		Name        string `json:"name"`               // The role's name (overwrites existing)
-		Color       int    `json:"color"`              // The color the role should have (as a decimal, not hex)
-		Hoist       bool   `json:"hoist"`              // Whether to display the role's users separately
-		Permissions int64  `json:"permissions,string"` // The overall permissions number of the role (overwrites existing)
-		Mentionable bool   `json:"mentionable"`        // Whether this role is mentionable
-	}{name, color, hoist, perm, mention}
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRole(guildID, roleID), data, EndpointGuildRole(guildID, ""))
 	if err != nil {

--- a/restapi.go
+++ b/restapi.go
@@ -1534,6 +1534,7 @@ func (s *Session) ChannelEdit(channelID string, data *ChannelEdit) (st *Channel,
 }
 
 // ChannelEditComplex edits an existing channel, replacing the parameters entirely with ChannelEdit struct
+// NOTE: deprecated, use ChannelEdit instead
 // channelID     : The ID of a Channel
 // data          : The channel struct to send
 func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit) (st *Channel, err error) {

--- a/restapi.go
+++ b/restapi.go
@@ -1273,12 +1273,10 @@ func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
 	return
 }
 
-// GuildEmbedEdit returns the embed for a Guild.
+// GuildEmbedEdit edits the embed of a Guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildEmbedEdit(guildID string, enabled bool, channelID string) (err error) {
-
-	data := GuildEmbed{enabled, channelID}
-
+// data      : New embed data.
+func (s *Session) GuildEmbedEdit(guildID string, data *GuildEmbed) (err error) {
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildEmbed(guildID), data, EndpointGuildEmbed(guildID))
 	return
 }

--- a/restapi.go
+++ b/restapi.go
@@ -1410,16 +1410,9 @@ func (s *Session) GuildTemplates(guildID string) (st []*GuildTemplate, err error
 }
 
 // GuildTemplateCreate creates a template for the guild
-// guildID: The ID of the guild
-// name: The name of the template (1-100 characters)
-// description: The description for the template (0-120 characters)
-func (s *Session) GuildTemplateCreate(guildID, name, description string) (st *GuildTemplate) {
-
-	data := struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-	}{name, description}
-
+// guildID : The ID of the guild
+// data    : Template metadata
+func (s *Session) GuildTemplateCreate(guildID string, data GuildTemplateParams) (st *GuildTemplate) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildTemplates(guildID), data, EndpointGuildTemplates(guildID))
 	if err != nil {
 		return

--- a/restapi.go
+++ b/restapi.go
@@ -763,7 +763,7 @@ func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
 //  guildID       : The ID of a Guild.
 //  userID        : The ID of a User.
 //  data          : Parameters of the user to add.
-func (s *Session) GuildMemberAdd(guildID, userID string, data GuildMemberAddParams) (err error) {
+func (s *Session) GuildMemberAdd(guildID, userID string, data *GuildMemberAddParams) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	if err != nil {
@@ -800,7 +800,7 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : Updated GuildMember data.
-func (s *Session) GuildMemberEdit(guildID, userID string, data GuildMemberParams) (st *Member, err error) {
+func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberParams) (st *Member, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	if err != nil {
@@ -816,7 +816,7 @@ func (s *Session) GuildMemberEdit(guildID, userID string, data GuildMemberParams
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : A GuildMemberEditData struct with the new nickname and roles
-func (s *Session) GuildMemberEditComplex(guildID, userID string, data GuildMemberParams) (st *Member, err error) {
+func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemberParams) (st *Member, err error) {
 	return s.GuildMemberEdit(guildID, userID, data)
 }
 
@@ -1330,7 +1330,7 @@ func (s *Session) GuildEmoji(guildID, emojiID string) (emoji *Emoji, err error) 
 // GuildEmojiCreate creates a new Emoji.
 // guildID : The ID of a Guild.
 // data    : New Emoji data.
-func (s *Session) GuildEmojiCreate(guildID string, data EmojiParams) (emoji *Emoji, err error) {
+func (s *Session) GuildEmojiCreate(guildID string, data *EmojiParams) (emoji *Emoji, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildEmojis(guildID), data, EndpointGuildEmojis(guildID))
 	if err != nil {
 		return
@@ -1344,7 +1344,7 @@ func (s *Session) GuildEmojiCreate(guildID string, data EmojiParams) (emoji *Emo
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
 // data    : Updated emoji data.
-func (s *Session) GuildEmojiEdit(guildID, emojiID string, data EmojiParams) (emoji *Emoji, err error) {
+func (s *Session) GuildEmojiEdit(guildID, emojiID string, data *EmojiParams) (emoji *Emoji, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildEmoji(guildID, emojiID), data, EndpointGuildEmojis(guildID))
 	if err != nil {
 		return
@@ -1412,7 +1412,7 @@ func (s *Session) GuildTemplates(guildID string) (st []*GuildTemplate, err error
 // GuildTemplateCreate creates a template for the guild
 // guildID : The ID of the guild
 // data    : Template metadata
-func (s *Session) GuildTemplateCreate(guildID string, data GuildTemplateParams) (st *GuildTemplate) {
+func (s *Session) GuildTemplateCreate(guildID string, data *GuildTemplateParams) (st *GuildTemplate) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildTemplates(guildID), data, EndpointGuildTemplates(guildID))
 	if err != nil {
 		return
@@ -1435,7 +1435,7 @@ func (s *Session) GuildTemplateSync(guildID, templateCode string) (err error) {
 // guildID      : The ID of the guild
 // templateCode : The code of the template
 // data         : New template metadata
-func (s *Session) GuildTemplateEdit(guildID, templateCode string, data GuildTemplateParams) (st *GuildTemplate, err error) {
+func (s *Session) GuildTemplateEdit(guildID, templateCode string, data *GuildTemplateParams) (st *GuildTemplate, err error) {
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildTemplateSync(guildID, templateCode), data, EndpointGuildTemplateSync(guildID, ""))
 	if err != nil {

--- a/restapi.go
+++ b/restapi.go
@@ -1031,11 +1031,11 @@ func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
 	return // TODO return pointer
 }
 
-// GuildRoleCreate returns a new Guild Role.
-// guildID: The ID of a Guild.
-func (s *Session) GuildRoleCreate(guildID string) (st *Role, err error) {
-
-	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID))
+// GuildRoleCreate creates a new Guild Role and returns it.
+// guildID : The ID of a Guild.
+// data    : New role parameters.
+func (s *Session) GuildRoleCreate(guildID string, data *RoleParams) (st *Role, err error) {
+	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), data, EndpointGuildRoles(guildID))
 	if err != nil {
 		return
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -1352,18 +1352,11 @@ func (s *Session) GuildEmojiCreate(guildID string, data EmojiParams) (emoji *Emo
 	return
 }
 
-// GuildEmojiEdit modifies an emoji
+// GuildEmojiEdit modifies and returns updated emoji.
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
-// name    : The Name of the Emoji.
-// roles   : The roles for which this emoji will be whitelisted, if nil or empty the roles will be reset.
-func (s *Session) GuildEmojiEdit(guildID, emojiID, name string, roles []string) (emoji *Emoji, err error) {
-
-	data := struct {
-		Name  string   `json:"name"`
-		Roles []string `json:"roles"`
-	}{name, roles}
-
+// data    : Updated emoji data.
+func (s *Session) GuildEmojiEdit(guildID, emojiID string, data EmojiParams) (emoji *Emoji, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildEmoji(guildID, emojiID), data, EndpointGuildEmojis(guildID))
 	if err != nil {
 		return

--- a/restapi.go
+++ b/restapi.go
@@ -808,25 +808,11 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 	return
 }
 
-// GuildMemberEdit edits the roles of a member.
+// GuildMemberEdit edits and returns updated member.
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
-// roles    : A list of role ID's to set on the member.
-func (s *Session) GuildMemberEdit(guildID, userID string, roles []string) (err error) {
-
-	data := struct {
-		Roles []string `json:"roles"`
-	}{roles}
-
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
-	return
-}
-
-// GuildMemberEditComplex edits the nickname and roles of a member.
-// guildID  : The ID of a Guild.
-// userID   : The ID of a User.
-// data     : A GuildMemberEditData struct with the new nickname and roles
-func (s *Session) GuildMemberEditComplex(guildID, userID string, data GuildMemberParams) (st *Member, err error) {
+// data     : Updated GuildMember data.
+func (s *Session) GuildMemberEdit(guildID, userID string, data GuildMemberParams) (st *Member, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	if err != nil {
@@ -835,6 +821,14 @@ func (s *Session) GuildMemberEditComplex(guildID, userID string, data GuildMembe
 
 	err = unmarshal(body, &st)
 	return
+}
+
+// GuildMemberEditComplex edits the nickname and roles of a member.
+// guildID  : The ID of a Guild.
+// userID   : The ID of a User.
+// data     : A GuildMemberEditData struct with the new nickname and roles
+func (s *Session) GuildMemberEditComplex(guildID, userID string, data GuildMemberParams) (st *Member, err error) {
+	return s.GuildMemberEdit(guildID, userID, data)
 }
 
 // GuildMemberMove moves a guild member from one voice channel to another/none

--- a/restapi.go
+++ b/restapi.go
@@ -1439,16 +1439,10 @@ func (s *Session) GuildTemplateSync(guildID, templateCode string) (err error) {
 }
 
 // GuildTemplateEdit modifies the template's metadata
-// guildID: The ID of the guild
-// templateCode: The code of the template
-// name: The name of the template (1-100 characters)
-// description: The description for the template (0-120 characters)
-func (s *Session) GuildTemplateEdit(guildID, templateCode, name, description string) (st *GuildTemplate, err error) {
-
-	data := struct {
-		Name        string `json:"name,omitempty"`
-		Description string `json:"description,omitempty"`
-	}{name, description}
+// guildID      : The ID of the guild
+// templateCode : The code of the template
+// data         : New template metadata
+func (s *Session) GuildTemplateEdit(guildID, templateCode string, data GuildTemplateParams) (st *GuildTemplate, err error) {
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildTemplateSync(guildID, templateCode), data, EndpointGuildTemplateSync(guildID, ""))
 	if err != nil {

--- a/restapi.go
+++ b/restapi.go
@@ -1016,7 +1016,7 @@ func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
 
 // GuildRoleCreate creates a new Guild Role and returns it.
 // guildID : The ID of a Guild.
-// data    : New role parameters.
+// data    : New Role parameters.
 func (s *Session) GuildRoleCreate(guildID string, data *RoleParams) (st *Role, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), data, EndpointGuildRoles(guildID))
 	if err != nil {
@@ -1028,7 +1028,7 @@ func (s *Session) GuildRoleCreate(guildID string, data *RoleParams) (st *Role, e
 	return
 }
 
-// GuildRoleEdit updates an existing Guild Role and updated Role data.
+// GuildRoleEdit updates an existing Guild Role and returns updated Role data.
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
 // data 		 : Updated Role data.
@@ -1258,7 +1258,7 @@ func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
 
 // GuildEmbedEdit edits the embed of a Guild.
 // guildID   : The ID of a Guild.
-// data      : New embed data.
+// data      : New GuildEmbed data.
 func (s *Session) GuildEmbedEdit(guildID string, data *GuildEmbed) (err error) {
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildEmbed(guildID), data, EndpointGuildEmbed(guildID))
 	return
@@ -1340,10 +1340,10 @@ func (s *Session) GuildEmojiCreate(guildID string, data *EmojiParams) (emoji *Em
 	return
 }
 
-// GuildEmojiEdit modifies and returns updated emoji.
+// GuildEmojiEdit modifies and returns updated Emoji.
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
-// data    : Updated emoji data.
+// data    : Updated Emoji data.
 func (s *Session) GuildEmojiEdit(guildID, emojiID string, data *EmojiParams) (emoji *Emoji, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildEmoji(guildID, emojiID), data, EndpointGuildEmojis(guildID))
 	if err != nil {

--- a/restapi.go
+++ b/restapi.go
@@ -824,6 +824,7 @@ func (s *Session) GuildMemberEdit(guildID, userID string, data GuildMemberParams
 }
 
 // GuildMemberEditComplex edits the nickname and roles of a member.
+// NOTE: deprecated, use GuildMemberEdit instead.
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : A GuildMemberEditData struct with the new nickname and roles

--- a/restapi.go
+++ b/restapi.go
@@ -1519,19 +1519,10 @@ func (s *Session) Channel(channelID string) (st *Channel, err error) {
 	return
 }
 
-// ChannelEdit edits the given channel
-// channelID  : The ID of a Channel
-// name       : The new name to assign the channel.
-func (s *Session) ChannelEdit(channelID, name string) (*Channel, error) {
-	return s.ChannelEditComplex(channelID, &ChannelEdit{
-		Name: name,
-	})
-}
-
-// ChannelEditComplex edits an existing channel, replacing the parameters entirely with ChannelEdit struct
-// channelID  : The ID of a Channel
-// data          : The channel struct to send
-func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit) (st *Channel, err error) {
+// ChannelEdit edits the given channel and returns the updated Channel data.
+// channelID  : The ID of a Channel.
+// data       : New Channel data.
+func (s *Session) ChannelEdit(channelID string, data *ChannelEdit) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointChannel(channelID), data, EndpointChannel(channelID))
 	if err != nil {
 		return
@@ -1539,6 +1530,14 @@ func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit) (st *C
 
 	err = unmarshal(body, &st)
 	return
+
+}
+
+// ChannelEditComplex edits an existing channel, replacing the parameters entirely with ChannelEdit struct
+// channelID     : The ID of a Channel
+// data          : The channel struct to send
+func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit) (st *Channel, err error) {
+	return s.ChannelEdit(channelID, data)
 }
 
 // ChannelDelete deletes the given channel

--- a/restapi.go
+++ b/restapi.go
@@ -1339,19 +1339,10 @@ func (s *Session) GuildEmoji(guildID, emojiID string) (emoji *Emoji, err error) 
 	return
 }
 
-// GuildEmojiCreate creates a new emoji
+// GuildEmojiCreate creates a new Emoji.
 // guildID : The ID of a Guild.
-// name    : The Name of the Emoji.
-// image   : The base64 encoded emoji image, has to be smaller than 256KB.
-// roles   : The roles for which this emoji will be whitelisted, can be nil.
-func (s *Session) GuildEmojiCreate(guildID, name, image string, roles []string) (emoji *Emoji, err error) {
-
-	data := struct {
-		Name  string   `json:"name"`
-		Image string   `json:"image"`
-		Roles []string `json:"roles,omitempty"`
-	}{name, image, roles}
-
+// data    : New Emoji data.
+func (s *Session) GuildEmojiCreate(guildID string, data EmojiParams) (emoji *Emoji, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildEmojis(guildID), data, EndpointGuildEmojis(guildID))
 	if err != nil {
 		return

--- a/restapi.go
+++ b/restapi.go
@@ -760,22 +760,10 @@ func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
 }
 
 // GuildMemberAdd force joins a user to the guild.
-//  accessToken   : Valid access_token for the user.
 //  guildID       : The ID of a Guild.
 //  userID        : The ID of a User.
-//  nick          : Value to set users nickname to
-//  roles         : A list of role ID's to set on the member.
-//  mute          : If the user is muted.
-//  deaf          : If the user is deafened.
-func (s *Session) GuildMemberAdd(accessToken, guildID, userID, nick string, roles []string, mute, deaf bool) (err error) {
-
-	data := struct {
-		AccessToken string   `json:"access_token"`
-		Nick        string   `json:"nick,omitempty"`
-		Roles       []string `json:"roles,omitempty"`
-		Mute        bool     `json:"mute,omitempty"`
-		Deaf        bool     `json:"deaf,omitempty"`
-	}{accessToken, nick, roles, mute, deaf}
+//  data          : Parameters of the user to add.
+func (s *Session) GuildMemberAdd(guildID, userID string, data GuildMemberAddParams) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
 	if err != nil {

--- a/structs.go
+++ b/structs.go
@@ -491,6 +491,17 @@ func (e *Emoji) APIName() string {
 	return e.ID
 }
 
+// EmojiParams represents parameters needed to create or update an Emoji.
+type EmojiParams struct {
+	// Name of the emoji
+	Name string `json:"name,omitempty"`
+	// A base64 encoded emoji image, has to be smaller than 256KB.
+	// NOTE: can be only set on creation.
+	Image string `json:"image,omitempty"`
+	// Roles for which this emoji will be available.
+	Roles []string `json:"roles,omitempty"`
+}
+
 // StickerFormat is the file format of the Sticker.
 type StickerFormat int
 

--- a/structs.go
+++ b/structs.go
@@ -995,6 +995,14 @@ type GuildTemplate struct {
 	IsDirty bool `json:"is_dirty"`
 }
 
+// GuildTemplateParams stores the data needed to create or update a GuildTemplate.
+type GuildTemplateParams struct {
+	// The name of the template (1-100 characters)
+	Name string `json:"name,omitempty"`
+	// The description of the template (0-120 characters)
+	Description string `json:"description,omitempty"`
+}
+
 // MessageNotifications is the notification level for a guild
 // https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
 type MessageNotifications int

--- a/structs.go
+++ b/structs.go
@@ -1407,8 +1407,8 @@ type AutoModerationAction struct {
 
 // A GuildEmbed stores data for a guild embed.
 type GuildEmbed struct {
-	Enabled   bool   `json:"enabled"`
-	ChannelID string `json:"channel_id"`
+	Enabled   *bool  `json:"enabled,omitempty"`
+	ChannelID string `json:"channel_id,omitempty"`
 }
 
 // A GuildAuditLog stores data for a guild audit log.

--- a/structs.go
+++ b/structs.go
@@ -1083,6 +1083,20 @@ func (r *Role) Mention() string {
 	return fmt.Sprintf("<@&%s>", r.ID)
 }
 
+// RoleParams represents the parameters needed to create or update a Role
+type RoleParams struct {
+	// The role's name
+	Name string `json:"name,omitempty"`
+	// The color the role should have (as a decimal, not hex)
+	Color *int `json:"color,omitempty"`
+	// Whether to display the role's users separately
+	Hoist *bool `json:"hoist,omitempty"`
+	// The overall permissions number of the role
+	Permissions *int64 `json:"permissions,omitempty,string"`
+	// Whether this role is mentionable
+	Mentionable *bool `json:"mentionable,omitempty"`
+}
+
 // Roles are a collection of Role
 type Roles []*Role
 

--- a/structs.go
+++ b/structs.go
@@ -1726,6 +1726,21 @@ type GuildMemberParams struct {
 	Roles *[]string `json:"roles,omitempty"`
 }
 
+// GuildMemberAddParams stores data needed to add a user to a guild.
+// NOTE: All fields are optional, except AccessToken.
+type GuildMemberAddParams struct {
+	// Valid access_token for the user.
+	AccessToken string `json:"access_token"`
+	// Value to set users nickname to.
+	Nick string `json:"nick,omitempty"`
+	// A list of role ID's to set on the member.
+	Roles []string `json:"roles,omitempty"`
+	// Whether the user is muted.
+	Mute bool `json:"mute,omitempty"`
+	// Whether the user is deafened.
+	Deaf bool `json:"deaf,omitempty"`
+}
+
 // An APIErrorMessage is an api error message returned from discord
 type APIErrorMessage struct {
 	Code    int    `json:"code"`


### PR DESCRIPTION
We have been thinking on how to improve developer experience with the library and clean up some stuff. 

One of the aspects that came to our attention is REST methods. Currently we don't have a consistent naming and signature style. 

This PR addresses this problem.
It refactors REST methods to use structs where possible and removes some of the unnecessary helper methods.

**This only affects older functions** , functions that came after `v0.24.0` already are following this design.

Here's how the usage will change:
```diff
// Change role name.
- s.GuildRoleEdit(guildID, roleID, "new name", 0xFFFFFF, true, 0x0, true)
+ s.GuildRoleEdit(guildID, roleID, &discordgo.RoleData {
+    Name: "new name",
+ })

// Change member's roles and nickname.
- s.GuildMemberEdit(guildID, memberID, roles)
- s.GuildMemberNickname(guildID, memberID, "new nickname")
+ s.GuildMemberEdit(guildID, memberID, &discordgo.GuildMemberParams { ... })

// Add member to the server with the given nickname and roles.
- s.GuildMemberAdd(token, guildID, userID, "member", []string{...}, false, false)
+ s.GuildMemberAdd(token, guildID, userID, &discordgo.GuildMemberParams {
+     Name: "member",
+     Roles: &[]string{...},
+ })
```

### Breaking changes
- [x]  `ChannelEdit` — will share same functional as `ChannelEditComplex`
- [x]  `GuildMemberEdit` — will share same functional as `GuildMemberEditComplex`
- [x]  `GuildEmojiEdit` — `name` and `roles` will be placed in a struct, to allow for partial edits
- [x]  `GuildEmojiCreate` — same as for `GuildEmojiEdit`
- [x]  `GuildMemberAdd` — `accessToken`, `nick`, `roles`, `mute` and `deaf` will be placed in a struct
- [x]  `GuildRoleEdit` — `name`, `color`, `hoist`, `perms`, `mention` will be placed in a struct to allow for partial edits
- [x]  `GuildTemplateCreate` — `name` and `description` will be placed in a struct to allow for partial edits
- [x]  `GuildTemplateEdit` — same as for `GuildTemplateCreate`
- [x] `GuildEmbedEdit` — `enabled` and `channel_id` will be places in a struct to allow for partial edits

### Deprecated functions
- [x]  `ChannelEditComplex` (renamed to `ChannelEdit`)
- [x]  `GuildMemberEditComplex` (renamed to `GuildMemberEdit`)

---
:construction: The changes are still work in progress, therefore the list of functions might change.


