### PR TITLE
Add missing fields to GuildMemberParams

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1727,10 +1727,53 @@ type UserGuildSettingsEdit struct {
 // GuildMemberParams stores data needed to update a member
 // https://discord.com/developers/docs/resources/guild#modify-guild-member
 type GuildMemberParams struct {
-	// Value to set user's nickname to
+	// Value to set user's nickname to.
 	Nick string `json:"nick,omitempty"`
-	// Array of role ids the member is assigned
+	// Array of role ids the member is assigned.
 	Roles *[]string `json:"roles,omitempty"`
+	// ID of channel to move user to (if they are connected to voice).
+	// Set to "" to remove user from a voice channel.
+	ChannelID *string `json:"channel_id,omitempty"`
+	// Whether the user is muted in voice channels.
+	Mute *bool `json:"mute,omitempty"`
+	// Whether the user is deafened in voice channels.
+	Deaf *bool `json:"deaf,omitempty"`
+	// When the user's timeout will expire and the user will be able
+	// to communicate in the guild again (up to 28 days in the future).
+	// Set to time.Time{} to remove timeout.
+	CommunicationDisabledUntil *time.Time `json:"communication_disabled_until,omitempty"`
+}
+
+// MarshalJSON is a helper function to marshal GuildMemberParams.
+func (p GuildMemberParams) MarshalJSON() (res []byte, err error) {
+	type guildMemberParams GuildMemberParams
+	v := struct {
+		guildMemberParams
+		ChannelID                  json.RawMessage `json:"channel_id,omitempty"`
+		CommunicationDisabledUntil json.RawMessage `json:"communication_disabled_until,omitempty"`
+	}{guildMemberParams: guildMemberParams(p)}
+
+	if p.ChannelID != nil && *p.ChannelID == "" {
+		v.ChannelID = json.RawMessage(`null`)
+	} else {
+		res, err = json.Marshal(v.ChannelID)
+		if err != nil {
+			return
+		}
+		v.ChannelID = res
+	}
+
+	if p.CommunicationDisabledUntil != nil && p.CommunicationDisabledUntil.IsZero() {
+		v.CommunicationDisabledUntil = json.RawMessage(`null`)
+	} else {
+		res, err = json.Marshal(v.CommunicationDisabledUntil)
+		if err != nil {
+			return
+		}
+		v.CommunicationDisabledUntil = res
+	}
+
+	return json.Marshal(v)
 }
 
 // An APIErrorMessage is an api error message returned from discord

--- a/structs.go
+++ b/structs.go
@@ -1753,24 +1753,28 @@ func (p GuildMemberParams) MarshalJSON() (res []byte, err error) {
 		CommunicationDisabledUntil json.RawMessage `json:"communication_disabled_until,omitempty"`
 	}{guildMemberParams: guildMemberParams(p)}
 
-	if p.ChannelID != nil && *p.ChannelID == "" {
-		v.ChannelID = json.RawMessage(`null`)
-	} else {
-		res, err = json.Marshal(v.ChannelID)
-		if err != nil {
-			return
+	if p.ChannelID != nil {
+		if *p.ChannelID == "" {
+			v.ChannelID = json.RawMessage(`null`)
+		} else {
+			res, err = json.Marshal(p.ChannelID)
+			if err != nil {
+				return
+			}
+			v.ChannelID = res
 		}
-		v.ChannelID = res
 	}
 
-	if p.CommunicationDisabledUntil != nil && p.CommunicationDisabledUntil.IsZero() {
-		v.CommunicationDisabledUntil = json.RawMessage(`null`)
-	} else {
-		res, err = json.Marshal(v.CommunicationDisabledUntil)
-		if err != nil {
-			return
+	if p.CommunicationDisabledUntil != nil {
+		if p.CommunicationDisabledUntil.IsZero() {
+			v.CommunicationDisabledUntil = json.RawMessage(`null`)
+		} else {
+			res, err = json.Marshal(p.CommunicationDisabledUntil)
+			if err != nil {
+				return
+			}
+			v.CommunicationDisabledUntil = res
 		}
-		v.CommunicationDisabledUntil = res
 	}
 
 	return json.Marshal(v)


### PR DESCRIPTION
This PR adds the following fields to the GuildMemberParams.
- `channel_id`
- `mute`
- `deaf`
- `communication_disabled_until`