### PR TITLE
graceful shutdown: notify using syscall.SIGTERM

### DIFF
--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -46,7 +46,7 @@ func main() {
 	// Wait here until CTRL-C or other term signal is received.
 	fmt.Println("Bot is now running.  Press CTRL-C to exit.")
 	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, syscall.SIGTERM)
 	<-sc
 
 	// Cleanly close down the Discord session.


### PR DESCRIPTION
`os.Kill` can't be caught it's just there for killing other processes. `os.Kill` is like kill -9 which kills a process immediately. `syscall.SIGTERM` is equivalent to kill which allows the process time to cleanup.