### PR TITLE
Automod trigger metadata update

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1449,7 +1449,7 @@ type AutoModerationTriggerMetadata struct {
 
 	// Substrings which should not trigger the rule.
 	// NOTE: should be only used with keyword or keyword preset trigger type.
-	AllowList []string `json:"allow_list,omitempty"`
+	AllowList []*string `json:"allow_list,omitempty"`
 
 	// Total number of unique role and user mentions allowed per message.
 	// NOTE: should be only used with mention spam trigger type.

--- a/structs.go
+++ b/structs.go
@@ -1149,7 +1149,7 @@ type GuildParams struct {
 	PreferredLocale             Locale             `json:"preferred_locale,omitempty"`
 	Features                    []GuildFeature     `json:"features,omitempty"`
 	Description                 string             `json:"description,omitempty"`
-	PremiumProgressBarEnabled   bool               `json:"premium_progress_bar_enabled,omitempty"`
+	PremiumProgressBarEnabled   *bool              `json:"premium_progress_bar_enabled,omitempty"`
 }
 
 // A Role stores information about Discord guild member roles.

--- a/structs.go
+++ b/structs.go
@@ -1449,7 +1449,7 @@ type AutoModerationTriggerMetadata struct {
 
 	// Substrings which should not trigger the rule.
 	// NOTE: should be only used with keyword or keyword preset trigger type.
-	AllowList []*string `json:"allow_list,omitempty"`
+	AllowList *[]string `json:"allow_list,omitempty"`
 
 	// Total number of unique role and user mentions allowed per message.
 	// NOTE: should be only used with mention spam trigger type.

--- a/structs.go
+++ b/structs.go
@@ -1446,6 +1446,14 @@ type AutoModerationTriggerMetadata struct {
 	// Internally pre-defined wordsets which will be searched for in content.
 	// NOTE: should be only used with keyword preset trigger type.
 	Presets []AutoModerationKeywordPreset `json:"presets,omitempty"`
+
+	// Substrings which should not trigger the rule.
+	// NOTE: should be only used with keyword or keyword preset trigger type.
+	AllowList []string `json:"allow_list,omitempty"`
+
+	// Total number of unique role and user mentions allowed per message.
+	// NOTE: should be only used with mention spam trigger type.
+	MentionTotalLimit int `json:"mention_total_limit,omitempty"`
 }
 
 // AutoModerationActionType represents an action which will execute whenever a rule is triggered.


### PR DESCRIPTION
Add AllowList and MentionTotalLimit to AutoMod as shown in docs below.
https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata