### PR TITLE
Continue to next packet if received broken packet

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -835,7 +835,7 @@ func (v *VoiceConnection) opusReceiver(udpConn *net.UDPConn, close <-chan struct
 		if opus, ok := secretbox.Open(nil, recvbuf[12:rlen], &nonce, &v.op4.SecretKey); ok {
 			p.Opus = opus
 		} else {
-			return
+			continue
 		}
 
 		// extension bit set, and not a RTCP packet


### PR DESCRIPTION
Broken packet should be ignored and continue to next packet.
This goroutine should not exit until close.