### PR TITLE
Discord API version bump

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -14,7 +14,7 @@ package discordgo
 import "strconv"
 
 // APIVersion is the Discord API version used for the REST and Websocket API.
-var APIVersion = "9"
+var APIVersion = "10"
 
 // Known Discord API Endpoints.
 var (


### PR DESCRIPTION
## Motivation
When trying to register commands using the `ApplicationCommandCreate` function, as done in [the example](https://github.com/bwmarrin/discordgo/blob/master/examples/slash_commands/main.go#L559), I am met with a `405: method not allowed` status code. 

## Solution
When using [this endpoint](https://discord.com/developers/docs/interactions/application-commands#registering-a-command), my commands are registered successfully. The `405` status code comes from the lack of support for discord API v10 (in this pkg).