### PR TITLE
fix: remove embedfield omitempty

### DIFF
--- a/message.go
+++ b/message.go
@@ -389,8 +389,8 @@ type MessageEmbedAuthor struct {
 
 // MessageEmbedField is a part of a MessageEmbed struct.
 type MessageEmbedField struct {
-	Name   string `json:"name,omitempty"`
-	Value  string `json:"value,omitempty"`
+	Name   string `json:"name"`
+	Value  string `json:"value"`
 	Inline bool   `json:"inline,omitempty"`
 }
 


### PR DESCRIPTION
Remove omitempty from Name/value since the Discord API requires both to be submitted.

https://discord.com/developers/docs/resources/channel#embed-object
![image](https://user-images.githubusercontent.com/36411819/197341922-f0730fb4-ec64-4554-aa35-f1846db3398a.png)

Fixes: #726