### PR TITLE
Options

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -321,9 +321,9 @@ func unmarshal(data []byte, v interface{}) error {
 
 // User returns the user details of the given userID
 // userID    : A user ID or "@me" which is a shortcut of current user ID
-func (s *Session) User(userID string) (st *User, err error) {
+func (s *Session) User(userID string, options ...RequestOption) (st *User, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointUser(userID), nil, EndpointUsers)
+	body, err := s.RequestWithBucketID("GET", EndpointUser(userID), nil, EndpointUsers, options...)
 	if err != nil {
 		return
 	}
@@ -334,7 +334,7 @@ func (s *Session) User(userID string) (st *User, err error) {
 
 // UserAvatar is deprecated. Please use UserAvatarDecode
 // userID    : A user ID or "@me" which is a shortcut of current user ID
-func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
+func (s *Session) UserAvatar(userID string, options ...RequestOption) (img image.Image, err error) {
 	u, err := s.User(userID)
 	if err != nil {
 		return
@@ -345,8 +345,8 @@ func (s *Session) UserAvatar(userID string) (img image.Image, err error) {
 
 // UserAvatarDecode returns an image.Image of a user's Avatar
 // user : The user which avatar should be retrieved
-func (s *Session) UserAvatarDecode(u *User) (img image.Image, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(u.ID, u.Avatar), nil, EndpointUserAvatar("", ""))
+func (s *Session) UserAvatarDecode(u *User, options ...RequestOption) (img image.Image, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointUserAvatar(u.ID, u.Avatar), nil, EndpointUserAvatar("", ""), options...)
 	if err != nil {
 		return
 	}
@@ -356,7 +356,7 @@ func (s *Session) UserAvatarDecode(u *User) (img image.Image, err error) {
 }
 
 // UserUpdate updates current user settings.
-func (s *Session) UserUpdate(username, avatar string) (st *User, err error) {
+func (s *Session) UserUpdate(username, avatar string, options ...RequestOption) (st *User, err error) {
 
 	// NOTE: Avatar must be either the hash/id of existing Avatar or
 	// data:image/png;base64,BASE64_STRING_OF_NEW_AVATAR_PNG
@@ -368,7 +368,7 @@ func (s *Session) UserUpdate(username, avatar string) (st *User, err error) {
 		Avatar   string `json:"avatar,omitempty"`
 	}{username, avatar}
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointUser("@me"), data, EndpointUsers)
+	body, err := s.RequestWithBucketID("PATCH", EndpointUser("@me"), data, EndpointUsers, options...)
 	if err != nil {
 		return
 	}
@@ -378,8 +378,8 @@ func (s *Session) UserUpdate(username, avatar string) (st *User, err error) {
 }
 
 // UserConnections returns the user's connections
-func (s *Session) UserConnections() (conn []*UserConnection, err error) {
-	response, err := s.RequestWithBucketID("GET", EndpointUserConnections("@me"), nil, EndpointUserConnections("@me"))
+func (s *Session) UserConnections(options ...RequestOption) (conn []*UserConnection, err error) {
+	response, err := s.RequestWithBucketID("GET", EndpointUserConnections("@me"), nil, EndpointUserConnections("@me"), options...)
 	if err != nil {
 		return nil, err
 	}
@@ -394,13 +394,13 @@ func (s *Session) UserConnections() (conn []*UserConnection, err error) {
 
 // UserChannelCreate creates a new User (Private) Channel with another User
 // recipientID : A user ID for the user to which this channel is opened with.
-func (s *Session) UserChannelCreate(recipientID string) (st *Channel, err error) {
+func (s *Session) UserChannelCreate(recipientID string, options ...RequestOption) (st *Channel, err error) {
 
 	data := struct {
 		RecipientID string `json:"recipient_id"`
 	}{recipientID}
 
-	body, err := s.RequestWithBucketID("POST", EndpointUserChannels("@me"), data, EndpointUserChannels(""))
+	body, err := s.RequestWithBucketID("POST", EndpointUserChannels("@me"), data, EndpointUserChannels(""), options...)
 	if err != nil {
 		return
 	}
@@ -411,8 +411,8 @@ func (s *Session) UserChannelCreate(recipientID string) (st *Channel, err error)
 
 // UserGuildMember returns a guild member object for the current user in the given Guild.
 // guildID : ID of the guild
-func (s *Session) UserGuildMember(guildID string) (st *Member, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointUserGuildMember("@me", guildID), nil, EndpointUserGuildMember("@me", guildID))
+func (s *Session) UserGuildMember(guildID string, options ...RequestOption) (st *Member, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointUserGuildMember("@me", guildID), nil, EndpointUserGuildMember("@me", guildID), options...)
 	if err != nil {
 		return
 	}
@@ -425,7 +425,7 @@ func (s *Session) UserGuildMember(guildID string) (st *Member, err error) {
 // limit     : The number guilds that can be returned. (max 100)
 // beforeID  : If provided all guilds returned will be before given ID.
 // afterID   : If provided all guilds returned will be after given ID.
-func (s *Session) UserGuilds(limit int, beforeID, afterID string) (st []*UserGuild, err error) {
+func (s *Session) UserGuilds(limit int, beforeID, afterID string, options ...RequestOption) (st []*UserGuild, err error) {
 
 	v := url.Values{}
 
@@ -445,7 +445,7 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string) (st []*UserGui
 		uri += "?" + v.Encode()
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointUserGuilds(""))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointUserGuilds(""), options...)
 	if err != nil {
 		return
 	}
@@ -573,8 +573,8 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 
 // Guild returns a Guild structure of a specific Guild.
 // guildID   : The ID of a Guild
-func (s *Session) Guild(guildID string) (st *Guild, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointGuild(guildID), nil, EndpointGuild(guildID))
+func (s *Session) Guild(guildID string, options ...RequestOption) (st *Guild, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointGuild(guildID), nil, EndpointGuild(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -585,9 +585,9 @@ func (s *Session) Guild(guildID string) (st *Guild, err error) {
 
 // GuildWithCounts returns a Guild structure of a specific Guild with approximate member and presence counts.
 // guildID    : The ID of a Guild
-func (s *Session) GuildWithCounts(guildID string) (st *Guild, err error) {
+func (s *Session) GuildWithCounts(guildID string, options ...RequestOption) (st *Guild, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuild(guildID)+"?with_counts=true", nil, EndpointGuild(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuild(guildID)+"?with_counts=true", nil, EndpointGuild(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -598,8 +598,8 @@ func (s *Session) GuildWithCounts(guildID string) (st *Guild, err error) {
 
 // GuildPreview returns a GuildPreview structure of a specific public Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildPreview(guildID string) (st *GuildPreview, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointGuildPreview(guildID), nil, EndpointGuildPreview(guildID))
+func (s *Session) GuildPreview(guildID string, options ...RequestOption) (st *GuildPreview, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointGuildPreview(guildID), nil, EndpointGuildPreview(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -610,13 +610,13 @@ func (s *Session) GuildPreview(guildID string) (st *GuildPreview, err error) {
 
 // GuildCreate creates a new Guild
 // name      : A name for the Guild (2-100 characters)
-func (s *Session) GuildCreate(name string) (st *Guild, err error) {
+func (s *Session) GuildCreate(name string, options ...RequestOption) (st *Guild, err error) {
 
 	data := struct {
 		Name string `json:"name"`
 	}{name}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate)
+	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate, options...)
 	if err != nil {
 		return
 	}
@@ -628,7 +628,7 @@ func (s *Session) GuildCreate(name string) (st *Guild, err error) {
 // GuildEdit edits a new Guild
 // guildID   : The ID of a Guild
 // g 		 : A GuildParams struct with the values Name, Region and VerificationLevel defined.
-func (s *Session) GuildEdit(guildID string, g *GuildParams) (st *Guild, err error) {
+func (s *Session) GuildEdit(guildID string, g *GuildParams, options ...RequestOption) (st *Guild, err error) {
 
 	// Bounds checking for VerificationLevel, interval: [0, 4]
 	if g.VerificationLevel != nil {
@@ -658,7 +658,7 @@ func (s *Session) GuildEdit(guildID string, g *GuildParams) (st *Guild, err erro
 		}
 	}
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointGuild(guildID), g, EndpointGuild(guildID))
+	body, err := s.RequestWithBucketID("PATCH", EndpointGuild(guildID), g, EndpointGuild(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -669,9 +669,9 @@ func (s *Session) GuildEdit(guildID string, g *GuildParams) (st *Guild, err erro
 
 // GuildDelete deletes a Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildDelete(guildID string) (st *Guild, err error) {
+func (s *Session) GuildDelete(guildID string, options ...RequestOption) (st *Guild, err error) {
 
-	body, err := s.RequestWithBucketID("DELETE", EndpointGuild(guildID), nil, EndpointGuild(guildID))
+	body, err := s.RequestWithBucketID("DELETE", EndpointGuild(guildID), nil, EndpointGuild(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -682,18 +682,19 @@ func (s *Session) GuildDelete(guildID string) (st *Guild, err error) {
 
 // GuildLeave leaves a Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildLeave(guildID string) (err error) {
+func (s *Session) GuildLeave(guildID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointUserGuild("@me", guildID), nil, EndpointUserGuild("", guildID))
+	_, err = s.RequestWithBucketID("DELETE", EndpointUserGuild("@me", guildID), nil, EndpointUserGuild("", guildID), options...)
 	return
 }
 
 // GuildBans returns an array of GuildBan structures for bans in the given guild.
-//  guildID   : The ID of a Guild
-//  limit     : Max number of bans to return (max 1000)
-//  beforeID  : If not empty all returned users will be after the given id
-//  afterID   : If not empty all returned users will be before the given id
-func (s *Session) GuildBans(guildID string, limit int, beforeID, afterID string) (st []*GuildBan, err error) {
+//
+//	guildID   : The ID of a Guild
+//	limit     : Max number of bans to return (max 1000)
+//	beforeID  : If not empty all returned users will be after the given id
+//	afterID   : If not empty all returned users will be before the given id
+func (s *Session) GuildBans(guildID string, limit int, beforeID, afterID string, options ...RequestOption) (st []*GuildBan, err error) {
 	uri := EndpointGuildBans(guildID)
 
 	v := url.Values{}
@@ -711,7 +712,7 @@ func (s *Session) GuildBans(guildID string, limit int, beforeID, afterID string)
 		uri += "?" + v.Encode()
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildBans(guildID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildBans(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -725,14 +726,14 @@ func (s *Session) GuildBans(guildID string, limit int, beforeID, afterID string)
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
 // days      : The number of days of previous comments to delete.
-func (s *Session) GuildBanCreate(guildID, userID string, days int) (err error) {
-	return s.GuildBanCreateWithReason(guildID, userID, "", days)
+func (s *Session) GuildBanCreate(guildID, userID string, days int, options ...RequestOption) (err error) {
+	return s.GuildBanCreateWithReason(guildID, userID, "", days, options...)
 }
 
 // GuildBan finds ban by given guild and user id and returns GuildBan structure
-func (s *Session) GuildBan(guildID, userID string) (st *GuildBan, err error) {
+func (s *Session) GuildBan(guildID, userID string, options ...RequestOption) (st *GuildBan, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, userID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, userID), options...)
 	if err != nil {
 		return
 	}
@@ -747,7 +748,7 @@ func (s *Session) GuildBan(guildID, userID string) (st *GuildBan, err error) {
 // userID    : The ID of a User
 // reason    : The reason for this ban
 // days      : The number of days of previous comments to delete.
-func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days int) (err error) {
+func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days int, options ...RequestOption) (err error) {
 
 	uri := EndpointGuildBan(guildID, userID)
 
@@ -763,24 +764,25 @@ func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days 
 		uri += "?" + queryParams.Encode()
 	}
 
-	_, err = s.RequestWithBucketID("PUT", uri, nil, EndpointGuildBan(guildID, ""))
+	_, err = s.RequestWithBucketID("PUT", uri, nil, EndpointGuildBan(guildID, ""), options...)
 	return
 }
 
 // GuildBanDelete removes the given user from the guild bans
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-func (s *Session) GuildBanDelete(guildID, userID string) (err error) {
+func (s *Session) GuildBanDelete(guildID, userID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, ""), options...)
 	return
 }
 
 // GuildMembers returns a list of members for a guild.
-//  guildID  : The ID of a Guild.
-//  after    : The id of the member to return members after
-//  limit    : max number of members to return (max 1000)
-func (s *Session) GuildMembers(guildID string, after string, limit int) (st []*Member, err error) {
+//
+//	guildID  : The ID of a Guild.
+//	after    : The id of the member to return members after
+//	limit    : max number of members to return (max 1000)
+func (s *Session) GuildMembers(guildID string, after string, limit int, options ...RequestOption) (st []*Member, err error) {
 
 	uri := EndpointGuildMembers(guildID)
 
@@ -798,7 +800,7 @@ func (s *Session) GuildMembers(guildID string, after string, limit int) (st []*M
 		uri += "?" + v.Encode()
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildMembers(guildID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildMembers(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -811,7 +813,7 @@ func (s *Session) GuildMembers(guildID string, after string, limit int) (st []*M
 // guildID  : The ID of a Guild
 // query    : Query string to match username(s) and nickname(s) against
 // limit    : Max number of members to return (default 1, min 1, max 1000)
-func (s *Session) GuildMembersSearch(guildID, query string, limit int) (st []*Member, err error) {
+func (s *Session) GuildMembersSearch(guildID, query string, limit int, options ...RequestOption) (st []*Member, err error) {
 
 	uri := EndpointGuildMembersSearch(guildID)
 
@@ -821,7 +823,7 @@ func (s *Session) GuildMembersSearch(guildID, query string, limit int) (st []*Me
 		queryParams.Set("limit", strconv.Itoa(limit))
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri+"?"+queryParams.Encode(), nil, uri)
+	body, err := s.RequestWithBucketID("GET", uri+"?"+queryParams.Encode(), nil, uri, options...)
 	if err != nil {
 		return
 	}
@@ -831,11 +833,12 @@ func (s *Session) GuildMembersSearch(guildID, query string, limit int) (st []*Me
 }
 
 // GuildMember returns a member of a guild.
-//  guildID   : The ID of a Guild.
-//  userID    : The ID of a User
-func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
+//
+//	guildID   : The ID of a Guild.
+//	userID    : The ID of a User
+func (s *Session) GuildMember(guildID, userID string, options ...RequestOption) (st *Member, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildMember(guildID, userID), nil, EndpointGuildMember(guildID, ""))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildMember(guildID, userID), nil, EndpointGuildMember(guildID, ""), options...)
 	if err != nil {
 		return
 	}
@@ -847,12 +850,13 @@ func (s *Session) GuildMember(guildID, userID string) (st *Member, err error) {
 }
 
 // GuildMemberAdd force joins a user to the guild.
-//  guildID       : The ID of a Guild.
-//  userID        : The ID of a User.
-//  data          : Parameters of the user to add.
-func (s *Session) GuildMemberAdd(guildID, userID string, data *GuildMemberAddParams) (err error) {
+//
+//	guildID       : The ID of a Guild.
+//	userID        : The ID of a User.
+//	data          : Parameters of the user to add.
+func (s *Session) GuildMemberAdd(guildID, userID string, data *GuildMemberAddParams, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("PUT", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	if err != nil {
 		return err
 	}
@@ -863,23 +867,23 @@ func (s *Session) GuildMemberAdd(guildID, userID string, data *GuildMemberAddPar
 // GuildMemberDelete removes the given user from the given guild.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-func (s *Session) GuildMemberDelete(guildID, userID string) (err error) {
+func (s *Session) GuildMemberDelete(guildID, userID string, options ...RequestOption) (err error) {
 
-	return s.GuildMemberDeleteWithReason(guildID, userID, "")
+	return s.GuildMemberDeleteWithReason(guildID, userID, "", options...)
 }
 
 // GuildMemberDeleteWithReason removes the given user from the given guild.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
 // reason    : The reason for the kick
-func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (err error) {
+func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string, options ...RequestOption) (err error) {
 
 	uri := EndpointGuildMember(guildID, userID)
 	if reason != "" {
 		uri += "?reason=" + url.QueryEscape(reason)
 	}
 
-	_, err = s.RequestWithBucketID("DELETE", uri, nil, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", uri, nil, EndpointGuildMember(guildID, ""), options...)
 	return
 }
 
@@ -887,9 +891,9 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string) (e
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : Updated GuildMember data.
-func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberParams) (st *Member, err error) {
+func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberParams, options ...RequestOption) (st *Member, err error) {
 	var body []byte
-	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	if err != nil {
 		return nil, err
 	}
@@ -903,22 +907,24 @@ func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberParam
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : A GuildMemberEditData struct with the new nickname and roles
-func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemberParams) (st *Member, err error) {
-	return s.GuildMemberEdit(guildID, userID, data)
+func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemberParams, options ...RequestOption) (st *Member, err error) {
+	return s.GuildMemberEdit(guildID, userID, data, options...)
 }
 
 // GuildMemberMove moves a guild member from one voice channel to another/none
-//  guildID   : The ID of a Guild.
-//  userID    : The ID of a User.
-//  channelID : The ID of a channel to move user to or nil to remove from voice channel
+//
+//	guildID   : The ID of a Guild.
+//	userID    : The ID of a User.
+//	channelID : The ID of a channel to move user to or nil to remove from voice channel
+//
 // NOTE : I am not entirely set on the name of this function and it may change
 // prior to the final 1.0.0 release of Discordgo
-func (s *Session) GuildMemberMove(guildID string, userID string, channelID *string) (err error) {
+func (s *Session) GuildMemberMove(guildID string, userID string, channelID *string, options ...RequestOption) (err error) {
 	data := struct {
 		ChannelID *string `json:"channel_id"`
 	}{channelID}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	return
 }
 
@@ -927,7 +933,7 @@ func (s *Session) GuildMemberMove(guildID string, userID string, channelID *stri
 // userID    : The ID of a user
 // userID    : The ID of a user or "@me" which is a shortcut of the current user ID
 // nickname  : The nickname of the member, "" will reset their nickname
-func (s *Session) GuildMemberNickname(guildID, userID, nickname string) (err error) {
+func (s *Session) GuildMemberNickname(guildID, userID, nickname string, options ...RequestOption) (err error) {
 
 	data := struct {
 		Nick string `json:"nick"`
@@ -937,68 +943,73 @@ func (s *Session) GuildMemberNickname(guildID, userID, nickname string) (err err
 		userID += "/nick"
 	}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	return
 }
 
 // GuildMemberMute server mutes a guild member
-//  guildID   : The ID of a Guild.
-//  userID    : The ID of a User.
-//  mute    : boolean value for if the user should be muted
-func (s *Session) GuildMemberMute(guildID string, userID string, mute bool) (err error) {
+//
+//	guildID   : The ID of a Guild.
+//	userID    : The ID of a User.
+//	mute    : boolean value for if the user should be muted
+func (s *Session) GuildMemberMute(guildID string, userID string, mute bool, options ...RequestOption) (err error) {
 	data := struct {
 		Mute bool `json:"mute"`
 	}{mute}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	return
 }
 
 // GuildMemberTimeout times out a guild member
-//  guildID   : The ID of a Guild.
-//  userID    : The ID of a User.
-//  until     : The timestamp for how long a member should be timed out.
-//              Set to nil to remove timeout.
-func (s *Session) GuildMemberTimeout(guildID string, userID string, until *time.Time) (err error) {
+//
+//	guildID   : The ID of a Guild.
+//	userID    : The ID of a User.
+//	until     : The timestamp for how long a member should be timed out.
+//	            Set to nil to remove timeout.
+func (s *Session) GuildMemberTimeout(guildID string, userID string, until *time.Time, options ...RequestOption) (err error) {
 	data := struct {
 		CommunicationDisabledUntil *time.Time `json:"communication_disabled_until"`
 	}{until}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	return
 }
 
 // GuildMemberDeafen server deafens a guild member
-//  guildID   : The ID of a Guild.
-//  userID    : The ID of a User.
-//  deaf    : boolean value for if the user should be deafened
-func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool) (err error) {
+//
+//	guildID   : The ID of a Guild.
+//	userID    : The ID of a User.
+//	deaf    : boolean value for if the user should be deafened
+func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool, options ...RequestOption) (err error) {
 	data := struct {
 		Deaf bool `json:"deaf"`
 	}{deaf}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	return
 }
 
 // GuildMemberRoleAdd adds the specified role to a given member
-//  guildID   : The ID of a Guild.
-//  userID    : The ID of a User.
-//  roleID 	  : The ID of a Role to be assigned to the user.
-func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string) (err error) {
+//
+//	guildID   : The ID of a Guild.
+//	userID    : The ID of a User.
+//	roleID 	  : The ID of a Role to be assigned to the user.
+func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("PUT", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""), options...)
 
 	return
 }
 
 // GuildMemberRoleRemove removes the specified role to a given member
-//  guildID   : The ID of a Guild.
-//  userID    : The ID of a User.
-//  roleID 	  : The ID of a Role to be removed from the user.
-func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string) (err error) {
+//
+//	guildID   : The ID of a Guild.
+//	userID    : The ID of a User.
+//	roleID 	  : The ID of a Role to be removed from the user.
+func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""), options...)
 
 	return
 }
@@ -1006,9 +1017,9 @@ func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string) (err err
 // GuildChannels returns an array of Channel structures for all channels of a
 // given guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildChannels(guildID string) (st []*Channel, err error) {
+func (s *Session) GuildChannels(guildID string, options ...RequestOption) (st []*Channel, err error) {
 
-	body, err := s.request("GET", EndpointGuildChannels(guildID), "", nil, EndpointGuildChannels(guildID), 0)
+	body, err := s.request("GET", EndpointGuildChannels(guildID), "", nil, EndpointGuildChannels(guildID), 0, options...)
 	if err != nil {
 		return
 	}
@@ -1035,8 +1046,8 @@ type GuildChannelCreateData struct {
 // GuildChannelCreateComplex creates a new channel in the given guild
 // guildID      : The ID of a Guild
 // data         : A data struct describing the new Channel, Name and Type are mandatory, other fields depending on the type
-func (s *Session) GuildChannelCreateComplex(guildID string, data GuildChannelCreateData) (st *Channel, err error) {
-	body, err := s.RequestWithBucketID("POST", EndpointGuildChannels(guildID), data, EndpointGuildChannels(guildID))
+func (s *Session) GuildChannelCreateComplex(guildID string, data GuildChannelCreateData, options ...RequestOption) (st *Channel, err error) {
+	body, err := s.RequestWithBucketID("POST", EndpointGuildChannels(guildID), data, EndpointGuildChannels(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1049,17 +1060,17 @@ func (s *Session) GuildChannelCreateComplex(guildID string, data GuildChannelCre
 // guildID   : The ID of a Guild.
 // name      : Name of the channel (2-100 chars length)
 // ctype     : Type of the channel
-func (s *Session) GuildChannelCreate(guildID, name string, ctype ChannelType) (st *Channel, err error) {
+func (s *Session) GuildChannelCreate(guildID, name string, ctype ChannelType, options ...RequestOption) (st *Channel, err error) {
 	return s.GuildChannelCreateComplex(guildID, GuildChannelCreateData{
 		Name: name,
 		Type: ctype,
-	})
+	}, options...)
 }
 
 // GuildChannelsReorder updates the order of channels in a guild
 // guildID   : The ID of a Guild.
 // channels  : Updated channels.
-func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel) (err error) {
+func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel, options ...RequestOption) (err error) {
 
 	data := make([]struct {
 		ID       string `json:"id"`
@@ -1071,14 +1082,14 @@ func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel) (err
 		data[i].Position = c.Position
 	}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildChannels(guildID), data, EndpointGuildChannels(guildID))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildChannels(guildID), data, EndpointGuildChannels(guildID), options...)
 	return
 }
 
 // GuildInvites returns an array of Invite structures for the given guild
 // guildID   : The ID of a Guild.
-func (s *Session) GuildInvites(guildID string) (st []*Invite, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointGuildInvites(guildID), nil, EndpointGuildInvites(guildID))
+func (s *Session) GuildInvites(guildID string, options ...RequestOption) (st []*Invite, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointGuildInvites(guildID), nil, EndpointGuildInvites(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1089,9 +1100,9 @@ func (s *Session) GuildInvites(guildID string) (st []*Invite, err error) {
 
 // GuildRoles returns all roles for a given guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
+func (s *Session) GuildRoles(guildID string, options ...RequestOption) (st []*Role, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1104,8 +1115,8 @@ func (s *Session) GuildRoles(guildID string) (st []*Role, err error) {
 // GuildRoleCreate creates a new Guild Role and returns it.
 // guildID : The ID of a Guild.
 // data    : New Role parameters.
-func (s *Session) GuildRoleCreate(guildID string, data *RoleParams) (st *Role, err error) {
-	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), data, EndpointGuildRoles(guildID))
+func (s *Session) GuildRoleCreate(guildID string, data *RoleParams, options ...RequestOption) (st *Role, err error) {
+	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), data, EndpointGuildRoles(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1119,14 +1130,14 @@ func (s *Session) GuildRoleCreate(guildID string, data *RoleParams) (st *Role, e
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
 // data 		 : Updated Role data.
-func (s *Session) GuildRoleEdit(guildID, roleID string, data *RoleParams) (st *Role, err error) {
+func (s *Session) GuildRoleEdit(guildID, roleID string, data *RoleParams, options ...RequestOption) (st *Role, err error) {
 
 	// Prevent sending a color int that is too big.
 	if data.Color != nil && *data.Color > 0xFFFFFF {
 		return nil, fmt.Errorf("color value cannot be larger than 0xFFFFFF")
 	}
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRole(guildID, roleID), data, EndpointGuildRole(guildID, ""))
+	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRole(guildID, roleID), data, EndpointGuildRole(guildID, ""), options...)
 	if err != nil {
 		return
 	}
@@ -1139,9 +1150,9 @@ func (s *Session) GuildRoleEdit(guildID, roleID string, data *RoleParams) (st *R
 // GuildRoleReorder reoders guild roles
 // guildID   : The ID of a Guild.
 // roles     : A list of ordered roles.
-func (s *Session) GuildRoleReorder(guildID string, roles []*Role) (st []*Role, err error) {
+func (s *Session) GuildRoleReorder(guildID string, roles []*Role, options ...RequestOption) (st []*Role, err error) {
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRoles(guildID), roles, EndpointGuildRoles(guildID))
+	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRoles(guildID), roles, EndpointGuildRoles(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1154,9 +1165,9 @@ func (s *Session) GuildRoleReorder(guildID string, roles []*Role) (st []*Role, e
 // GuildRoleDelete deletes an existing role.
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
-func (s *Session) GuildRoleDelete(guildID, roleID string) (err error) {
+func (s *Session) GuildRoleDelete(guildID, roleID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildRole(guildID, roleID), nil, EndpointGuildRole(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildRole(guildID, roleID), nil, EndpointGuildRole(guildID, ""), options...)
 
 	return
 }
@@ -1165,7 +1176,7 @@ func (s *Session) GuildRoleDelete(guildID, roleID string) (err error) {
 // Requires 'KICK_MEMBER' permission.
 // guildID	: The ID of a Guild.
 // days		: The number of days to count prune for (1 or more).
-func (s *Session) GuildPruneCount(guildID string, days uint32) (count uint32, err error) {
+func (s *Session) GuildPruneCount(guildID string, days uint32, options ...RequestOption) (count uint32, err error) {
 	count = 0
 
 	if days <= 0 {
@@ -1178,7 +1189,7 @@ func (s *Session) GuildPruneCount(guildID string, days uint32) (count uint32, er
 	}{}
 
 	uri := EndpointGuildPrune(guildID) + "?days=" + strconv.FormatUint(uint64(days), 10)
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildPrune(guildID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildPrune(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1197,7 +1208,7 @@ func (s *Session) GuildPruneCount(guildID string, days uint32) (count uint32, er
 // Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation.
 // guildID	: The ID of a Guild.
 // days		: The number of days to count prune for (1 or more).
-func (s *Session) GuildPrune(guildID string, days uint32) (count uint32, err error) {
+func (s *Session) GuildPrune(guildID string, days uint32, options ...RequestOption) (count uint32, err error) {
 
 	count = 0
 
@@ -1214,7 +1225,7 @@ func (s *Session) GuildPrune(guildID string, days uint32) (count uint32, err err
 		Pruned uint32 `json:"pruned"`
 	}{}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuildPrune(guildID), data, EndpointGuildPrune(guildID))
+	body, err := s.RequestWithBucketID("POST", EndpointGuildPrune(guildID), data, EndpointGuildPrune(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1231,9 +1242,9 @@ func (s *Session) GuildPrune(guildID string, days uint32) (count uint32, err err
 
 // GuildIntegrations returns an array of Integrations for a guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildIntegrations(guildID string) (st []*Integration, err error) {
+func (s *Session) GuildIntegrations(guildID string, options ...RequestOption) (st []*Integration, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildIntegrations(guildID), nil, EndpointGuildIntegrations(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildIntegrations(guildID), nil, EndpointGuildIntegrations(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1247,14 +1258,14 @@ func (s *Session) GuildIntegrations(guildID string) (st []*Integration, err erro
 // guildID          : The ID of a Guild.
 // integrationType  : The Integration type.
 // integrationID    : The ID of an integration.
-func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID string) (err error) {
+func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID string, options ...RequestOption) (err error) {
 
 	data := struct {
 		Type string `json:"type"`
 		ID   string `json:"id"`
 	}{integrationType, integrationID}
 
-	_, err = s.RequestWithBucketID("POST", EndpointGuildIntegrations(guildID), data, EndpointGuildIntegrations(guildID))
+	_, err = s.RequestWithBucketID("POST", EndpointGuildIntegrations(guildID), data, EndpointGuildIntegrations(guildID), options...)
 	return
 }
 
@@ -1265,7 +1276,7 @@ func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID
 // expireBehavior	      : The behavior when an integration subscription lapses (see the integration object documentation).
 // expireGracePeriod    : Period (in seconds) where the integration will ignore lapsed subscriptions.
 // enableEmoticons	    : Whether emoticons should be synced for this integration (twitch only currently).
-func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBehavior, expireGracePeriod int, enableEmoticons bool) (err error) {
+func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBehavior, expireGracePeriod int, enableEmoticons bool, options ...RequestOption) (err error) {
 
 	data := struct {
 		ExpireBehavior    int  `json:"expire_behavior"`
@@ -1273,22 +1284,22 @@ func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBeha
 		EnableEmoticons   bool `json:"enable_emoticons"`
 	}{expireBehavior, expireGracePeriod, enableEmoticons}
 
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildIntegration(guildID, integrationID), data, EndpointGuildIntegration(guildID, ""))
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildIntegration(guildID, integrationID), data, EndpointGuildIntegration(guildID, ""), options...)
 	return
 }
 
 // GuildIntegrationDelete removes the given integration from the Guild.
 // guildID          : The ID of a Guild.
 // integrationID    : The ID of an integration.
-func (s *Session) GuildIntegrationDelete(guildID, integrationID string) (err error) {
+func (s *Session) GuildIntegrationDelete(guildID, integrationID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildIntegration(guildID, integrationID), nil, EndpointGuildIntegration(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildIntegration(guildID, integrationID), nil, EndpointGuildIntegration(guildID, ""), options...)
 	return
 }
 
 // GuildIcon returns an image.Image of a guild icon.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildIcon(guildID string) (img image.Image, err error) {
+func (s *Session) GuildIcon(guildID string, options ...RequestOption) (img image.Image, err error) {
 	g, err := s.Guild(guildID)
 	if err != nil {
 		return
@@ -1299,7 +1310,7 @@ func (s *Session) GuildIcon(guildID string) (img image.Image, err error) {
 		return
 	}
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildIcon(guildID, g.Icon), nil, EndpointGuildIcon(guildID, ""))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildIcon(guildID, g.Icon), nil, EndpointGuildIcon(guildID, ""), options...)
 	if err != nil {
 		return
 	}
@@ -1310,7 +1321,7 @@ func (s *Session) GuildIcon(guildID string) (img image.Image, err error) {
 
 // GuildSplash returns an image.Image of a guild splash image.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildSplash(guildID string) (img image.Image, err error) {
+func (s *Session) GuildSplash(guildID string, options ...RequestOption) (img image.Image, err error) {
 	g, err := s.Guild(guildID)
 	if err != nil {
 		return
@@ -1321,7 +1332,7 @@ func (s *Session) GuildSplash(guildID string) (img image.Image, err error) {
 		return
 	}
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildSplash(guildID, g.Splash), nil, EndpointGuildSplash(guildID, ""))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildSplash(guildID, g.Splash), nil, EndpointGuildSplash(guildID, ""), options...)
 	if err != nil {
 		return
 	}
@@ -1332,9 +1343,9 @@ func (s *Session) GuildSplash(guildID string) (img image.Image, err error) {
 
 // GuildEmbed returns the embed for a Guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
+func (s *Session) GuildEmbed(guildID string, options ...RequestOption) (st *GuildEmbed, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildEmbed(guildID), nil, EndpointGuildEmbed(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildEmbed(guildID), nil, EndpointGuildEmbed(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1346,8 +1357,8 @@ func (s *Session) GuildEmbed(guildID string) (st *GuildEmbed, err error) {
 // GuildEmbedEdit edits the embed of a Guild.
 // guildID   : The ID of a Guild.
 // data      : New GuildEmbed data.
-func (s *Session) GuildEmbedEdit(guildID string, data *GuildEmbed) (err error) {
-	_, err = s.RequestWithBucketID("PATCH", EndpointGuildEmbed(guildID), data, EndpointGuildEmbed(guildID))
+func (s *Session) GuildEmbedEdit(guildID string, data *GuildEmbed, options ...RequestOption) (err error) {
+	_, err = s.RequestWithBucketID("PATCH", EndpointGuildEmbed(guildID), data, EndpointGuildEmbed(guildID), options...)
 	return
 }
 
@@ -1357,7 +1368,7 @@ func (s *Session) GuildEmbedEdit(guildID string, data *GuildEmbed) (err error) {
 // beforeID    : If provided all log entries returned will be before the given ID.
 // actionType  : If provided the log will be filtered for the given Action Type.
 // limit       : The number messages that can be returned. (default 50, min 1, max 100)
-func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, limit int) (st *GuildAuditLog, err error) {
+func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, limit int, options ...RequestOption) (st *GuildAuditLog, err error) {
 
 	uri := EndpointGuildAuditLogs(guildID)
 
@@ -1378,7 +1389,7 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 		uri = fmt.Sprintf("%s?%s", uri, v.Encode())
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildAuditLogs(guildID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildAuditLogs(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1389,9 +1400,9 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 
 // GuildEmojis returns all emoji
 // guildID : The ID of a Guild.
-func (s *Session) GuildEmojis(guildID string) (emoji []*Emoji, err error) {
+func (s *Session) GuildEmojis(guildID string, options ...RequestOption) (emoji []*Emoji, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildEmojis(guildID), nil, EndpointGuildEmojis(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildEmojis(guildID), nil, EndpointGuildEmojis(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1403,9 +1414,9 @@ func (s *Session) GuildEmojis(guildID string) (emoji []*Emoji, err error) {
 // GuildEmoji returns specified emoji.
 // guildID : The ID of a Guild
 // emojiID : The ID of an Emoji to retrieve
-func (s *Session) GuildEmoji(guildID, emojiID string) (emoji *Emoji, err error) {
+func (s *Session) GuildEmoji(guildID, emojiID string, options ...RequestOption) (emoji *Emoji, err error) {
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", EndpointGuildEmoji(guildID, emojiID), nil, EndpointGuildEmoji(guildID, emojiID))
+	body, err = s.RequestWithBucketID("GET", EndpointGuildEmoji(guildID, emojiID), nil, EndpointGuildEmoji(guildID, emojiID), options...)
 	if err != nil {
 		return
 	}
@@ -1417,8 +1428,8 @@ func (s *Session) GuildEmoji(guildID, emojiID string) (emoji *Emoji, err error) 
 // GuildEmojiCreate creates a new Emoji.
 // guildID : The ID of a Guild.
 // data    : New Emoji data.
-func (s *Session) GuildEmojiCreate(guildID string, data *EmojiParams) (emoji *Emoji, err error) {
-	body, err := s.RequestWithBucketID("POST", EndpointGuildEmojis(guildID), data, EndpointGuildEmojis(guildID))
+func (s *Session) GuildEmojiCreate(guildID string, data *EmojiParams, options ...RequestOption) (emoji *Emoji, err error) {
+	body, err := s.RequestWithBucketID("POST", EndpointGuildEmojis(guildID), data, EndpointGuildEmojis(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1431,8 +1442,8 @@ func (s *Session) GuildEmojiCreate(guildID string, data *EmojiParams) (emoji *Em
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
 // data    : Updated Emoji data.
-func (s *Session) GuildEmojiEdit(guildID, emojiID string, data *EmojiParams) (emoji *Emoji, err error) {
-	body, err := s.RequestWithBucketID("PATCH", EndpointGuildEmoji(guildID, emojiID), data, EndpointGuildEmojis(guildID))
+func (s *Session) GuildEmojiEdit(guildID, emojiID string, data *EmojiParams, options ...RequestOption) (emoji *Emoji, err error) {
+	body, err := s.RequestWithBucketID("PATCH", EndpointGuildEmoji(guildID, emojiID), data, EndpointGuildEmojis(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1444,17 +1455,17 @@ func (s *Session) GuildEmojiEdit(guildID, emojiID string, data *EmojiParams) (em
 // GuildEmojiDelete deletes an Emoji.
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
-func (s *Session) GuildEmojiDelete(guildID, emojiID string) (err error) {
+func (s *Session) GuildEmojiDelete(guildID, emojiID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildEmoji(guildID, emojiID), nil, EndpointGuildEmojis(guildID))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildEmoji(guildID, emojiID), nil, EndpointGuildEmojis(guildID), options...)
 	return
 }
 
 // GuildTemplate returns a GuildTemplate for the given code
 // templateCode: The Code of a GuildTemplate
-func (s *Session) GuildTemplate(templateCode string) (st *GuildTemplate, err error) {
+func (s *Session) GuildTemplate(templateCode string, options ...RequestOption) (st *GuildTemplate, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildTemplate(templateCode), nil, EndpointGuildTemplate(templateCode))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildTemplate(templateCode), nil, EndpointGuildTemplate(templateCode), options...)
 	if err != nil {
 		return
 	}
@@ -1467,14 +1478,14 @@ func (s *Session) GuildTemplate(templateCode string) (st *GuildTemplate, err err
 // templateCode: The Code of a GuildTemplate
 // name: The name of the guild (2-100) characters
 // icon: base64 encoded 128x128 image for the guild icon
-func (s *Session) GuildCreateWithTemplate(templateCode, name, icon string) (st *Guild, err error) {
+func (s *Session) GuildCreateWithTemplate(templateCode, name, icon string, options ...RequestOption) (st *Guild, err error) {
 
 	data := struct {
 		Name string `json:"name"`
 		Icon string `json:"icon"`
 	}{name, icon}
 
-	body, err := s.RequestWithBucketID("POST", EndpointGuildTemplate(templateCode), data, EndpointGuildTemplate(templateCode))
+	body, err := s.RequestWithBucketID("POST", EndpointGuildTemplate(templateCode), data, EndpointGuildTemplate(templateCode), options...)
 	if err != nil {
 		return
 	}
@@ -1485,9 +1496,9 @@ func (s *Session) GuildCreateWithTemplate(templateCode, name, icon string) (st *
 
 // GuildTemplates returns all of GuildTemplates
 // guildID: The ID of the guild
-func (s *Session) GuildTemplates(guildID string) (st []*GuildTemplate, err error) {
+func (s *Session) GuildTemplates(guildID string, options ...RequestOption) (st []*GuildTemplate, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildTemplates(guildID), nil, EndpointGuildTemplates(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildTemplates(guildID), nil, EndpointGuildTemplates(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1499,8 +1510,8 @@ func (s *Session) GuildTemplates(guildID string) (st []*GuildTemplate, err error
 // GuildTemplateCreate creates a template for the guild
 // guildID : The ID of the guild
 // data    : Template metadata
-func (s *Session) GuildTemplateCreate(guildID string, data *GuildTemplateParams) (st *GuildTemplate) {
-	body, err := s.RequestWithBucketID("POST", EndpointGuildTemplates(guildID), data, EndpointGuildTemplates(guildID))
+func (s *Session) GuildTemplateCreate(guildID string, data *GuildTemplateParams, options ...RequestOption) (st *GuildTemplate) {
+	body, err := s.RequestWithBucketID("POST", EndpointGuildTemplates(guildID), data, EndpointGuildTemplates(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -1512,9 +1523,9 @@ func (s *Session) GuildTemplateCreate(guildID string, data *GuildTemplateParams)
 // GuildTemplateSync syncs the template to the guild's current state
 // guildID: The ID of the guild
 // templateCode: The code of the template
-func (s *Session) GuildTemplateSync(guildID, templateCode string) (err error) {
+func (s *Session) GuildTemplateSync(guildID, templateCode string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("PUT", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""), options...)
 	return
 }
 
@@ -1522,9 +1533,9 @@ func (s *Session) GuildTemplateSync(guildID, templateCode string) (err error) {
 // guildID      : The ID of the guild
 // templateCode : The code of the template
 // data         : New template metadata
-func (s *Session) GuildTemplateEdit(guildID, templateCode string, data *GuildTemplateParams) (st *GuildTemplate, err error) {
+func (s *Session) GuildTemplateEdit(guildID, templateCode string, data *GuildTemplateParams, options ...RequestOption) (st *GuildTemplate, err error) {
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointGuildTemplateSync(guildID, templateCode), data, EndpointGuildTemplateSync(guildID, ""))
+	body, err := s.RequestWithBucketID("PATCH", EndpointGuildTemplateSync(guildID, templateCode), data, EndpointGuildTemplateSync(guildID, ""), options...)
 	if err != nil {
 		return
 	}
@@ -1536,9 +1547,9 @@ func (s *Session) GuildTemplateEdit(guildID, templateCode string, data *GuildTem
 // GuildTemplateDelete deletes the template
 // guildID: The ID of the guild
 // templateCode: The code of the template
-func (s *Session) GuildTemplateDelete(guildID, templateCode string) (err error) {
+func (s *Session) GuildTemplateDelete(guildID, templateCode string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""), options...)
 	return
 }
 
@@ -1548,8 +1559,8 @@ func (s *Session) GuildTemplateDelete(guildID, templateCode string) (err error) 
 
 // Channel returns a Channel structure of a specific Channel.
 // channelID  : The ID of the Channel you want returned.
-func (s *Session) Channel(channelID string) (st *Channel, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointChannel(channelID), nil, EndpointChannel(channelID))
+func (s *Session) Channel(channelID string, options ...RequestOption) (st *Channel, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointChannel(channelID), nil, EndpointChannel(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -1561,8 +1572,8 @@ func (s *Session) Channel(channelID string) (st *Channel, err error) {
 // ChannelEdit edits the given channel and returns the updated Channel data.
 // channelID  : The ID of a Channel.
 // data       : New Channel data.
-func (s *Session) ChannelEdit(channelID string, data *ChannelEdit) (st *Channel, err error) {
-	body, err := s.RequestWithBucketID("PATCH", EndpointChannel(channelID), data, EndpointChannel(channelID))
+func (s *Session) ChannelEdit(channelID string, data *ChannelEdit, options ...RequestOption) (st *Channel, err error) {
+	body, err := s.RequestWithBucketID("PATCH", EndpointChannel(channelID), data, EndpointChannel(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -1576,15 +1587,15 @@ func (s *Session) ChannelEdit(channelID string, data *ChannelEdit) (st *Channel,
 // NOTE: deprecated, use ChannelEdit instead
 // channelID     : The ID of a Channel
 // data          : The channel struct to send
-func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit) (st *Channel, err error) {
-	return s.ChannelEdit(channelID, data)
+func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit, options ...RequestOption) (st *Channel, err error) {
+	return s.ChannelEdit(channelID, data, options...)
 }
 
 // ChannelDelete deletes the given channel
 // channelID  : The ID of a Channel
-func (s *Session) ChannelDelete(channelID string) (st *Channel, err error) {
+func (s *Session) ChannelDelete(channelID string, options ...RequestOption) (st *Channel, err error) {
 
-	body, err := s.RequestWithBucketID("DELETE", EndpointChannel(channelID), nil, EndpointChannel(channelID))
+	body, err := s.RequestWithBucketID("DELETE", EndpointChannel(channelID), nil, EndpointChannel(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -1596,9 +1607,9 @@ func (s *Session) ChannelDelete(channelID string) (st *Channel, err error) {
 // ChannelTyping broadcasts to all members that authenticated user is typing in
 // the given channel.
 // channelID  : The ID of a Channel
-func (s *Session) ChannelTyping(channelID string) (err error) {
+func (s *Session) ChannelTyping(channelID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("POST", EndpointChannelTyping(channelID), nil, EndpointChannelTyping(channelID))
+	_, err = s.RequestWithBucketID("POST", EndpointChannelTyping(channelID), nil, EndpointChannelTyping(channelID), options...)
 	return
 }
 
@@ -1609,7 +1620,7 @@ func (s *Session) ChannelTyping(channelID string) (err error) {
 // beforeID  : If provided all messages returned will be before given ID.
 // afterID   : If provided all messages returned will be after given ID.
 // aroundID  : If provided all messages returned will be around given ID.
-func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID, aroundID string) (st []*Message, err error) {
+func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID, aroundID string, options ...RequestOption) (st []*Message, err error) {
 
 	uri := EndpointChannelMessages(channelID)
 
@@ -1630,7 +1641,7 @@ func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID
 		uri += "?" + v.Encode()
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointChannelMessages(channelID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointChannelMessages(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -1642,9 +1653,9 @@ func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID
 // ChannelMessage gets a single message by ID from a given channel.
 // channeld  : The ID of a Channel
 // messageID : the ID of a Message
-func (s *Session) ChannelMessage(channelID, messageID string) (st *Message, err error) {
+func (s *Session) ChannelMessage(channelID, messageID string, options ...RequestOption) (st *Message, err error) {
 
-	response, err := s.RequestWithBucketID("GET", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""))
+	response, err := s.RequestWithBucketID("GET", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""), options...)
 	if err != nil {
 		return
 	}
@@ -1656,10 +1667,10 @@ func (s *Session) ChannelMessage(channelID, messageID string) (st *Message, err 
 // ChannelMessageSend sends a message to the given channel.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSend(channelID string, content string) (*Message, error) {
+func (s *Session) ChannelMessageSend(channelID string, content string, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Content: content,
-	})
+	}, options...)
 }
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
@@ -1667,7 +1678,7 @@ var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 // ChannelMessageSendComplex sends a message to the given channel.
 // channelID : The ID of a Channel.
 // data      : The message struct to send.
-func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend) (st *Message, err error) {
+func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend, options ...RequestOption) (st *Message, err error) {
 	// TODO: Remove this when compatibility is not required.
 	if data.Embed != nil {
 		if data.Embeds == nil {
@@ -1703,9 +1714,9 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 			return st, encodeErr
 		}
 
-		response, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
+		response, err = s.request("POST", endpoint, contentType, body, endpoint, 0, options...)
 	} else {
-		response, err = s.RequestWithBucketID("POST", endpoint, data, endpoint)
+		response, err = s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
 	}
 	if err != nil {
 		return
@@ -1718,48 +1729,48 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend)
 // ChannelMessageSendTTS sends a message to the given channel with Text to Speech.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSendTTS(channelID string, content string) (*Message, error) {
+func (s *Session) ChannelMessageSendTTS(channelID string, content string, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Content: content,
 		TTS:     true,
-	})
+	}, options...)
 }
 
 // ChannelMessageSendEmbed sends a message to the given channel with embedded data.
 // channelID : The ID of a Channel.
 // embed     : The embed data to send.
-func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed) (*Message, error) {
-	return s.ChannelMessageSendEmbeds(channelID, []*MessageEmbed{embed})
+func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed, options ...RequestOption) (*Message, error) {
+	return s.ChannelMessageSendEmbeds(channelID, []*MessageEmbed{embed}, options...)
 }
 
 // ChannelMessageSendEmbeds sends a message to the given channel with multiple embedded data.
 // channelID : The ID of a Channel.
 // embeds    : The embeds data to send.
-func (s *Session) ChannelMessageSendEmbeds(channelID string, embeds []*MessageEmbed) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbeds(channelID string, embeds []*MessageEmbed, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Embeds: embeds,
-	})
+	}, options...)
 }
 
 // ChannelMessageSendReply sends a message to the given channel with reference data.
 // channelID : The ID of a Channel.
 // content   : The message to send.
 // reference : The message reference to send.
-func (s *Session) ChannelMessageSendReply(channelID string, content string, reference *MessageReference) (*Message, error) {
+func (s *Session) ChannelMessageSendReply(channelID string, content string, reference *MessageReference, options ...RequestOption) (*Message, error) {
 	if reference == nil {
 		return nil, fmt.Errorf("reply attempted with nil message reference")
 	}
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Content:   content,
 		Reference: reference,
-	})
+	}, options...)
 }
 
 // ChannelMessageSendEmbedReply sends a message to the given channel with reference data and embedded data.
 // channelID : The ID of a Channel.
 // embed   : The embed data to send.
 // reference : The message reference to send.
-func (s *Session) ChannelMessageSendEmbedReply(channelID string, embed *MessageEmbed, reference *MessageReference) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbedReply(channelID string, embed *MessageEmbed, reference *MessageReference, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendEmbedsReply(channelID, []*MessageEmbed{embed}, reference)
 }
 
@@ -1767,14 +1778,14 @@ func (s *Session) ChannelMessageSendEmbedReply(channelID string, embed *MessageE
 // channelID : The ID of a Channel.
 // embeds    : The embeds data to send.
 // reference : The message reference to send.
-func (s *Session) ChannelMessageSendEmbedsReply(channelID string, embeds []*MessageEmbed, reference *MessageReference) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbedsReply(channelID string, embeds []*MessageEmbed, reference *MessageReference, options ...RequestOption) (*Message, error) {
 	if reference == nil {
 		return nil, fmt.Errorf("reply attempted with nil message reference")
 	}
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Embeds:    embeds,
 		Reference: reference,
-	})
+	}, options...)
 }
 
 // ChannelMessageEdit edits an existing message, replacing it entirely with
@@ -1782,13 +1793,13 @@ func (s *Session) ChannelMessageSendEmbedsReply(channelID string, embeds []*Mess
 // channelID  : The ID of a Channel
 // messageID  : The ID of a Message
 // content    : The contents of the message
-func (s *Session) ChannelMessageEdit(channelID, messageID, content string) (*Message, error) {
-	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetContent(content))
+func (s *Session) ChannelMessageEdit(channelID, messageID, content string, options ...RequestOption) (*Message, error) {
+	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetContent(content), options...)
 }
 
 // ChannelMessageEditComplex edits an existing message, replacing it entirely with
 // the given MessageEdit struct
-func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err error) {
+func (s *Session) ChannelMessageEditComplex(m *MessageEdit, options ...RequestOption) (st *Message, err error) {
 	// TODO: Remove this when compatibility is not required.
 	if m.Embed != nil {
 		if m.Embeds == nil {
@@ -1813,9 +1824,9 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err er
 		if encodeErr != nil {
 			return st, encodeErr
 		}
-		response, err = s.request("PATCH", endpoint, contentType, body, EndpointChannelMessage(m.Channel, ""), 0)
+		response, err = s.request("PATCH", endpoint, contentType, body, EndpointChannelMessage(m.Channel, ""), 0, options...)
 	} else {
-		response, err = s.RequestWithBucketID("PATCH", endpoint, m, EndpointChannelMessage(m.Channel, ""))
+		response, err = s.RequestWithBucketID("PATCH", endpoint, m, EndpointChannelMessage(m.Channel, ""), options...)
 	}
 	if err != nil {
 		return
@@ -1829,22 +1840,22 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit) (st *Message, err er
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
 // embed     : The embed data to send
-func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed) (*Message, error) {
-	return s.ChannelMessageEditEmbeds(channelID, messageID, []*MessageEmbed{embed})
+func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed, options ...RequestOption) (*Message, error) {
+	return s.ChannelMessageEditEmbeds(channelID, messageID, []*MessageEmbed{embed}, options...)
 }
 
 // ChannelMessageEditEmbeds edits an existing message with multiple embedded data.
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
 // embeds    : The embeds data to send
-func (s *Session) ChannelMessageEditEmbeds(channelID, messageID string, embeds []*MessageEmbed) (*Message, error) {
-	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetEmbeds(embeds))
+func (s *Session) ChannelMessageEditEmbeds(channelID, messageID string, embeds []*MessageEmbed, options ...RequestOption) (*Message, error) {
+	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetEmbeds(embeds), options...)
 }
 
 // ChannelMessageDelete deletes a message from the Channel.
-func (s *Session) ChannelMessageDelete(channelID, messageID string) (err error) {
+func (s *Session) ChannelMessageDelete(channelID, messageID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""), options...)
 	return
 }
 
@@ -1853,7 +1864,7 @@ func (s *Session) ChannelMessageDelete(channelID, messageID string) (err error) 
 // If the slice is empty do nothing.
 // channelID : The ID of the channel for the messages to delete.
 // messages  : The IDs of the messages to be deleted. A slice of string IDs. A maximum of 100 messages.
-func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string) (err error) {
+func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string, options ...RequestOption) (err error) {
 
 	if len(messages) == 0 {
 		return
@@ -1872,34 +1883,34 @@ func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string)
 		Messages []string `json:"messages"`
 	}{messages}
 
-	_, err = s.RequestWithBucketID("POST", EndpointChannelMessagesBulkDelete(channelID), data, EndpointChannelMessagesBulkDelete(channelID))
+	_, err = s.RequestWithBucketID("POST", EndpointChannelMessagesBulkDelete(channelID), data, EndpointChannelMessagesBulkDelete(channelID), options...)
 	return
 }
 
 // ChannelMessagePin pins a message within a given channel.
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
-func (s *Session) ChannelMessagePin(channelID, messageID string) (err error) {
+func (s *Session) ChannelMessagePin(channelID, messageID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("PUT", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""), options...)
 	return
 }
 
 // ChannelMessageUnpin unpins a message within a given channel.
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
-func (s *Session) ChannelMessageUnpin(channelID, messageID string) (err error) {
+func (s *Session) ChannelMessageUnpin(channelID, messageID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""), options...)
 	return
 }
 
 // ChannelMessagesPinned returns an array of Message structures for pinned messages
 // within a given channel
 // channelID : The ID of a Channel.
-func (s *Session) ChannelMessagesPinned(channelID string) (st []*Message, err error) {
+func (s *Session) ChannelMessagesPinned(channelID string, options ...RequestOption) (st []*Message, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointChannelMessagesPins(channelID), nil, EndpointChannelMessagesPins(channelID))
+	body, err := s.RequestWithBucketID("GET", EndpointChannelMessagesPins(channelID), nil, EndpointChannelMessagesPins(channelID), options...)
 
 	if err != nil {
 		return
@@ -1913,8 +1924,8 @@ func (s *Session) ChannelMessagesPinned(channelID string) (st []*Message, err er
 // channelID : The ID of a Channel.
 // name: The name of the file.
 // io.Reader : A reader for the file contents.
-func (s *Session) ChannelFileSend(channelID, name string, r io.Reader) (*Message, error) {
-	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}})
+func (s *Session) ChannelFileSend(channelID, name string, r io.Reader, options ...RequestOption) (*Message, error) {
+	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}}, options...)
 }
 
 // ChannelFileSendWithMessage sends a file to the given channel with an message.
@@ -1923,15 +1934,15 @@ func (s *Session) ChannelFileSend(channelID, name string, r io.Reader) (*Message
 // content: Optional Message content.
 // name: The name of the file.
 // io.Reader : A reader for the file contents.
-func (s *Session) ChannelFileSendWithMessage(channelID, content string, name string, r io.Reader) (*Message, error) {
-	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}, Content: content})
+func (s *Session) ChannelFileSendWithMessage(channelID, content string, name string, r io.Reader, options ...RequestOption) (*Message, error) {
+	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}, Content: content}, options...)
 }
 
 // ChannelInvites returns an array of Invite structures for the given channel
 // channelID   : The ID of a Channel
-func (s *Session) ChannelInvites(channelID string) (st []*Invite, err error) {
+func (s *Session) ChannelInvites(channelID string, options ...RequestOption) (st []*Invite, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointChannelInvites(channelID), nil, EndpointChannelInvites(channelID))
+	body, err := s.RequestWithBucketID("GET", EndpointChannelInvites(channelID), nil, EndpointChannelInvites(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -1943,7 +1954,7 @@ func (s *Session) ChannelInvites(channelID string) (st []*Invite, err error) {
 // ChannelInviteCreate creates a new invite for the given channel.
 // channelID   : The ID of a Channel
 // i           : An Invite struct with the values MaxAge, MaxUses and Temporary defined.
-func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, err error) {
+func (s *Session) ChannelInviteCreate(channelID string, i Invite, options ...RequestOption) (st *Invite, err error) {
 
 	data := struct {
 		MaxAge    int  `json:"max_age"`
@@ -1952,7 +1963,7 @@ func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, e
 		Unique    bool `json:"unique"`
 	}{i.MaxAge, i.MaxUses, i.Temporary, i.Unique}
 
-	body, err := s.RequestWithBucketID("POST", EndpointChannelInvites(channelID), data, EndpointChannelInvites(channelID))
+	body, err := s.RequestWithBucketID("POST", EndpointChannelInvites(channelID), data, EndpointChannelInvites(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -1964,7 +1975,7 @@ func (s *Session) ChannelInviteCreate(channelID string, i Invite) (st *Invite, e
 // ChannelPermissionSet creates a Permission Override for the given channel.
 // NOTE: This func name may changed.  Using Set instead of Create because
 // you can both create a new override or update an override with this function.
-func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType PermissionOverwriteType, allow, deny int64) (err error) {
+func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType PermissionOverwriteType, allow, deny int64, options ...RequestOption) (err error) {
 
 	data := struct {
 		ID    string                  `json:"id"`
@@ -1973,15 +1984,15 @@ func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType Pe
 		Deny  int64                   `json:"deny,string"`
 	}{targetID, targetType, allow, deny}
 
-	_, err = s.RequestWithBucketID("PUT", EndpointChannelPermission(channelID, targetID), data, EndpointChannelPermission(channelID, ""))
+	_, err = s.RequestWithBucketID("PUT", EndpointChannelPermission(channelID, targetID), data, EndpointChannelPermission(channelID, ""), options...)
 	return
 }
 
 // ChannelPermissionDelete deletes a specific permission override for the given channel.
 // NOTE: Name of this func may change.
-func (s *Session) ChannelPermissionDelete(channelID, targetID string) (err error) {
+func (s *Session) ChannelPermissionDelete(channelID, targetID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointChannelPermission(channelID, targetID), nil, EndpointChannelPermission(channelID, ""))
+	_, err = s.RequestWithBucketID("DELETE", EndpointChannelPermission(channelID, targetID), nil, EndpointChannelPermission(channelID, ""), options...)
 	return
 }
 
@@ -1989,11 +2000,11 @@ func (s *Session) ChannelPermissionDelete(channelID, targetID string) (err error
 // of the channel
 // channelID   : The ID of a Channel
 // messageID   : The ID of a Message
-func (s *Session) ChannelMessageCrosspost(channelID, messageID string) (st *Message, err error) {
+func (s *Session) ChannelMessageCrosspost(channelID, messageID string, options ...RequestOption) (st *Message, err error) {
 
 	endpoint := EndpointChannelMessageCrosspost(channelID, messageID)
 
-	body, err := s.RequestWithBucketID("POST", endpoint, nil, endpoint)
+	body, err := s.RequestWithBucketID("POST", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2005,7 +2016,7 @@ func (s *Session) ChannelMessageCrosspost(channelID, messageID string) (st *Mess
 // ChannelNewsFollow follows a news channel in the targetID
 // channelID   : The ID of a News Channel
 // targetID    : The ID of a Channel where the News Channel should post to
-func (s *Session) ChannelNewsFollow(channelID, targetID string) (st *ChannelFollow, err error) {
+func (s *Session) ChannelNewsFollow(channelID, targetID string, options ...RequestOption) (st *ChannelFollow, err error) {
 
 	endpoint := EndpointChannelFollow(channelID)
 
@@ -2013,7 +2024,7 @@ func (s *Session) ChannelNewsFollow(channelID, targetID string) (st *ChannelFoll
 		WebhookChannelID string `json:"webhook_channel_id"`
 	}{targetID}
 
-	body, err := s.RequestWithBucketID("POST", endpoint, data, endpoint)
+	body, err := s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2028,9 +2039,9 @@ func (s *Session) ChannelNewsFollow(channelID, targetID string) (st *ChannelFoll
 
 // Invite returns an Invite structure of the given invite
 // inviteID : The invite code
-func (s *Session) Invite(inviteID string) (st *Invite, err error) {
+func (s *Session) Invite(inviteID string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID), nil, EndpointInvite(""))
+	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID), nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2041,9 +2052,9 @@ func (s *Session) Invite(inviteID string) (st *Invite, err error) {
 
 // InviteWithCounts returns an Invite structure of the given invite including approximate member counts
 // inviteID : The invite code
-func (s *Session) InviteWithCounts(inviteID string) (st *Invite, err error) {
+func (s *Session) InviteWithCounts(inviteID string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID)+"?with_counts=true", nil, EndpointInvite(""))
+	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID)+"?with_counts=true", nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2053,11 +2064,7 @@ func (s *Session) InviteWithCounts(inviteID string) (st *Invite, err error) {
 }
 
 // InviteComplex returns an Invite structure of the given invite including specified fields.
-//  inviteID                  : The invite code
-//  guildScheduledEventID     : If specified, includes specified guild scheduled event.
-//  withCounts                : Whether to include approximate member counts or not
-//  withExpiration            : Whether to include expiration time or not
-func (s *Session) InviteComplex(inviteID, guildScheduledEventID string, withCounts, withExpiration bool) (st *Invite, err error) {
+func (s *Session) InviteComplex(inviteID, guildScheduledEventID string, withCounts, withExpiration bool, options ...RequestOption) (st *Invite, err error) {
 	endpoint := EndpointInvite(inviteID)
 	v := url.Values{}
 	if guildScheduledEventID != "" {
@@ -2074,7 +2081,7 @@ func (s *Session) InviteComplex(inviteID, guildScheduledEventID string, withCoun
 		endpoint += "?" + v.Encode()
 	}
 
-	body, err := s.RequestWithBucketID("GET", endpoint, nil, EndpointInvite(""))
+	body, err := s.RequestWithBucketID("GET", endpoint, nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2085,9 +2092,9 @@ func (s *Session) InviteComplex(inviteID, guildScheduledEventID string, withCoun
 
 // InviteDelete deletes an existing invite
 // inviteID   : the code of an invite
-func (s *Session) InviteDelete(inviteID string) (st *Invite, err error) {
+func (s *Session) InviteDelete(inviteID string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("DELETE", EndpointInvite(inviteID), nil, EndpointInvite(""))
+	body, err := s.RequestWithBucketID("DELETE", EndpointInvite(inviteID), nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2098,9 +2105,9 @@ func (s *Session) InviteDelete(inviteID string) (st *Invite, err error) {
 
 // InviteAccept accepts an Invite to a Guild or Channel
 // inviteID : The invite code
-func (s *Session) InviteAccept(inviteID string) (st *Invite, err error) {
+func (s *Session) InviteAccept(inviteID string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("POST", EndpointInvite(inviteID), nil, EndpointInvite(""))
+	body, err := s.RequestWithBucketID("POST", EndpointInvite(inviteID), nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2114,9 +2121,9 @@ func (s *Session) InviteAccept(inviteID string) (st *Invite, err error) {
 // ------------------------------------------------------------------------------------------------
 
 // VoiceRegions returns the voice server regions
-func (s *Session) VoiceRegions() (st []*VoiceRegion, err error) {
+func (s *Session) VoiceRegions(options ...RequestOption) (st []*VoiceRegion, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointVoiceRegions, nil, EndpointVoiceRegions)
+	body, err := s.RequestWithBucketID("GET", EndpointVoiceRegions, nil, EndpointVoiceRegions, options...)
 	if err != nil {
 		return
 	}
@@ -2130,9 +2137,9 @@ func (s *Session) VoiceRegions() (st []*VoiceRegion, err error) {
 // ------------------------------------------------------------------------------------------------
 
 // Gateway returns the websocket Gateway address
-func (s *Session) Gateway() (gateway string, err error) {
+func (s *Session) Gateway(options ...RequestOption) (gateway string, err error) {
 
-	response, err := s.RequestWithBucketID("GET", EndpointGateway, nil, EndpointGateway)
+	response, err := s.RequestWithBucketID("GET", EndpointGateway, nil, EndpointGateway, options...)
 	if err != nil {
 		return
 	}
@@ -2158,7 +2165,7 @@ func (s *Session) Gateway() (gateway string, err error) {
 }
 
 // GatewayBot returns the websocket Gateway address and the recommended number of shards
-func (s *Session) GatewayBot() (st *GatewayBotResponse, err error) {
+func (s *Session) GatewayBot(options ...RequestOption) (st *GatewayBotResponse, err error) {
 
 	response, err := s.RequestWithBucketID("GET", EndpointGatewayBot, nil, EndpointGatewayBot)
 	if err != nil {
@@ -2185,14 +2192,14 @@ func (s *Session) GatewayBot() (st *GatewayBotResponse, err error) {
 // channelID: The ID of a Channel.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookCreate(channelID, name, avatar string) (st *Webhook, err error) {
+func (s *Session) WebhookCreate(channelID, name, avatar string, options ...RequestOption) (st *Webhook, err error) {
 
 	data := struct {
 		Name   string `json:"name"`
 		Avatar string `json:"avatar,omitempty"`
 	}{name, avatar}
 
-	body, err := s.RequestWithBucketID("POST", EndpointChannelWebhooks(channelID), data, EndpointChannelWebhooks(channelID))
+	body, err := s.RequestWithBucketID("POST", EndpointChannelWebhooks(channelID), data, EndpointChannelWebhooks(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -2204,9 +2211,9 @@ func (s *Session) WebhookCreate(channelID, name, avatar string) (st *Webhook, er
 
 // ChannelWebhooks returns all webhooks for a given channel.
 // channelID: The ID of a channel.
-func (s *Session) ChannelWebhooks(channelID string) (st []*Webhook, err error) {
+func (s *Session) ChannelWebhooks(channelID string, options ...RequestOption) (st []*Webhook, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointChannelWebhooks(channelID), nil, EndpointChannelWebhooks(channelID))
+	body, err := s.RequestWithBucketID("GET", EndpointChannelWebhooks(channelID), nil, EndpointChannelWebhooks(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -2218,9 +2225,9 @@ func (s *Session) ChannelWebhooks(channelID string) (st []*Webhook, err error) {
 
 // GuildWebhooks returns all webhooks for a given guild.
 // guildID: The ID of a Guild.
-func (s *Session) GuildWebhooks(guildID string) (st []*Webhook, err error) {
+func (s *Session) GuildWebhooks(guildID string, options ...RequestOption) (st []*Webhook, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointGuildWebhooks(guildID), nil, EndpointGuildWebhooks(guildID))
+	body, err := s.RequestWithBucketID("GET", EndpointGuildWebhooks(guildID), nil, EndpointGuildWebhooks(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -2232,9 +2239,9 @@ func (s *Session) GuildWebhooks(guildID string) (st []*Webhook, err error) {
 
 // Webhook returns a webhook for a given ID
 // webhookID: The ID of a webhook.
-func (s *Session) Webhook(webhookID string) (st *Webhook, err error) {
+func (s *Session) Webhook(webhookID string, options ...RequestOption) (st *Webhook, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointWebhook(webhookID), nil, EndpointWebhooks)
+	body, err := s.RequestWithBucketID("GET", EndpointWebhook(webhookID), nil, EndpointWebhooks, options...)
 	if err != nil {
 		return
 	}
@@ -2247,9 +2254,9 @@ func (s *Session) Webhook(webhookID string) (st *Webhook, err error) {
 // WebhookWithToken returns a webhook for a given ID
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
-func (s *Session) WebhookWithToken(webhookID, token string) (st *Webhook, err error) {
+func (s *Session) WebhookWithToken(webhookID, token string, options ...RequestOption) (st *Webhook, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""))
+	body, err := s.RequestWithBucketID("GET", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""), options...)
 	if err != nil {
 		return
 	}
@@ -2263,7 +2270,7 @@ func (s *Session) WebhookWithToken(webhookID, token string) (st *Webhook, err er
 // webhookID: The ID of a webhook.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string) (st *Role, err error) {
+func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string, options ...RequestOption) (st *Role, err error) {
 
 	data := struct {
 		Name      string `json:"name,omitempty"`
@@ -2271,7 +2278,7 @@ func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string) (st *Ro
 		ChannelID string `json:"channel_id,omitempty"`
 	}{name, avatar, channelID}
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointWebhook(webhookID), data, EndpointWebhooks)
+	body, err := s.RequestWithBucketID("PATCH", EndpointWebhook(webhookID), data, EndpointWebhooks, options...)
 	if err != nil {
 		return
 	}
@@ -2286,14 +2293,14 @@ func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string) (st *Ro
 // token    : The auth token for the webhook.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string) (st *Role, err error) {
+func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string, options ...RequestOption) (st *Role, err error) {
 
 	data := struct {
 		Name   string `json:"name,omitempty"`
 		Avatar string `json:"avatar,omitempty"`
 	}{name, avatar}
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointWebhookToken(webhookID, token), data, EndpointWebhookToken("", ""))
+	body, err := s.RequestWithBucketID("PATCH", EndpointWebhookToken(webhookID, token), data, EndpointWebhookToken("", ""), options...)
 	if err != nil {
 		return
 	}
@@ -2305,9 +2312,9 @@ func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string) (s
 
 // WebhookDelete deletes a webhook for a given ID
 // webhookID: The ID of a webhook.
-func (s *Session) WebhookDelete(webhookID string) (err error) {
+func (s *Session) WebhookDelete(webhookID string, options ...RequestOption) (err error) {
 
-	_, err = s.RequestWithBucketID("DELETE", EndpointWebhook(webhookID), nil, EndpointWebhooks)
+	_, err = s.RequestWithBucketID("DELETE", EndpointWebhook(webhookID), nil, EndpointWebhooks, options...)
 
 	return
 }
@@ -2315,9 +2322,9 @@ func (s *Session) WebhookDelete(webhookID string) (err error) {
 // WebhookDeleteWithToken deletes a webhook for a given ID with an auth token.
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
-func (s *Session) WebhookDeleteWithToken(webhookID, token string) (st *Webhook, err error) {
+func (s *Session) WebhookDeleteWithToken(webhookID, token string, options ...RequestOption) (st *Webhook, err error) {
 
-	body, err := s.RequestWithBucketID("DELETE", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""))
+	body, err := s.RequestWithBucketID("DELETE", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""), options...)
 	if err != nil {
 		return
 	}
@@ -2327,7 +2334,7 @@ func (s *Session) WebhookDeleteWithToken(webhookID, token string) (st *Webhook, 
 	return
 }
 
-func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID string, data *WebhookParams) (st *Message, err error) {
+func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID string, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
 	uri := EndpointWebhookToken(webhookID, token)
 
 	v := url.Values{}
@@ -2351,7 +2358,7 @@ func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID st
 
 		response, err = s.request("POST", uri, contentType, body, uri, 0)
 	} else {
-		response, err = s.RequestWithBucketID("POST", uri, data, uri)
+		response, err = s.RequestWithBucketID("POST", uri, data, uri, options...)
 	}
 	if !wait || err != nil {
 		return
@@ -2365,8 +2372,8 @@ func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID st
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook
 // wait     : Waits for server confirmation of message send and ensures that the return struct is populated (it is nil otherwise)
-func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *WebhookParams) (st *Message, err error) {
-	return s.webhookExecute(webhookID, token, wait, "", data)
+func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
+	return s.webhookExecute(webhookID, token, wait, "", data, options...)
 }
 
 // WebhookThreadExecute executes a webhook in a thread.
@@ -2374,18 +2381,18 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 // token    : The auth token for the webhook
 // wait     : Waits for server confirmation of message send and ensures that the return struct is populated (it is nil otherwise)
 // threadID :	Sends a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.
-func (s *Session) WebhookThreadExecute(webhookID, token string, wait bool, threadID string, data *WebhookParams) (st *Message, err error) {
-	return s.webhookExecute(webhookID, token, wait, threadID, data)
+func (s *Session) WebhookThreadExecute(webhookID, token string, wait bool, threadID string, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
+	return s.webhookExecute(webhookID, token, wait, threadID, data, options...)
 }
 
 // WebhookMessage gets a webhook message.
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
 // messageID : The ID of message to get
-func (s *Session) WebhookMessage(webhookID, token, messageID string) (message *Message, err error) {
+func (s *Session) WebhookMessage(webhookID, token, messageID string, options ...RequestOption) (message *Message, err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointWebhookToken("", ""))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointWebhookToken("", ""), options...)
 	if err != nil {
 		return
 	}
@@ -2399,7 +2406,7 @@ func (s *Session) WebhookMessage(webhookID, token, messageID string) (message *M
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
 // messageID : The ID of message to edit
-func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *WebhookEdit) (st *Message, err error) {
+func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *WebhookEdit, options ...RequestOption) (st *Message, err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
 	var response []byte
@@ -2409,12 +2416,12 @@ func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *W
 			return nil, err
 		}
 
-		response, err = s.request("PATCH", uri, contentType, body, uri, 0)
+		response, err = s.request("PATCH", uri, contentType, body, uri, 0, options...)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		response, err = s.RequestWithBucketID("PATCH", uri, data, EndpointWebhookToken("", ""))
+		response, err = s.RequestWithBucketID("PATCH", uri, data, EndpointWebhookToken("", ""), options...)
 
 		if err != nil {
 			return nil, err
@@ -2429,10 +2436,10 @@ func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *W
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
 // messageID : The ID of a message to edit
-func (s *Session) WebhookMessageDelete(webhookID, token, messageID string) (err error) {
+func (s *Session) WebhookMessageDelete(webhookID, token, messageID string, options ...RequestOption) (err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
-	_, err = s.RequestWithBucketID("DELETE", uri, nil, EndpointWebhookToken("", ""))
+	_, err = s.RequestWithBucketID("DELETE", uri, nil, EndpointWebhookToken("", ""), options...)
 	return
 }
 
@@ -2440,11 +2447,11 @@ func (s *Session) WebhookMessageDelete(webhookID, token, messageID string) (err 
 // channelID : The channel ID.
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier in name:id format (e.g. "hello:1234567654321")
-func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error {
+func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string, options ...RequestOption) error {
 
 	// emoji such as  #⃣ need to have # escaped
 	emojiID = strings.Replace(emojiID, "#", "%23", -1)
-	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, "", "", ""))
+	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, "", "", ""), options...)
 
 	return err
 }
@@ -2454,11 +2461,11 @@ func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string) error
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
 // userID	 : @me or ID of the user to delete the reaction for.
-func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID string) error {
+func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID string, options ...RequestOption) error {
 
 	// emoji such as  #⃣ need to have # escaped
 	emojiID = strings.Replace(emojiID, "#", "%23", -1)
-	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, userID), nil, EndpointMessageReaction(channelID, "", "", ""))
+	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, userID), nil, EndpointMessageReaction(channelID, "", "", ""), options...)
 
 	return err
 }
@@ -2466,9 +2473,9 @@ func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID st
 // MessageReactionsRemoveAll deletes all reactions from a message
 // channelID : The channel ID
 // messageID : The message ID.
-func (s *Session) MessageReactionsRemoveAll(channelID, messageID string) error {
+func (s *Session) MessageReactionsRemoveAll(channelID, messageID string, options ...RequestOption) error {
 
-	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactionsAll(channelID, messageID), nil, EndpointMessageReactionsAll(channelID, messageID))
+	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactionsAll(channelID, messageID), nil, EndpointMessageReactionsAll(channelID, messageID), options...)
 
 	return err
 }
@@ -2477,11 +2484,11 @@ func (s *Session) MessageReactionsRemoveAll(channelID, messageID string) error {
 // channelID : The channel ID
 // messageID : The message ID
 // emojiID   : The emoji ID
-func (s *Session) MessageReactionsRemoveEmoji(channelID, messageID, emojiID string) error {
+func (s *Session) MessageReactionsRemoveEmoji(channelID, messageID, emojiID string, options ...RequestOption) error {
 
 	// emoji such as  #⃣ need to have # escaped
 	emojiID = strings.Replace(emojiID, "#", "%23", -1)
-	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactions(channelID, messageID, emojiID), nil, EndpointMessageReactions(channelID, messageID, emojiID))
+	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactions(channelID, messageID, emojiID), nil, EndpointMessageReactions(channelID, messageID, emojiID), options...)
 
 	return err
 }
@@ -2493,7 +2500,7 @@ func (s *Session) MessageReactionsRemoveEmoji(channelID, messageID, emojiID stri
 // limit    : max number of users to return (max 100)
 // beforeID  : If provided all reactions returned will be before given ID.
 // afterID   : If provided all reactions returned will be after given ID.
-func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit int, beforeID, afterID string) (st []*User, err error) {
+func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit int, beforeID, afterID string, options ...RequestOption) (st []*User, err error) {
 	// emoji such as  #⃣ need to have # escaped
 	emojiID = strings.Replace(emojiID, "#", "%23", -1)
 	uri := EndpointMessageReactions(channelID, messageID, emojiID)
@@ -2515,7 +2522,7 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 		uri += "?" + v.Encode()
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointMessageReaction(channelID, "", "", ""))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointMessageReaction(channelID, "", "", ""), options...)
 	if err != nil {
 		return
 	}
@@ -2532,10 +2539,10 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 // channelID : Channel to create thread in
 // messageID : Message to start thread from
 // data : Parameters of the thread
-func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *ThreadStart) (ch *Channel, err error) {
+func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *ThreadStart, options ...RequestOption) (ch *Channel, err error) {
 	endpoint := EndpointChannelMessageThread(channelID, messageID)
 	var body []byte
-	body, err = s.RequestWithBucketID("POST", endpoint, data, endpoint)
+	body, err = s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2549,20 +2556,20 @@ func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *T
 // messageID       : Message to start thread from
 // name            : Name of the thread
 // archiveDuration : Auto archive duration (in minutes)
-func (s *Session) MessageThreadStart(channelID, messageID string, name string, archiveDuration int) (ch *Channel, err error) {
+func (s *Session) MessageThreadStart(channelID, messageID string, name string, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
 	return s.MessageThreadStartComplex(channelID, messageID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
-	})
+	}, options...)
 }
 
 // ThreadStartComplex creates a new thread.
 // channelID : Channel to create thread in
 // data : Parameters of the thread
-func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart) (ch *Channel, err error) {
+func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart, options ...RequestOption) (ch *Channel, err error) {
 	endpoint := EndpointChannelThreads(channelID)
 	var body []byte
-	body, err = s.RequestWithBucketID("POST", endpoint, data, endpoint)
+	body, err = s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2575,19 +2582,19 @@ func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart) (ch *C
 // channelID       : Channel to create thread in
 // name            : Name of the thread
 // archiveDuration : Auto archive duration (in minutes)
-func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDuration int) (ch *Channel, err error) {
+func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
 	return s.ThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		Type:                typ,
 		AutoArchiveDuration: archiveDuration,
-	})
+	}, options...)
 }
 
 // ForumThreadStartComplex starts a new thread (creates a post) in a forum channel.
 // channelID   : Channel to create thread in.
 // threadData  : Parameters of the thread.
 // messageData : Parameters of the starting message.
-func (s *Session) ForumThreadStartComplex(channelID string, threadData *ThreadStart, messageData *MessageSend) (th *Channel, err error) {
+func (s *Session) ForumThreadStartComplex(channelID string, threadData *ThreadStart, messageData *MessageSend, options ...RequestOption) (th *Channel, err error) {
 	endpoint := EndpointChannelThreads(channelID)
 
 	// TODO: Remove this when compatibility is not required.
@@ -2629,9 +2636,9 @@ func (s *Session) ForumThreadStartComplex(channelID string, threadData *ThreadSt
 			return th, encodeErr
 		}
 
-		response, err = s.request("POST", endpoint, contentType, body, endpoint, 0)
+		response, err = s.request("POST", endpoint, contentType, body, endpoint, 0, options...)
 	} else {
-		response, err = s.RequestWithBucketID("POST", endpoint, data, endpoint)
+		response, err = s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
 	}
 	if err != nil {
 		return
@@ -2646,11 +2653,11 @@ func (s *Session) ForumThreadStartComplex(channelID string, threadData *ThreadSt
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // content         : Content of the starting message.
-func (s *Session) ForumThreadStart(channelID, name string, archiveDuration int, content string) (th *Channel, err error) {
+func (s *Session) ForumThreadStart(channelID, name string, archiveDuration int, content string, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
-	}, &MessageSend{Content: content})
+	}, &MessageSend{Content: content}, options...)
 }
 
 // ForumThreadStartEmbed starts a new thread (post) in a forum channel.
@@ -2658,11 +2665,11 @@ func (s *Session) ForumThreadStart(channelID, name string, archiveDuration int, 
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // embed           : Embed data of the starting message.
-func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration int, embed *MessageEmbed) (th *Channel, err error) {
+func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration int, embed *MessageEmbed, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
-	}, &MessageSend{Embeds: []*MessageEmbed{embed}})
+	}, &MessageSend{Embeds: []*MessageEmbed{embed}}, options...)
 }
 
 // ForumThreadStartEmbeds starts a new thread (post) in a forum channel.
@@ -2670,46 +2677,46 @@ func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration 
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // embeds          : Embeds data of the starting message.
-func (s *Session) ForumThreadStartEmbeds(channelID, name string, archiveDuration int, embeds []*MessageEmbed) (th *Channel, err error) {
+func (s *Session) ForumThreadStartEmbeds(channelID, name string, archiveDuration int, embeds []*MessageEmbed, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
-	}, &MessageSend{Embeds: embeds})
+	}, &MessageSend{Embeds: embeds}, options...)
 }
 
 // ThreadJoin adds current user to a thread
-func (s *Session) ThreadJoin(id string) error {
+func (s *Session) ThreadJoin(id string, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(id, "@me")
-	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint)
+	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint, options...)
 	return err
 }
 
 // ThreadLeave removes current user to a thread
-func (s *Session) ThreadLeave(id string) error {
+func (s *Session) ThreadLeave(id string, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(id, "@me")
-	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint)
+	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 	return err
 }
 
 // ThreadMemberAdd adds another member to a thread
-func (s *Session) ThreadMemberAdd(threadID, memberID string) error {
+func (s *Session) ThreadMemberAdd(threadID, memberID string, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(threadID, memberID)
-	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint)
+	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint, options...)
 	return err
 }
 
 // ThreadMemberRemove removes another member from a thread
-func (s *Session) ThreadMemberRemove(threadID, memberID string) error {
+func (s *Session) ThreadMemberRemove(threadID, memberID string, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(threadID, memberID)
-	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint)
+	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 	return err
 }
 
 // ThreadMember returns thread member object for the specified member of a thread
-func (s *Session) ThreadMember(threadID, memberID string) (member *ThreadMember, err error) {
+func (s *Session) ThreadMember(threadID, memberID string, options ...RequestOption) (member *ThreadMember, err error) {
 	endpoint := EndpointThreadMember(threadID, memberID)
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 
 	if err != nil {
 		return
@@ -2720,9 +2727,9 @@ func (s *Session) ThreadMember(threadID, memberID string) (member *ThreadMember,
 }
 
 // ThreadMembers returns all members of specified thread.
-func (s *Session) ThreadMembers(threadID string) (members []*ThreadMember, err error) {
+func (s *Session) ThreadMembers(threadID string, options ...RequestOption) (members []*ThreadMember, err error) {
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", EndpointThreadMembers(threadID), nil, EndpointThreadMembers(threadID))
+	body, err = s.RequestWithBucketID("GET", EndpointThreadMembers(threadID), nil, EndpointThreadMembers(threadID), options...)
 
 	if err != nil {
 		return
@@ -2733,9 +2740,9 @@ func (s *Session) ThreadMembers(threadID string) (members []*ThreadMember, err e
 }
 
 // ThreadsActive returns all active threads for specified channel.
-func (s *Session) ThreadsActive(channelID string) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsActive(channelID string, options ...RequestOption) (threads *ThreadsList, err error) {
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", EndpointChannelActiveThreads(channelID), nil, EndpointChannelActiveThreads(channelID))
+	body, err = s.RequestWithBucketID("GET", EndpointChannelActiveThreads(channelID), nil, EndpointChannelActiveThreads(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -2745,9 +2752,9 @@ func (s *Session) ThreadsActive(channelID string) (threads *ThreadsList, err err
 }
 
 // GuildThreadsActive returns all active threads for specified guild.
-func (s *Session) GuildThreadsActive(guildID string) (threads *ThreadsList, err error) {
+func (s *Session) GuildThreadsActive(guildID string, options ...RequestOption) (threads *ThreadsList, err error) {
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", EndpointGuildActiveThreads(guildID), nil, EndpointGuildActiveThreads(guildID))
+	body, err = s.RequestWithBucketID("GET", EndpointGuildActiveThreads(guildID), nil, EndpointGuildActiveThreads(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -2759,7 +2766,7 @@ func (s *Session) GuildThreadsActive(guildID string) (threads *ThreadsList, err 
 // ThreadsArchived returns archived threads for specified channel.
 // before : If specified returns only threads before the timestamp
 // limit  : Optional maximum amount of threads to return.
-func (s *Session) ThreadsArchived(channelID string, before *time.Time, limit int) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsArchived(channelID string, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
 	endpoint := EndpointChannelPublicArchivedThreads(channelID)
 	v := url.Values{}
 	if before != nil {
@@ -2775,7 +2782,7 @@ func (s *Session) ThreadsArchived(channelID string, before *time.Time, limit int
 	}
 
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2787,7 +2794,7 @@ func (s *Session) ThreadsArchived(channelID string, before *time.Time, limit int
 // ThreadsPrivateArchived returns archived private threads for specified channel.
 // before : If specified returns only threads before the timestamp
 // limit  : Optional maximum amount of threads to return.
-func (s *Session) ThreadsPrivateArchived(channelID string, before *time.Time, limit int) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsPrivateArchived(channelID string, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
 	endpoint := EndpointChannelPrivateArchivedThreads(channelID)
 	v := url.Values{}
 	if before != nil {
@@ -2802,7 +2809,7 @@ func (s *Session) ThreadsPrivateArchived(channelID string, before *time.Time, li
 		endpoint += "?" + v.Encode()
 	}
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2814,7 +2821,7 @@ func (s *Session) ThreadsPrivateArchived(channelID string, before *time.Time, li
 // ThreadsPrivateJoinedArchived returns archived joined private threads for specified channel.
 // before : If specified returns only threads before the timestamp
 // limit  : Optional maximum amount of threads to return.
-func (s *Session) ThreadsPrivateJoinedArchived(channelID string, before *time.Time, limit int) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsPrivateJoinedArchived(channelID string, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
 	endpoint := EndpointChannelJoinedPrivateArchivedThreads(channelID)
 	v := url.Values{}
 	if before != nil {
@@ -2829,7 +2836,7 @@ func (s *Session) ThreadsPrivateJoinedArchived(channelID string, before *time.Ti
 		endpoint += "?" + v.Encode()
 	}
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2846,13 +2853,13 @@ func (s *Session) ThreadsPrivateJoinedArchived(channelID string, before *time.Ti
 // appID       : The application ID.
 // guildID     : Guild ID to create guild-specific application command. If empty - creates global application command.
 // cmd         : New application command data.
-func (s *Session) ApplicationCommandCreate(appID string, guildID string, cmd *ApplicationCommand) (ccmd *ApplicationCommand, err error) {
+func (s *Session) ApplicationCommandCreate(appID string, guildID string, cmd *ApplicationCommand, options ...RequestOption) (ccmd *ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommands(appID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommands(appID, guildID)
 	}
 
-	body, err := s.RequestWithBucketID("POST", endpoint, *cmd, endpoint)
+	body, err := s.RequestWithBucketID("POST", endpoint, *cmd, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2867,13 +2874,13 @@ func (s *Session) ApplicationCommandCreate(appID string, guildID string, cmd *Ap
 // cmdID       : Application command ID to edit.
 // guildID     : Guild ID to edit guild-specific application command. If empty - edits global application command.
 // cmd         : Updated application command data.
-func (s *Session) ApplicationCommandEdit(appID, guildID, cmdID string, cmd *ApplicationCommand) (updated *ApplicationCommand, err error) {
+func (s *Session) ApplicationCommandEdit(appID, guildID, cmdID string, cmd *ApplicationCommand, options ...RequestOption) (updated *ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommand(appID, cmdID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommand(appID, guildID, cmdID)
 	}
 
-	body, err := s.RequestWithBucketID("PATCH", endpoint, *cmd, endpoint)
+	body, err := s.RequestWithBucketID("PATCH", endpoint, *cmd, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2886,13 +2893,13 @@ func (s *Session) ApplicationCommandEdit(appID, guildID, cmdID string, cmd *Appl
 // ApplicationCommandBulkOverwrite Creates commands overwriting existing commands. Returns a list of commands.
 // appID    : The application ID.
 // commands : The commands to create.
-func (s *Session) ApplicationCommandBulkOverwrite(appID string, guildID string, commands []*ApplicationCommand) (createdCommands []*ApplicationCommand, err error) {
+func (s *Session) ApplicationCommandBulkOverwrite(appID string, guildID string, commands []*ApplicationCommand, options ...RequestOption) (createdCommands []*ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommands(appID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommands(appID, guildID)
 	}
 
-	body, err := s.RequestWithBucketID("PUT", endpoint, commands, endpoint)
+	body, err := s.RequestWithBucketID("PUT", endpoint, commands, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2906,13 +2913,13 @@ func (s *Session) ApplicationCommandBulkOverwrite(appID string, guildID string, 
 // appID       : The application ID.
 // cmdID       : Application command ID to delete.
 // guildID     : Guild ID to delete guild-specific application command. If empty - deletes global application command.
-func (s *Session) ApplicationCommandDelete(appID, guildID, cmdID string) error {
+func (s *Session) ApplicationCommandDelete(appID, guildID, cmdID string, options ...RequestOption) error {
 	endpoint := EndpointApplicationGlobalCommand(appID, cmdID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommand(appID, guildID, cmdID)
 	}
 
-	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint)
+	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 
 	return err
 }
@@ -2921,13 +2928,13 @@ func (s *Session) ApplicationCommandDelete(appID, guildID, cmdID string) error {
 // appID       : The application ID.
 // cmdID       : Application command ID.
 // guildID     : Guild ID to retrieve guild-specific application command. If empty - retrieves global application command.
-func (s *Session) ApplicationCommand(appID, guildID, cmdID string) (cmd *ApplicationCommand, err error) {
+func (s *Session) ApplicationCommand(appID, guildID, cmdID string, options ...RequestOption) (cmd *ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommand(appID, cmdID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommand(appID, guildID, cmdID)
 	}
 
-	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2940,13 +2947,13 @@ func (s *Session) ApplicationCommand(appID, guildID, cmdID string) (cmd *Applica
 // ApplicationCommands retrieves all commands in application.
 // appID       : The application ID.
 // guildID     : Guild ID to retrieve all guild-specific application commands. If empty - retrieves global application commands.
-func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*ApplicationCommand, err error) {
+func (s *Session) ApplicationCommands(appID, guildID string, options ...RequestOption) (cmd []*ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommands(appID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommands(appID, guildID)
 	}
 
-	body, err := s.RequestWithBucketID("GET", endpoint+"?with_localizations=true", nil, "GET "+endpoint)
+	body, err := s.RequestWithBucketID("GET", endpoint+"?with_localizations=true", nil, "GET "+endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2959,11 +2966,11 @@ func (s *Session) ApplicationCommands(appID, guildID string) (cmd []*Application
 // GuildApplicationCommandsPermissions returns permissions for application commands in a guild.
 // appID       : The application ID
 // guildID     : Guild ID to retrieve application commands permissions for.
-func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string) (permissions []*GuildApplicationCommandPermissions, err error) {
+func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string, options ...RequestOption) (permissions []*GuildApplicationCommandPermissions, err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2976,11 +2983,11 @@ func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string) (pe
 // appID       : The Application ID
 // guildID     : The guild ID containing the application command
 // cmdID       : The command ID to retrieve the permissions of
-func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (permissions *GuildApplicationCommandPermissions, err error) {
+func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string, options ...RequestOption) (permissions *GuildApplicationCommandPermissions, err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -2996,10 +3003,10 @@ func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string) (p
 // permissions : An object containing a list of permissions for the application command
 //
 // NOTE: Requires OAuth2 token with applications.commands.permissions.update scope
-func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string, permissions *ApplicationCommandPermissionsList) (err error) {
+func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string, permissions *ApplicationCommandPermissionsList, options ...RequestOption) (err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
-	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
+	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint, options...)
 	return
 }
 
@@ -3009,17 +3016,17 @@ func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string
 // permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command
 //
 // NOTE: This endpoint has been disabled with updates to command permissions (Permissions v2). Please use ApplicationCommandPermissionsEdit instead.
-func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, permissions []*GuildApplicationCommandPermissions) (err error) {
+func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, permissions []*GuildApplicationCommandPermissions, options ...RequestOption) (err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
-	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint)
+	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint, options...)
 	return
 }
 
 // InteractionRespond creates the response to an interaction.
 // interaction : Interaction instance.
 // resp        : Response message data.
-func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse) error {
+func (s *Session) InteractionRespond(interaction *Interaction, resp *InteractionResponse, options ...RequestOption) error {
 	endpoint := EndpointInteractionResponse(interaction.ID, interaction.Token)
 
 	if resp.Data != nil && len(resp.Data.Files) > 0 {
@@ -3032,29 +3039,29 @@ func (s *Session) InteractionRespond(interaction *Interaction, resp *Interaction
 		return err
 	}
 
-	_, err := s.RequestWithBucketID("POST", endpoint, *resp, endpoint)
+	_, err := s.RequestWithBucketID("POST", endpoint, *resp, endpoint, options...)
 	return err
 }
 
 // InteractionResponse gets the response to an interaction.
 // interaction : Interaction instance.
-func (s *Session) InteractionResponse(interaction *Interaction) (*Message, error) {
-	return s.WebhookMessage(interaction.AppID, interaction.Token, "@original")
+func (s *Session) InteractionResponse(interaction *Interaction, options ...RequestOption) (*Message, error) {
+	return s.WebhookMessage(interaction.AppID, interaction.Token, "@original", options...)
 }
 
 // InteractionResponseEdit edits the response to an interaction.
 // interaction : Interaction instance.
 // newresp     : Updated response message data.
-func (s *Session) InteractionResponseEdit(interaction *Interaction, newresp *WebhookEdit) (*Message, error) {
-	return s.WebhookMessageEdit(interaction.AppID, interaction.Token, "@original", newresp)
+func (s *Session) InteractionResponseEdit(interaction *Interaction, newresp *WebhookEdit, options ...RequestOption) (*Message, error) {
+	return s.WebhookMessageEdit(interaction.AppID, interaction.Token, "@original", newresp, options...)
 }
 
 // InteractionResponseDelete deletes the response to an interaction.
 // interaction : Interaction instance.
-func (s *Session) InteractionResponseDelete(interaction *Interaction) error {
+func (s *Session) InteractionResponseDelete(interaction *Interaction, options ...RequestOption) error {
 	endpoint := EndpointInteractionResponseActions(interaction.AppID, interaction.Token)
 
-	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint)
+	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 
 	return err
 }
@@ -3063,23 +3070,23 @@ func (s *Session) InteractionResponseDelete(interaction *Interaction) error {
 // interaction : Interaction instance.
 // wait        : Waits for server confirmation of message send and ensures that the return struct is populated (it is nil otherwise)
 // data        : Data of the message to send.
-func (s *Session) FollowupMessageCreate(interaction *Interaction, wait bool, data *WebhookParams) (*Message, error) {
-	return s.WebhookExecute(interaction.AppID, interaction.Token, wait, data)
+func (s *Session) FollowupMessageCreate(interaction *Interaction, wait bool, data *WebhookParams, options ...RequestOption) (*Message, error) {
+	return s.WebhookExecute(interaction.AppID, interaction.Token, wait, data, options...)
 }
 
 // FollowupMessageEdit edits a followup message of an interaction.
 // interaction : Interaction instance.
 // messageID   : The followup message ID.
 // data        : Data to update the message
-func (s *Session) FollowupMessageEdit(interaction *Interaction, messageID string, data *WebhookEdit) (*Message, error) {
-	return s.WebhookMessageEdit(interaction.AppID, interaction.Token, messageID, data)
+func (s *Session) FollowupMessageEdit(interaction *Interaction, messageID string, data *WebhookEdit, options ...RequestOption) (*Message, error) {
+	return s.WebhookMessageEdit(interaction.AppID, interaction.Token, messageID, data, options...)
 }
 
 // FollowupMessageDelete deletes a followup message of an interaction.
 // interaction : Interaction instance.
 // messageID   : The followup message ID.
-func (s *Session) FollowupMessageDelete(interaction *Interaction, messageID string) error {
-	return s.WebhookMessageDelete(interaction.AppID, interaction.Token, messageID)
+func (s *Session) FollowupMessageDelete(interaction *Interaction, messageID string, options ...RequestOption) error {
+	return s.WebhookMessageDelete(interaction.AppID, interaction.Token, messageID, options...)
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -3089,8 +3096,8 @@ func (s *Session) FollowupMessageDelete(interaction *Interaction, messageID stri
 // StageInstanceCreate creates and returns a new Stage instance associated to a Stage channel.
 // data : Parameters needed to create a stage instance.
 // data : The data of the Stage instance to create
-func (s *Session) StageInstanceCreate(data *StageInstanceParams) (si *StageInstance, err error) {
-	body, err := s.RequestWithBucketID("POST", EndpointStageInstances, data, EndpointStageInstances)
+func (s *Session) StageInstanceCreate(data *StageInstanceParams, options ...RequestOption) (si *StageInstance, err error) {
+	body, err := s.RequestWithBucketID("POST", EndpointStageInstances, data, EndpointStageInstances, options...)
 	if err != nil {
 		return
 	}
@@ -3101,8 +3108,8 @@ func (s *Session) StageInstanceCreate(data *StageInstanceParams) (si *StageInsta
 
 // StageInstance will retrieve a Stage instance by ID of the Stage channel.
 // channelID : The ID of the Stage channel
-func (s *Session) StageInstance(channelID string) (si *StageInstance, err error) {
-	body, err := s.RequestWithBucketID("GET", EndpointStageInstance(channelID), nil, EndpointStageInstance(channelID))
+func (s *Session) StageInstance(channelID string, options ...RequestOption) (si *StageInstance, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointStageInstance(channelID), nil, EndpointStageInstance(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -3114,9 +3121,9 @@ func (s *Session) StageInstance(channelID string) (si *StageInstance, err error)
 // StageInstanceEdit will edit a Stage instance by ID of the Stage channel.
 // channelID : The ID of the Stage channel
 // data : The data to edit the Stage instance
-func (s *Session) StageInstanceEdit(channelID string, data *StageInstanceParams) (si *StageInstance, err error) {
+func (s *Session) StageInstanceEdit(channelID string, data *StageInstanceParams, options ...RequestOption) (si *StageInstance, err error) {
 
-	body, err := s.RequestWithBucketID("PATCH", EndpointStageInstance(channelID), data, EndpointStageInstance(channelID))
+	body, err := s.RequestWithBucketID("PATCH", EndpointStageInstance(channelID), data, EndpointStageInstance(channelID), options...)
 	if err != nil {
 		return
 	}
@@ -3127,8 +3134,8 @@ func (s *Session) StageInstanceEdit(channelID string, data *StageInstanceParams)
 
 // StageInstanceDelete will delete a Stage instance by ID of the Stage channel.
 // channelID : The ID of the Stage channel
-func (s *Session) StageInstanceDelete(channelID string) (err error) {
-	_, err = s.RequestWithBucketID("DELETE", EndpointStageInstance(channelID), nil, EndpointStageInstance(channelID))
+func (s *Session) StageInstanceDelete(channelID string, options ...RequestOption) (err error) {
+	_, err = s.RequestWithBucketID("DELETE", EndpointStageInstance(channelID), nil, EndpointStageInstance(channelID), options...)
 	return
 }
 
@@ -3139,13 +3146,13 @@ func (s *Session) StageInstanceDelete(channelID string) (err error) {
 // GuildScheduledEvents returns an array of GuildScheduledEvent for a guild
 // guildID        : The ID of a Guild
 // userCount      : Whether to include the user count in the response
-func (s *Session) GuildScheduledEvents(guildID string, userCount bool) (st []*GuildScheduledEvent, err error) {
+func (s *Session) GuildScheduledEvents(guildID string, userCount bool, options ...RequestOption) (st []*GuildScheduledEvent, err error) {
 	uri := EndpointGuildScheduledEvents(guildID)
 	if userCount {
 		uri += "?with_user_count=true"
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildScheduledEvents(guildID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildScheduledEvents(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -3158,13 +3165,13 @@ func (s *Session) GuildScheduledEvents(guildID string, userCount bool) (st []*Gu
 // guildID        : The ID of a Guild
 // eventID        : The ID of the event
 // userCount      : Whether to include the user count in the response
-func (s *Session) GuildScheduledEvent(guildID, eventID string, userCount bool) (st *GuildScheduledEvent, err error) {
+func (s *Session) GuildScheduledEvent(guildID, eventID string, userCount bool, options ...RequestOption) (st *GuildScheduledEvent, err error) {
 	uri := EndpointGuildScheduledEvent(guildID, eventID)
 	if userCount {
 		uri += "?with_user_count=true"
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildScheduledEvent(guildID, eventID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildScheduledEvent(guildID, eventID), options...)
 	if err != nil {
 		return
 	}
@@ -3176,8 +3183,8 @@ func (s *Session) GuildScheduledEvent(guildID, eventID string, userCount bool) (
 // GuildScheduledEventCreate creates a GuildScheduledEvent for a guild and returns it
 // guildID   : The ID of a Guild
 // eventID   : The ID of the event
-func (s *Session) GuildScheduledEventCreate(guildID string, event *GuildScheduledEventParams) (st *GuildScheduledEvent, err error) {
-	body, err := s.RequestWithBucketID("POST", EndpointGuildScheduledEvents(guildID), event, EndpointGuildScheduledEvents(guildID))
+func (s *Session) GuildScheduledEventCreate(guildID string, event *GuildScheduledEventParams, options ...RequestOption) (st *GuildScheduledEvent, err error) {
+	body, err := s.RequestWithBucketID("POST", EndpointGuildScheduledEvents(guildID), event, EndpointGuildScheduledEvents(guildID), options...)
 	if err != nil {
 		return
 	}
@@ -3189,8 +3196,8 @@ func (s *Session) GuildScheduledEventCreate(guildID string, event *GuildSchedule
 // GuildScheduledEventEdit updates a specific event for a guild and returns it.
 // guildID   : The ID of a Guild
 // eventID   : The ID of the event
-func (s *Session) GuildScheduledEventEdit(guildID, eventID string, event *GuildScheduledEventParams) (st *GuildScheduledEvent, err error) {
-	body, err := s.RequestWithBucketID("PATCH", EndpointGuildScheduledEvent(guildID, eventID), event, EndpointGuildScheduledEvent(guildID, eventID))
+func (s *Session) GuildScheduledEventEdit(guildID, eventID string, event *GuildScheduledEventParams, options ...RequestOption) (st *GuildScheduledEvent, err error) {
+	body, err := s.RequestWithBucketID("PATCH", EndpointGuildScheduledEvent(guildID, eventID), event, EndpointGuildScheduledEvent(guildID, eventID), options...)
 	if err != nil {
 		return
 	}
@@ -3202,8 +3209,8 @@ func (s *Session) GuildScheduledEventEdit(guildID, eventID string, event *GuildS
 // GuildScheduledEventDelete deletes a specific GuildScheduledEvent in a guild
 // guildID   : The ID of a Guild
 // eventID   : The ID of the event
-func (s *Session) GuildScheduledEventDelete(guildID, eventID string) (err error) {
-	_, err = s.RequestWithBucketID("DELETE", EndpointGuildScheduledEvent(guildID, eventID), nil, EndpointGuildScheduledEvent(guildID, eventID))
+func (s *Session) GuildScheduledEventDelete(guildID, eventID string, options ...RequestOption) (err error) {
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuildScheduledEvent(guildID, eventID), nil, EndpointGuildScheduledEvent(guildID, eventID), options...)
 	return
 }
 
@@ -3214,7 +3221,7 @@ func (s *Session) GuildScheduledEventDelete(guildID, eventID string) (err error)
 // withMember : Whether to include the member object in the response
 // beforeID   : If is not empty all returned users entries will be before the given ID
 // afterID    : If is not empty all returned users entries will be after the given ID
-func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, withMember bool, beforeID, afterID string) (st []*GuildScheduledEventUser, err error) {
+func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, withMember bool, beforeID, afterID string, options ...RequestOption) (st []*GuildScheduledEventUser, err error) {
 	uri := EndpointGuildScheduledEventUsers(guildID, eventID)
 
 	queryParams := url.Values{}
@@ -3235,7 +3242,7 @@ func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, w
 		uri += "?" + queryParams.Encode()
 	}
 
-	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildScheduledEventUsers(guildID, eventID))
+	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointGuildScheduledEventUsers(guildID, eventID), options...)
 	if err != nil {
 		return
 	}
@@ -3250,11 +3257,11 @@ func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, w
 
 // AutoModerationRules returns a list of auto moderation rules.
 // guildID : ID of the guild
-func (s *Session) AutoModerationRules(guildID string) (st []*AutoModerationRule, err error) {
+func (s *Session) AutoModerationRules(guildID string, options ...RequestOption) (st []*AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRules(guildID)
 
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -3266,11 +3273,11 @@ func (s *Session) AutoModerationRules(guildID string) (st []*AutoModerationRule,
 // AutoModerationRule returns an auto moderation rule.
 // guildID : ID of the guild
 // ruleID  : ID of the auto moderation rule
-func (s *Session) AutoModerationRule(guildID, ruleID string) (st *AutoModerationRule, err error) {
+func (s *Session) AutoModerationRule(guildID, ruleID string, options ...RequestOption) (st *AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRule(guildID, ruleID)
 
 	var body []byte
-	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -3282,11 +3289,11 @@ func (s *Session) AutoModerationRule(guildID, ruleID string) (st *AutoModeration
 // AutoModerationRuleCreate creates an auto moderation rule with the given data and returns it.
 // guildID : ID of the guild
 // rule    : Rule data
-func (s *Session) AutoModerationRuleCreate(guildID string, rule *AutoModerationRule) (st *AutoModerationRule, err error) {
+func (s *Session) AutoModerationRuleCreate(guildID string, rule *AutoModerationRule, options ...RequestOption) (st *AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRules(guildID)
 
 	var body []byte
-	body, err = s.RequestWithBucketID("POST", endpoint, rule, endpoint)
+	body, err = s.RequestWithBucketID("POST", endpoint, rule, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -3299,11 +3306,11 @@ func (s *Session) AutoModerationRuleCreate(guildID string, rule *AutoModerationR
 // guildID : ID of the guild
 // ruleID  : ID of the auto moderation rule
 // rule    : New rule data
-func (s *Session) AutoModerationRuleEdit(guildID, ruleID string, rule *AutoModerationRule) (st *AutoModerationRule, err error) {
+func (s *Session) AutoModerationRuleEdit(guildID, ruleID string, rule *AutoModerationRule, options ...RequestOption) (st *AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRule(guildID, ruleID)
 
 	var body []byte
-	body, err = s.RequestWithBucketID("PATCH", endpoint, rule, endpoint)
+	body, err = s.RequestWithBucketID("PATCH", endpoint, rule, endpoint, options...)
 	if err != nil {
 		return
 	}
@@ -3315,8 +3322,8 @@ func (s *Session) AutoModerationRuleEdit(guildID, ruleID string, rule *AutoModer
 // AutoModerationRuleDelete deletes an auto moderation rule.
 // guildID : ID of the guild
 // ruleID  : ID of the auto moderation rule
-func (s *Session) AutoModerationRuleDelete(guildID, ruleID string) (err error) {
+func (s *Session) AutoModerationRuleDelete(guildID, ruleID string, options ...RequestOption) (err error) {
 	endpoint := EndpointGuildAutoModerationRule(guildID, ruleID)
-	_, err = s.RequestWithBucketID("DELETE", endpoint, nil, endpoint)
+	_, err = s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 	return
 }

--- a/restapi.go
+++ b/restapi.go
@@ -94,7 +94,7 @@ func (e RateLimitError) Error() string {
 	return "Rate limit exceeded on " + e.URL + ", retry after " + e.RetryAfter.String()
 }
 
-// RequestConfig represents configuration for a HTTP request.
+// RequestConfig is an HTTP request configuration.
 type RequestConfig struct {
 	Request                *http.Request
 	ShouldRetryOnRateLimit bool
@@ -111,11 +111,11 @@ func requestConfig(s *Session, req *http.Request) *RequestConfig {
 	}
 }
 
-// RequestOption represents a function which mutates the request config.
+// RequestOption is a function which mutates request configuration.
 // It can be supplied as an argument to any REST method.
 type RequestOption func(cfg *RequestConfig)
 
-// WithClient uses a custom HTTP client for the request.
+// WithClient changes the HTTP client used for the request.
 func WithClient(client *http.Client) RequestOption {
 	return func(cfg *RequestConfig) {
 		if client != nil {
@@ -145,17 +145,17 @@ func WithHeader(key, value string) RequestOption {
 	}
 }
 
-// WithAuditLogReason changes the request reason displayed in the audit log.
+// WithAuditLogReason changes audit log reason associated with the request.
 func WithAuditLogReason(reason string) RequestOption {
 	return WithHeader("X-Audit-Log-Reason", reason)
 }
 
-// WithLocale changes accepted locale for the request.
+// WithLocale changes accepted locale of the request.
 func WithLocale(locale Locale) RequestOption {
 	return WithHeader("X-Discord-Locale", string(locale))
 }
 
-// WithContext changes request context.
+// WithContext changes context of the request.
 func WithContext(ctx context.Context) RequestOption {
 	return func(cfg *RequestConfig) {
 		cfg.Request = cfg.Request.WithContext(ctx)

--- a/restapi.go
+++ b/restapi.go
@@ -26,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"context"
 )
 
 // All error constants
@@ -124,6 +126,12 @@ func WithRetryOnRatelimit(retry bool) RequestOption {
 	}
 }
 
+func WithRestRetries(max int) RequestOption {
+	return func(cfg *RequestConfig) {
+		cfg.MaxRestRetries = max
+	}
+}
+
 func WithHeader(key, value string) RequestOption {
 	return func(cfg *RequestConfig) {
 		cfg.Request.Header.Set(key, value)
@@ -136,6 +144,12 @@ func WithAuditLogReason(reason string) RequestOption {
 
 func WithLocale(locale Locale) RequestOption {
 	return WithHeader("X-Discord-Locale", string(locale))
+}
+
+func WithContext(ctx context.Context) RequestOption {
+	return func(cfg *RequestConfig) {
+		cfg.Request = cfg.Request.WithContext(ctx)
+	}
 }
 
 // Request is the same as RequestWithBucketID but the bucket id is the same as the urlStr

--- a/restapi.go
+++ b/restapi.go
@@ -2056,6 +2056,10 @@ func (s *Session) InviteWithCounts(inviteID string, options ...RequestOption) (s
 }
 
 // InviteComplex returns an Invite structure of the given invite including specified fields.
+// inviteID                  : The invite code
+// guildScheduledEventID     : If specified, includes specified guild scheduled event.
+// withCounts                : Whether to include approximate member counts or not
+// withExpiration            : Whether to include expiration time or not
 func (s *Session) InviteComplex(inviteID, guildScheduledEventID string, withCounts, withExpiration bool, options ...RequestOption) (st *Invite, err error) {
 	endpoint := EndpointInvite(inviteID)
 	v := url.Values{}

--- a/restapi.go
+++ b/restapi.go
@@ -690,11 +690,10 @@ func (s *Session) GuildLeave(guildID string, options ...RequestOption) (err erro
 }
 
 // GuildBans returns an array of GuildBan structures for bans in the given guild.
-//
-//	guildID   : The ID of a Guild
-//	limit     : Max number of bans to return (max 1000)
-//	beforeID  : If not empty all returned users will be after the given id
-//	afterID   : If not empty all returned users will be before the given id
+// guildID   : The ID of a Guild
+// limit     : Max number of bans to return (max 1000)
+// beforeID  : If not empty all returned users will be after the given id
+// afterID   : If not empty all returned users will be before the given id
 func (s *Session) GuildBans(guildID string, limit int, beforeID, afterID string, options ...RequestOption) (st []*GuildBan, err error) {
 	uri := EndpointGuildBans(guildID)
 
@@ -779,10 +778,9 @@ func (s *Session) GuildBanDelete(guildID, userID string, options ...RequestOptio
 }
 
 // GuildMembers returns a list of members for a guild.
-//
-//	guildID  : The ID of a Guild.
-//	after    : The id of the member to return members after
-//	limit    : max number of members to return (max 1000)
+// guildID  : The ID of a Guild.
+// after    : The id of the member to return members after
+// limit    : max number of members to return (max 1000)
 func (s *Session) GuildMembers(guildID string, after string, limit int, options ...RequestOption) (st []*Member, err error) {
 
 	uri := EndpointGuildMembers(guildID)
@@ -834,9 +832,8 @@ func (s *Session) GuildMembersSearch(guildID, query string, limit int, options .
 }
 
 // GuildMember returns a member of a guild.
-//
-//	guildID   : The ID of a Guild.
-//	userID    : The ID of a User
+// guildID   : The ID of a Guild.
+// userID    : The ID of a User
 func (s *Session) GuildMember(guildID, userID string, options ...RequestOption) (st *Member, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildMember(guildID, userID), nil, EndpointGuildMember(guildID, ""), options...)
@@ -851,10 +848,9 @@ func (s *Session) GuildMember(guildID, userID string, options ...RequestOption) 
 }
 
 // GuildMemberAdd force joins a user to the guild.
-//
-//	guildID       : The ID of a Guild.
-//	userID        : The ID of a User.
-//	data          : Parameters of the user to add.
+// guildID       : The ID of a Guild.
+// userID        : The ID of a User.
+// data          : Parameters of the user to add.
 func (s *Session) GuildMemberAdd(guildID, userID string, data *GuildMemberAddParams, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
@@ -905,6 +901,7 @@ func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberParam
 
 // GuildMemberEditComplex edits the nickname and roles of a member.
 // NOTE: deprecated, use GuildMemberEdit instead.
+//
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : A GuildMemberEditData struct with the new nickname and roles
@@ -913,10 +910,9 @@ func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemb
 }
 
 // GuildMemberMove moves a guild member from one voice channel to another/none
-//
-//	guildID   : The ID of a Guild.
-//	userID    : The ID of a User.
-//	channelID : The ID of a channel to move user to or nil to remove from voice channel
+// guildID   : The ID of a Guild.
+// userID    : The ID of a User.
+// channelID : The ID of a channel to move user to or nil to remove from voice channel
 //
 // NOTE : I am not entirely set on the name of this function and it may change
 // prior to the final 1.0.0 release of Discordgo
@@ -949,10 +945,9 @@ func (s *Session) GuildMemberNickname(guildID, userID, nickname string, options 
 }
 
 // GuildMemberMute server mutes a guild member
-//
-//	guildID   : The ID of a Guild.
-//	userID    : The ID of a User.
-//	mute    : boolean value for if the user should be muted
+// guildID   : The ID of a Guild.
+// userID    : The ID of a User.
+// mute      : boolean value for if the user should be muted
 func (s *Session) GuildMemberMute(guildID string, userID string, mute bool, options ...RequestOption) (err error) {
 	data := struct {
 		Mute bool `json:"mute"`
@@ -963,11 +958,9 @@ func (s *Session) GuildMemberMute(guildID string, userID string, mute bool, opti
 }
 
 // GuildMemberTimeout times out a guild member
-//
-//	guildID   : The ID of a Guild.
-//	userID    : The ID of a User.
-//	until     : The timestamp for how long a member should be timed out.
-//	            Set to nil to remove timeout.
+// guildID   : The ID of a Guild.
+// userID    : The ID of a User.
+// until     : The timestamp for how long a member should be timed out. Set to nil to remove timeout.
 func (s *Session) GuildMemberTimeout(guildID string, userID string, until *time.Time, options ...RequestOption) (err error) {
 	data := struct {
 		CommunicationDisabledUntil *time.Time `json:"communication_disabled_until"`
@@ -978,10 +971,9 @@ func (s *Session) GuildMemberTimeout(guildID string, userID string, until *time.
 }
 
 // GuildMemberDeafen server deafens a guild member
-//
-//	guildID   : The ID of a Guild.
-//	userID    : The ID of a User.
-//	deaf    : boolean value for if the user should be deafened
+// guildID   : The ID of a Guild.
+// userID    : The ID of a User.
+// deaf      : boolean value for if the user should be deafened
 func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool, options ...RequestOption) (err error) {
 	data := struct {
 		Deaf bool `json:"deaf"`
@@ -992,10 +984,9 @@ func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool, op
 }
 
 // GuildMemberRoleAdd adds the specified role to a given member
-//
-//	guildID   : The ID of a Guild.
-//	userID    : The ID of a User.
-//	roleID 	  : The ID of a Role to be assigned to the user.
+// guildID   : The ID of a Guild.
+// userID    : The ID of a User.
+// roleID    : The ID of a Role to be assigned to the user.
 func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""), options...)
@@ -1004,10 +995,9 @@ func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string, options ...
 }
 
 // GuildMemberRoleRemove removes the specified role to a given member
-//
-//	guildID   : The ID of a Guild.
-//	userID    : The ID of a User.
-//	roleID 	  : The ID of a Role to be removed from the user.
+// guildID   : The ID of a Guild.
+// userID    : The ID of a User.
+// roleID    : The ID of a Role to be removed from the user.
 func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""), options...)

--- a/restapi.go
+++ b/restapi.go
@@ -1763,7 +1763,7 @@ func (s *Session) ChannelMessageSendReply(channelID string, content string, refe
 // embed   : The embed data to send.
 // reference : The message reference to send.
 func (s *Session) ChannelMessageSendEmbedReply(channelID string, embed *MessageEmbed, reference *MessageReference, options ...RequestOption) (*Message, error) {
-	return s.ChannelMessageSendEmbedsReply(channelID, []*MessageEmbed{embed}, reference)
+	return s.ChannelMessageSendEmbedsReply(channelID, []*MessageEmbed{embed}, reference, options...)
 }
 
 // ChannelMessageSendEmbedsReply sends a message to the given channel with reference data and multiple embedded data.

--- a/restapi.go
+++ b/restapi.go
@@ -102,7 +102,8 @@ type RequestConfig struct {
 	Client                 *http.Client
 }
 
-func requestConfig(s *Session, req *http.Request) *RequestConfig {
+// newRequestConfig returns a new HTTP request configuration based on parameters in Session.
+func newRequestConfig(s *Session, req *http.Request) *RequestConfig {
 	return &RequestConfig{
 		ShouldRetryOnRateLimit: s.ShouldRetryOnRateLimit,
 		MaxRestRetries:         s.MaxRestRetries,
@@ -218,7 +219,7 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 	// TODO: Make a configurable static variable.
 	req.Header.Set("User-Agent", s.UserAgent)
 
-	cfg := requestConfig(s, req)
+	cfg := newRequestConfig(s, req)
 	for _, opt := range options {
 		opt(cfg)
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -456,8 +456,9 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string, options ...Req
 }
 
 // UserChannelPermissions returns the permission of a user in a channel.
-// userID    : The ID of the user to calculate permissions for.
-// channelID : The ID of the channel to calculate permission for.
+// userID        : The ID of the user to calculate permissions for.
+// channelID     : The ID of the channel to calculate permission for.
+// fetchOptions  : Options used to fetch guild, member or channel if they are not present in state.
 //
 // NOTE: This function is now deprecated and will be removed in the future.
 // Please see the same function inside state.go


### PR DESCRIPTION
Since the beginning, DiscordGo did not have ability for adding per-call customization:

- What if you want to disable automatic rate limit handling when you call `ChannelMessageDelete`, instead handling the error by yourself?
- Or what if you want to set additional headers on `GuildBanCreate`, like `X-Audit-Log-Reason`, to comment your action in audit log?

We’ve been thinking on how to combat this problem, and came up with the following solutions:

- Builders pattern
    
    ```go
    s.WithAuditLogReason("my reason").GuildBanCreate(...)
    s.WithRetryOnRateLimit(false).ChannelMessageDelete(...)
    ```
    
- Functional options
    
    ```go
    s.GuildBanCreate(..., discordgo.WithAuditLogReason("reason"))
    s.ChannelMessageDelete(..., discordgo.WithRetryOnRateLimit(false))
    ```
    

This PR implements the latter. It provides a few pre-built options. However, you can always supply your custom option.

Options have access to a `RequestConfig` struct, which is internally used by `RequestX` functions. This config allows you to modify a few global settings, like `Client`, `ShouldRetryOnRateLimit` and `MaxRestRetries`, but it also allows you to modify the request directly.

A typical functional option would look like this:

```go
func WithQuery(key string, value string) discordgo.RequestOption {
	return func(cfg *discordgo.RequestConfig) {
		q := cfg.Request.Query()
		q.Add(key, value)
		cfg.Request.RawQuery = q.Encode()
	}
}
```

These are built-in options discordgo will provide:

- [x]  `WithClient` - Control `http.Client` used for the request (defaults to `s.Client`)
- [x]  `WithHeader` - Change a certain header in the request
    - [x]  `WithAuditLogReason` - Set `X-Audit-Log-Reason` header
    - [x]  `WithLocale` - Set `X-Discord-Locale` header
- [x]  `WithRetryOnRateLimit` - Control `Session.ShouldRetryOnRateLimit` field for the request
- [x]  `WithMaxRestRetries` - Control `Session.MaxRestRetries` field for the request
- [x]  `WithContext` - Provide a `context.Context` to the `http.Request`

This change will be affecting all of the REST endpoints. However it should be non-breaking.

If you have used any function signatures though, you would need to change them accordingly:

```diff
- func (s *Session) XXX(...) (...) {}
+ func (s *Session) XXX(..., options ...RequestOption) (...) {}
```