### PR TITLE
Complement `GuildParams` struct to comply with Discord's API

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1064,9 +1064,9 @@ type SystemChannelFlag int
 // Block containing known SystemChannelFlag values
 const (
 	SystemChannelFlagsSuppressJoinNotifications         SystemChannelFlag = 1 << 0
-	SystemChannelFlagsSuppressPremium      SystemChannelFlag = 1 << 1
+	SystemChannelFlagsSuppressPremium                   SystemChannelFlag = 1 << 1
 	SystemChannelFlagsSupressGuildReminderNotifications SystemChannelFlag = 1 << 2
-	SystemChannelFlagsSupressJoinNotificationReplies   SystemChannelFlag = 1 << 3
+	SystemChannelFlagsSupressJoinNotificationReplies    SystemChannelFlag = 1 << 3
 )
 
 // IconURL returns a URL to the guild's icon.
@@ -1140,7 +1140,7 @@ type GuildParams struct {
 	Icon                        string             `json:"icon,omitempty"`
 	OwnerID                     string             `json:"owner_id,omitempty"`
 	Splash                      string             `json:"splash,omitempty"`
-	DiscoverySplash              string             `json:"discovery_splash,omitempty"`
+	DiscoverySplash             string             `json:"discovery_splash,omitempty"`
 	Banner                      string             `json:"banner,omitempty"`
 	SystemChannelID             string             `json:"system_channel_id,omitempty"`
 	SystemChannelFlags          SystemChannelFlag  `json:"system_channel_flags,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -1063,10 +1063,10 @@ type SystemChannelFlag int
 
 // Block containing known SystemChannelFlag values
 const (
-	SystemChannelFlagsSuppressJoin         SystemChannelFlag = 1 << 0
+	SystemChannelFlagsSuppressJoinNotifications         SystemChannelFlag = 1 << 0
 	SystemChannelFlagsSuppressPremium      SystemChannelFlag = 1 << 1
-	SystemChannelFlagsSupressGuildReminder SystemChannelFlag = 1 << 2
-	SystemChannelFlagsSupressJoinReplies   SystemChannelFlag = 1 << 3
+	SystemChannelFlagsSupressGuildReminderNotifications SystemChannelFlag = 1 << 2
+	SystemChannelFlagsSupressJoinNotificationReplies   SystemChannelFlag = 1 << 3
 )
 
 // IconURL returns a URL to the guild's icon.
@@ -1140,7 +1140,7 @@ type GuildParams struct {
 	Icon                        string             `json:"icon,omitempty"`
 	OwnerID                     string             `json:"owner_id,omitempty"`
 	Splash                      string             `json:"splash,omitempty"`
-	DiscoverSplash              string             `json:"discovery_splash,omitempty"`
+	DiscoverySplash              string             `json:"discovery_splash,omitempty"`
 	Banner                      string             `json:"banner,omitempty"`
 	SystemChannelID             string             `json:"system_channel_id,omitempty"`
 	SystemChannelFlags          SystemChannelFlag  `json:"system_channel_flags,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -1146,7 +1146,7 @@ type GuildParams struct {
 	SystemChannelFlags          SystemChannelFlag  `json:"system_channel_flags,omitempty"`
 	RulesChannelID              string             `json:"rules_channel_id,omitempty"`
 	PublicUpdatesChannelID      string             `json:"public_updates_channel_id,omitempty"`
-	PreferredLocale             string             `json:"preferred_locale,omitempty"`
+	PreferredLocale             Locale             `json:"preferred_locale,omitempty"`
 	Features                    []GuildFeature     `json:"features,omitempty"`
 	Description                 string             `json:"description,omitempty"`
 	PremiumProgressBarEnabled   bool               `json:"premium_progress_bar_enabled,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -1063,8 +1063,10 @@ type SystemChannelFlag int
 
 // Block containing known SystemChannelFlag values
 const (
-	SystemChannelFlagsSuppressJoin    SystemChannelFlag = 1 << 0
-	SystemChannelFlagsSuppressPremium SystemChannelFlag = 1 << 1
+	SystemChannelFlagsSuppressJoin         SystemChannelFlag = 1 << 0
+	SystemChannelFlagsSuppressPremium      SystemChannelFlag = 1 << 1
+	SystemChannelFlagsSupressGuildReminder SystemChannelFlag = 1 << 2
+	SystemChannelFlagsSupressJoinReplies   SystemChannelFlag = 1 << 3
 )
 
 // IconURL returns a URL to the guild's icon.
@@ -1132,12 +1134,22 @@ type GuildParams struct {
 	Region                      string             `json:"region,omitempty"`
 	VerificationLevel           *VerificationLevel `json:"verification_level,omitempty"`
 	DefaultMessageNotifications int                `json:"default_message_notifications,omitempty"` // TODO: Separate type?
+	ExplicitContentFilter       int                `json:"explicit_content_filter,omitempty"`
 	AfkChannelID                string             `json:"afk_channel_id,omitempty"`
 	AfkTimeout                  int                `json:"afk_timeout,omitempty"`
 	Icon                        string             `json:"icon,omitempty"`
 	OwnerID                     string             `json:"owner_id,omitempty"`
 	Splash                      string             `json:"splash,omitempty"`
+	DiscoverSplash              string             `json:"discovery_splash,omitempty"`
 	Banner                      string             `json:"banner,omitempty"`
+	SystemChannelID             string             `json:"system_channel_id,omitempty"`
+	SystemChannelFlags          SystemChannelFlag  `json:"system_channel_flags,omitempty"`
+	RulesChannelID              string             `json:"rules_channel_id,omitempty"`
+	PublicUpdatesChannelID      string             `json:"public_updates_channel_id,omitempty"`
+	PreferredLocale             string             `json:"preferred_locale,omitempty"`
+	Features                    []GuildFeature     `json:"features,omitempty"`
+	Description                 string             `json:"description,omitempty"`
+	PremiumProgressBarEnabled   bool               `json:"premium_progress_bar_enabled,omitempty"`
 }
 
 // A Role stores information about Discord guild member roles.


### PR DESCRIPTION
I've updated the `GuildParams` struct to be complient with the [`Modify Guild`](https://discord.com/developers/docs/resources/guild#modify-guild) payload as described in the Discord API docs. Therefore, I've also added the two System Channel Flags `SUPPRESS_GUILD_REMINDER_NOTIFICATIONS` and `SUPPRESS_JOIN_NOTIFICATION_REPLIES` to the `SystemChannelFlag` constants.

This pull request should fix issue #994.