### PR TITLE
feat: state.GuildIDs() to get ids of guilds the bot is present in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE-specific metadata
 .idea/
+.vscode/
 
 # Environment variables. Useful for examples.
 .env

--- a/state.go
+++ b/state.go
@@ -192,6 +192,29 @@ func (s *State) Guild(guildID string) (*Guild, error) {
 	return nil, ErrStateNotFound
 }
 
+// retrieves IDs of guilds the bot is present in
+func (s *State) GuildIDs() ([]string, error) {
+	if s == nil {
+		return nil, ErrNilState
+	}
+
+	s.RLock()
+	defer s.RUnlock()
+
+	if len(s.guildMap) == 0 {
+		return nil, ErrStateNotFound
+	}
+
+	ids := make([]string, len(s.guildMap))
+	i := 0
+	for k := range s.guildMap {
+		ids[i] = k
+		i++
+	}
+
+	return ids, nil
+}
+
 func (s *State) presenceAdd(guildID string, presence *Presence) error {
 	guild, ok := s.guildMap[guildID]
 	if !ok {


### PR DESCRIPTION
To be able to get guildID at runtime thus, saving a hustle for end user of getting manually after enabling developer mod. Useful for self-hosted single guild bots.