### PR TITLE
fix(interactions): incorrect call of State.Role in RoleValue()

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -472,7 +472,7 @@ func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID strin
 		return &Role{ID: roleID}
 	}
 
-	r, err := s.State.Role(roleID, gID)
+	r, err := s.State.Role(gID, roleID)
 	if err != nil {
 		roles, err := s.GuildRoles(gID)
 		if err == nil {


### PR DESCRIPTION
If i’m not mistaken, the gID parameter of `RoleValue(s *Session, gID string)` line 465 of `interactions.go` corresponds to the guild ID.

The gID parameter was passed to State.Role as roleID and the roleID was passed as guildID.
Inverting the arguments should fix the issue.