### PR TITLE
Add missing fields to Ready

### DIFF
--- a/events.go
+++ b/events.go
@@ -39,7 +39,7 @@ type Ready struct {
 	Version         int          `json:"v"`
 	SessionID       string       `json:"session_id"`
 	User            *User        `json:"user"`
-	Shard           [2]int       `json:"shard"`
+	Shard           *[2]int      `json:"shard"`
 	Application     *Application `json:"application"`
 	Guilds          []*Guild     `json:"guilds"`
 	PrivateChannels []*Channel   `json:"private_channels"`

--- a/events.go
+++ b/events.go
@@ -36,13 +36,13 @@ type Event struct {
 
 // A Ready stores all data for the websocket READY event.
 type Ready struct {
-	Version         int        `json:"v"`
-	SessionID       string     `json:"session_id"`
-	User            *User      `json:"user"`
-	Guilds          []*Guild   `json:"guilds"`
-	PrivateChannels []*Channel `json:"private_channels"`
-
-	// TODO: Application and Shard
+	Version         int          `json:"v"`
+	SessionID       string       `json:"session_id"`
+	User            *User        `json:"user"`
+	Shard           [2]int       `json:"shard"`
+	Application     *Application `json:"application"`
+	Guilds          []*Guild     `json:"guilds"`
+	PrivateChannels []*Channel   `json:"private_channels"`
 }
 
 // ChannelCreate is the data for a ChannelCreate event.

--- a/state.go
+++ b/state.go
@@ -909,9 +909,11 @@ func (s *State) onReady(se *Session, r *Ready) (err error) {
 	// if state is disabled, store the bare essentials.
 	if !se.StateEnabled {
 		ready := Ready{
-			Version:   r.Version,
-			SessionID: r.SessionID,
-			User:      r.User,
+			Version:     r.Version,
+			SessionID:   r.SessionID,
+			User:        r.User,
+			Shard:       r.Shard,
+			Application: r.Application,
 		}
 
 		s.Ready = ready


### PR DESCRIPTION
Add `Shard` and `Application` fields to `Ready` event struct.
