### PR TITLE
EmojiRegex: emojis with longer ids

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -508,7 +508,7 @@ type Emoji struct {
 
 // EmojiRegex is the regex used to find and identify emojis in messages
 var (
-	EmojiRegex = regexp.MustCompile(`<(a|):[A-z0-9_~]+:[0-9]{18}>`)
+	EmojiRegex = regexp.MustCompile(`<(a|):[A-z0-9_~]+:[0-9]{18,20}>`)
 )
 
 // MessageFormat returns a correctly formatted Emoji for use in Message content and embeds


### PR DESCRIPTION
Fix EmojiRegex to accept emojis with ids up to 20 characters long