### PR TITLE
Resume gateway url

### DIFF
--- a/event.go
+++ b/event.go
@@ -244,4 +244,7 @@ func (s *Session) onReady(r *Ready) {
 
 	// Store the SessionID within the Session struct.
 	s.sessionID = r.SessionID
+
+	// Store the ResumeGatewayURL within the Session struct.
+	s.resumeGatewayURL = r.ResumeGatewayURL
 }

--- a/events.go
+++ b/events.go
@@ -36,13 +36,14 @@ type Event struct {
 
 // A Ready stores all data for the websocket READY event.
 type Ready struct {
-	Version         int          `json:"v"`
-	SessionID       string       `json:"session_id"`
-	User            *User        `json:"user"`
-	Shard           *[2]int      `json:"shard"`
-	Application     *Application `json:"application"`
-	Guilds          []*Guild     `json:"guilds"`
-	PrivateChannels []*Channel   `json:"private_channels"`
+	Version          int          `json:"v"`
+	SessionID        string       `json:"session_id"`
+	User             *User        `json:"user"`
+	Shard            *[2]int      `json:"shard"`
+	ResumeGatewayURL string       `json:"resume_gateway_url"`
+	Application      *Application `json:"application"`
+	Guilds           []*Guild     `json:"guilds"`
+	PrivateChannels  []*Channel   `json:"private_channels"`
 }
 
 // ChannelCreate is the data for a ChannelCreate event.

--- a/structs.go
+++ b/structs.go
@@ -124,7 +124,7 @@ type Session struct {
 	// sequence tracks the current gateway api websocket sequence number
 	sequence *int64
 
-	// stores URL of the gateway for resuming connections
+	// stores sessions current Discord Resume Gateway
 	resumeGatewayURL string
 
 	// stores sessions current Discord Gateway

--- a/structs.go
+++ b/structs.go
@@ -124,6 +124,9 @@ type Session struct {
 	// sequence tracks the current gateway api websocket sequence number
 	sequence *int64
 
+	// stores URL of the gateway for resuming connections
+	resumeGatewayURL string
+
 	// stores sessions current Discord Gateway
 	gateway string
 

--- a/wsapi.go
+++ b/wsapi.go
@@ -591,17 +591,18 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 	// Must respond with a Identify packet.
 	if e.Operation == 9 {
 		var resumable bool
+		s.log(LogInformational, "Closing and reconnecting in response to Op9")
 		if err := json.Unmarshal(e.RawData, &resumable); err != nil {
 			s.log(LogError, "error unmarshalling invalid session event, %s", err)
 			return e, err
 		}
 
 		if !resumable {
+			s.log(LogInformational, "Gateway session is not resumable, discarding its information")
 			s.resumeGatewayURL = ""
 			s.sessionID = ""
 			atomic.StoreInt64(s.sequence, 0)
 		}
-
 		s.reconnect()
 		return e, nil
 	}

--- a/wsapi.go
+++ b/wsapi.go
@@ -63,7 +63,10 @@ func (s *Session) Open() error {
 	}
 
 	// Get the gateway to use for the Websocket connection
-	if s.gateway == "" {
+	if s.resumeGatewayURL != "" {
+		s.log(LogInformational, "resuming on gateway %s", s.resumeGatewayURL)
+		s.gateway = s.resumeGatewayURL + "?v=" + APIVersion + "&encoding=json"
+	} else if s.gateway == "" {
 		s.gateway, err = s.Gateway()
 		if err != nil {
 			return err

--- a/wsapi.go
+++ b/wsapi.go
@@ -590,8 +590,10 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 	// Invalid Session
 	// Must respond with a Identify packet.
 	if e.Operation == 9 {
-		var resumable bool
 		s.log(LogInformational, "Closing and reconnecting in response to Op9")
+		s.CloseWithCode(websocket.CloseServiceRestart)
+
+		var resumable bool
 		if err := json.Unmarshal(e.RawData, &resumable); err != nil {
 			s.log(LogError, "error unmarshalling invalid session event, %s", err)
 			return e, err
@@ -603,6 +605,7 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 			s.sessionID = ""
 			atomic.StoreInt64(s.sequence, 0)
 		}
+
 		s.reconnect()
 		return e, nil
 	}


### PR DESCRIPTION
Implement [`resume_gateway_url`](https://discord.com/developers/docs/change-log#sessionspecific-gateway-resume-urls) functionality for the gateway.