### PR TITLE
Properly reference previous user when user data is changed and GuildM…

### DIFF
--- a/state.go
+++ b/state.go
@@ -996,6 +996,10 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 			old, err = s.Member(t.GuildID, t.User.ID)
 			if err == nil {
 				oldCopy := *old
+				if oldCopy.User != nil {
+					oldUser := *oldCopy.User
+					oldCopy.User = &oldUser
+				}
 				t.BeforeUpdate = &oldCopy
 			}
 


### PR DESCRIPTION
…emberUpdate is fired with TrackMembers enabled

Minimal implementation for obtaining before/after snapshot of user changes. See additional information and items for consideration in #1318 if a different implementation path is preferred. 

Currently the User changed data is lost as the BeforeUpdate Member copies the pointer to the associated user, leaving both the current Member and BeforeUpdate Member to reference the now updated user properties.

Thank you.