### PR TITLE
Add Forum settings to Channel struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -270,10 +270,9 @@ const (
 	ChannelFlagRequireTag ChannelFlags = 1 << 4
 )
 
-// ForumSortOrderType represent sort order type of a forum channel.
+// ForumSortOrderType represents sort order of a forum channel.
 type ForumSortOrderType int
 
-// Block contains known ForumSortOrderType values.
 const (
 	// ForumSortOrderLatestActivity sorts posts by activity.
 	ForumSortOrderLatestActivity ForumSortOrderType = 0
@@ -281,10 +280,9 @@ const (
 	ForumSortOrderCreationDate ForumSortOrderType = 1
 )
 
-// ForumLayout represent layout of a forum channel.
+// ForumLayout represents layout of a forum channel.
 type ForumLayout int
 
-// Block contains known ForumLayout values.
 const (
 	// ForumLayoutNotSet represents no default layout.
 	ForumLayoutNotSet ForumLayout = 0

--- a/structs.go
+++ b/structs.go
@@ -270,6 +270,30 @@ const (
 	ChannelFlagRequireTag ChannelFlags = 1 << 4
 )
 
+// SortOrderType represent type of a forum channel.
+type SortOrderType int
+
+// Block contains known SortOrderType values.
+const (
+	// 	Sort forum posts by activity
+	LatestActivity SortOrderType = 0
+	// Sort forum posts by creation time (from most recent to oldest)
+	CreationDate SortOrderType = 1
+)
+
+// ForumLayout represent layout of a forum channel.
+type ForumLayout int
+
+// Block contains known ForumLayout values.
+const (
+	// No default has been set for forum channel
+	NotSet ForumLayout = 0
+	// Display posts as a list
+	ListView ForumLayout = 1
+	//Display posts as a collection of tiles
+	GalleryView ForumLayout = 2
+)
+
 // A Channel holds all data related to an individual Discord channel.
 type Channel struct {
 	// The ID of the channel.
@@ -358,6 +382,18 @@ type Channel struct {
 
 	// Emoji to use as the default reaction to a forum post.
 	DefaultReactionEmoji ForumDefaultReaction `json:"default_reaction_emoji"`
+
+	// The initial RateLimitPerUser to set on newly created threads in a channel.
+	// This field is copied to the thread at creation time and does not live update.
+	DefaultRateLimitPerUser int `json:"default_rate_limit_per_user"`
+
+	// The default sort order type used to order posts in forum channels.
+	// Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin.
+	DefaultSortOrder SortOrderType `json:"default_sort_order"`
+
+	// the default forum layout view used to display posts in forum channels.
+	// Defaults to 0, which indicates a layout view has not been set by a channel admin.
+	DefaultForumLayout ForumLayout `json:"default_forum_layout"`
 }
 
 // Mention returns a string which mentions the channel

--- a/structs.go
+++ b/structs.go
@@ -275,9 +275,9 @@ type ForumSortOrderType int
 
 // Block contains known ForumSortOrderType values.
 const (
-	// 	Sort forum posts by activity
+	// ForumSortOrderLatestActivity sorts posts by activity.
 	ForumSortOrderLatestActivity ForumSortOrderType = 0
-	// Sort forum posts by creation time (from most recent to oldest)
+	// ForumSortOrderCreationDate sorts posts by creation time (from most recent to oldest).
 	ForumSortOrderCreationDate ForumSortOrderType = 1
 )
 
@@ -286,11 +286,11 @@ type ForumLayout int
 
 // Block contains known ForumLayout values.
 const (
-	// No default has been set for forum channel
+	// ForumLayoutNotSet represents no default layout.
 	ForumLayoutNotSet ForumLayout = 0
-	// Display posts as a list
+	// ForumLayoutListView displays forum posts as a list.
 	ForumLayoutListView ForumLayout = 1
-	//Display posts as a collection of tiles
+	// ForumLayoutGalleryView displays forum posts as a collection of tiles.
 	ForumLayoutGalleryView ForumLayout = 2
 )
 
@@ -392,7 +392,7 @@ type Channel struct {
 	DefaultSortOrder *ForumSortOrderType `json:"default_sort_order"`
 
 	// The default forum layout view used to display posts in forum channels.
-	// Defaults to 0, which indicates a layout view has not been set by a channel admin.
+	// Defaults to ForumLayoutNotSet, which indicates a layout view has not been set by a channel admin.
 	DefaultForumLayout ForumLayout `json:"default_forum_layout"`
 }
 
@@ -418,7 +418,7 @@ type ChannelEdit struct {
 	ParentID                      string                 `json:"parent_id,omitempty"`
 	RateLimitPerUser              *int                   `json:"rate_limit_per_user,omitempty"`
 	Flags                         *ChannelFlags          `json:"flags,omitempty"`
-	DefaultThreadRateLimitPerUser int                    `json:"default_thread_rate_limit_per_user,omitempty"`
+	DefaultThreadRateLimitPerUser *int                   `json:"default_thread_rate_limit_per_user,omitempty"`
 
 	// NOTE: threads only
 
@@ -431,8 +431,8 @@ type ChannelEdit struct {
 
 	AvailableTags        *[]ForumTag           `json:"available_tags,omitempty"`
 	DefaultReactionEmoji *ForumDefaultReaction `json:"default_reaction_emoji,omitempty"`
-	DefaultSortOrder     *ForumSortOrderType   `json:"default_sort_order,omitempty"`
-	DefaultForumLayout   ForumLayout           `json:"default_forum_layout,omitempty"`
+	DefaultSortOrder     *ForumSortOrderType   `json:"default_sort_order,omitempty"` // TODO: null
+	DefaultForumLayout   *ForumLayout          `json:"default_forum_layout,omitempty"`
 
 	// NOTE: forum threads only
 	AppliedTags *[]string `json:"applied_tags,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -408,24 +408,24 @@ func (c *Channel) IsThread() bool {
 
 // A ChannelEdit holds Channel Field data for a channel edit.
 type ChannelEdit struct {
-	Name                 string                 `json:"name,omitempty"`
-	Topic                string                 `json:"topic,omitempty"`
-	NSFW                 *bool                  `json:"nsfw,omitempty"`
-	Position             int                    `json:"position"`
-	Bitrate              int                    `json:"bitrate,omitempty"`
-	UserLimit            int                    `json:"user_limit,omitempty"`
-	PermissionOverwrites []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
-	ParentID             string                 `json:"parent_id,omitempty"`
-	RateLimitPerUser     *int                   `json:"rate_limit_per_user,omitempty"`
-	Flags                *ChannelFlags          `json:"flags,omitempty"`
+	Name                          string                 `json:"name,omitempty"`
+	Topic                         string                 `json:"topic,omitempty"`
+	NSFW                          *bool                  `json:"nsfw,omitempty"`
+	Position                      int                    `json:"position"`
+	Bitrate                       int                    `json:"bitrate,omitempty"`
+	UserLimit                     int                    `json:"user_limit,omitempty"`
+	PermissionOverwrites          []*PermissionOverwrite `json:"permission_overwrites,omitempty"`
+	ParentID                      string                 `json:"parent_id,omitempty"`
+	RateLimitPerUser              *int                   `json:"rate_limit_per_user,omitempty"`
+	Flags                         *ChannelFlags          `json:"flags,omitempty"`
+	DefaultThreadRateLimitPerUser int                    `json:"default_thread_rate_limit_per_user,omitempty"`
 
 	// NOTE: threads only
 
-	Archived                *bool `json:"archived,omitempty"`
-	AutoArchiveDuration     int   `json:"auto_archive_duration,omitempty"`
-	Locked                  *bool `json:"locked,omitempty"`
-	Invitable               *bool `json:"invitable,omitempty"`
-	DefaultRateLimitPerUser int   `json:"default_thread_rate_limit_per_user,omitempty"`
+	Archived            *bool `json:"archived,omitempty"`
+	AutoArchiveDuration int   `json:"auto_archive_duration,omitempty"`
+	Locked              *bool `json:"locked,omitempty"`
+	Invitable           *bool `json:"invitable,omitempty"`
 
 	// NOTE: forum channels only
 

--- a/structs.go
+++ b/structs.go
@@ -421,15 +421,18 @@ type ChannelEdit struct {
 
 	// NOTE: threads only
 
-	Archived            *bool `json:"archived,omitempty"`
-	AutoArchiveDuration int   `json:"auto_archive_duration,omitempty"`
-	Locked              *bool `json:"locked,omitempty"`
-	Invitable           *bool `json:"invitable,omitempty"`
+	Archived                *bool `json:"archived,omitempty"`
+	AutoArchiveDuration     int   `json:"auto_archive_duration,omitempty"`
+	Locked                  *bool `json:"locked,omitempty"`
+	Invitable               *bool `json:"invitable,omitempty"`
+	DefaultRateLimitPerUser int   `json:"default_thread_rate_limit_per_user,omitempty"`
 
 	// NOTE: forum channels only
 
 	AvailableTags        *[]ForumTag           `json:"available_tags,omitempty"`
 	DefaultReactionEmoji *ForumDefaultReaction `json:"default_reaction_emoji,omitempty"`
+	DefaultSortOrder     *ForumSortOrderType   `json:"default_sort_order,omitempty"`
+	DefaultForumLayout   ForumLayout           `json:"default_forum_layout,omitempty"`
 
 	// NOTE: forum threads only
 	AppliedTags *[]string `json:"applied_tags,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -1149,7 +1149,7 @@ type GuildParams struct {
 	PreferredLocale             Locale             `json:"preferred_locale,omitempty"`
 	Features                    []GuildFeature     `json:"features,omitempty"`
 	Description                 string             `json:"description,omitempty"`
-	PremiumProgressBarEnabled   bool               `json:"premium_progress_bar_enabled,omitempty"`
+	PremiumProgressBarEnabled   *bool              `json:"premium_progress_bar_enabled,omitempty"`
 }
 
 // A Role stores information about Discord guild member roles.

--- a/structs.go
+++ b/structs.go
@@ -270,15 +270,15 @@ const (
 	ChannelFlagRequireTag ChannelFlags = 1 << 4
 )
 
-// SortOrderType represent type of a forum channel.
-type SortOrderType int
+// ForumSortOrderType represent sort order type of a forum channel.
+type ForumSortOrderType int
 
-// Block contains known SortOrderType values.
+// Block contains known ForumSortOrderType values.
 const (
 	// 	Sort forum posts by activity
-	LatestActivity SortOrderType = 0
+	ForumSortOrderLatestActivity ForumSortOrderType = 0
 	// Sort forum posts by creation time (from most recent to oldest)
-	CreationDate SortOrderType = 1
+	ForumSortOrderCreationDate ForumSortOrderType = 1
 )
 
 // ForumLayout represent layout of a forum channel.
@@ -389,7 +389,7 @@ type Channel struct {
 
 	// The default sort order type used to order posts in forum channels.
 	// Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin.
-	DefaultSortOrder SortOrderType `json:"default_sort_order"`
+	DefaultSortOrder *ForumSortOrderType `json:"default_sort_order"`
 
 	// the default forum layout view used to display posts in forum channels.
 	// Defaults to 0, which indicates a layout view has not been set by a channel admin.

--- a/structs.go
+++ b/structs.go
@@ -385,7 +385,7 @@ type Channel struct {
 
 	// The initial RateLimitPerUser to set on newly created threads in a channel.
 	// This field is copied to the thread at creation time and does not live update.
-	DefaultRateLimitPerUser int `json:"default_rate_limit_per_user"`
+	DefaultRateLimitPerUser int `json:"default_thread_rate_limit_per_user"`
 
 	// The default sort order type used to order posts in forum channels.
 	// Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin.

--- a/structs.go
+++ b/structs.go
@@ -385,7 +385,7 @@ type Channel struct {
 
 	// The initial RateLimitPerUser to set on newly created threads in a channel.
 	// This field is copied to the thread at creation time and does not live update.
-	DefaultRateLimitPerUser int `json:"default_thread_rate_limit_per_user"`
+	DefaultThreadRateLimitPerUser int `json:"default_thread_rate_limit_per_user"`
 
 	// The default sort order type used to order posts in forum channels.
 	// Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin.

--- a/structs.go
+++ b/structs.go
@@ -391,7 +391,7 @@ type Channel struct {
 	// Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin.
 	DefaultSortOrder *ForumSortOrderType `json:"default_sort_order"`
 
-	// the default forum layout view used to display posts in forum channels.
+	// The default forum layout view used to display posts in forum channels.
 	// Defaults to 0, which indicates a layout view has not been set by a channel admin.
 	DefaultForumLayout ForumLayout `json:"default_forum_layout"`
 }

--- a/structs.go
+++ b/structs.go
@@ -287,11 +287,11 @@ type ForumLayout int
 // Block contains known ForumLayout values.
 const (
 	// No default has been set for forum channel
-	NotSet ForumLayout = 0
+	ForumLayoutNotSet ForumLayout = 0
 	// Display posts as a list
-	ListView ForumLayout = 1
+	ForumLayoutListView ForumLayout = 1
 	//Display posts as a collection of tiles
-	GalleryView ForumLayout = 2
+	ForumLayoutGalleryView ForumLayout = 2
 )
 
 // A Channel holds all data related to an individual Discord channel.


### PR DESCRIPTION
Add some settings of forum channel as shown docs.
https://discord.com/developers/docs/change-log#add-default-layout-setting-for-forum-channels
https://discord.com/developers/docs/change-log#default-sort-order-for-forum-channels
https://discord.com/developers/docs/resources/channel#channel-object-channel-structure