### PR TITLE
Provide previous Member state for GuildMemberUpdate events

### DIFF
--- a/events.go
+++ b/events.go
@@ -150,6 +150,7 @@ type GuildMemberAdd struct {
 // GuildMemberUpdate is the data for a GuildMemberUpdate event.
 type GuildMemberUpdate struct {
 	*Member
+	BeforeUpdate *Member `json:"-"`
 }
 
 // GuildMemberRemove is the data for a GuildMemberRemove event.

--- a/state.go
+++ b/state.go
@@ -983,6 +983,13 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	case *GuildMemberUpdate:
 		if s.TrackMembers {
+			var old *Member
+			old, err = s.Member(t.GuildID, t.User.ID)
+			if err == nil {
+				oldCopy := *old
+				t.BeforeUpdate = &oldCopy
+			}
+
 			err = s.MemberAdd(t.Member)
 		}
 	case *GuildMemberRemove:


### PR DESCRIPTION
Hey! I'm currently using this package in a personal project and wanted to track member role changes.
Since the old state of the Member is currently not part of the GuildMemberUpdate, I've simply added it similar to how it was done for other events like ThreadUpdate or MessageUpdate.

Fixes #1200 