### PR TITLE
fix(MultipartBodyWithJSON): form file field name format

### DIFF
--- a/util.go
+++ b/util.go
@@ -51,7 +51,7 @@ func MultipartBodyWithJSON(data interface{}, files []*File) (requestContentType 
 
 	for i, file := range files {
 		h := make(textproto.MIMEHeader)
-		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file%d"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file[%d]"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
 		contentType := file.ContentType
 		if contentType == "" {
 			contentType = "application/octet-stream"

--- a/util.go
+++ b/util.go
@@ -51,7 +51,7 @@ func MultipartBodyWithJSON(data interface{}, files []*File) (requestContentType 
 
 	for i, file := range files {
 		h := make(textproto.MIMEHeader)
-		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file[%d]"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
+		h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="files[%d]"; filename="%s"`, i, quoteEscaper.Replace(file.Name)))
 		contentType := file.ContentType
 		if contentType == "" {
 			contentType = "application/octet-stream"


### PR DESCRIPTION
Currently `MultipartBodyWithJSON` uses `file<index>` format for the `name` of the form field for files. However this format is not correct, according to the [documentation](https://discord.com/developers/docs/reference#uploading-files). The correct format is `files[<index>]`.

The implementation was working all that time, because all the endpoints with support of attachments append them automatically and you do not need to reference them, however when you would try to, you would just get an "Unknown attachment" error. 
This PR should fix this problem.

Initially I discovered this when I was performing manual tests on #1253.