### PR TITLE
feat: add UpdateWatchStatus function

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -361,6 +361,14 @@ func (s *Session) UpdateGameStatus(idle int, name string) (err error) {
 	return s.UpdateStatusComplex(*newUpdateStatusData(idle, ActivityTypeGame, name, ""))
 }
 
+// UpdateWatchStatus is used to update the user's watch status.
+// If idle>0 then set status to idle.
+// If name!="" then set movie/stream.
+// if otherwise, set status to active, and no activity.
+func (s *Session) UpdateWatchStatus(idle int, name string) (err error) {
+	return s.UpdateStatusComplex(*newUpdateStatusData(idle, ActivityTypeWatching, name, ""))
+}
+
 // UpdateStreamingStatus is used to update the user's streaming status.
 // If idle>0 then set status to idle.
 // If name!="" then set game.


### PR DESCRIPTION
This commit adds the UpdateWatchStatus method that can be used to set discords Watch status (see https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum).
