### PR TITLE
Remove returned guild from GuildDelete

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -671,14 +671,9 @@ func (s *Session) GuildEdit(guildID string, g *GuildParams, options ...RequestOp
 
 // GuildDelete deletes a Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildDelete(guildID string, options ...RequestOption) (st *Guild, err error) {
+func (s *Session) GuildDelete(guildID string, options ...RequestOption) (err error) {
 
-	body, err := s.RequestWithBucketID("DELETE", EndpointGuild(guildID), nil, EndpointGuild(guildID), options...)
-	if err != nil {
-		return
-	}
-
-	err = unmarshal(body, &st)
+	_, err = s.RequestWithBucketID("DELETE", EndpointGuild(guildID), nil, EndpointGuild(guildID), options...)
 	return
 }
 


### PR DESCRIPTION
[Delete Guild returns `204` (No Content), with no content.](https://discord.com/developers/docs/resources/guild#delete-guild). This PR updates the `GuildDelete` method to not attempt an unmarshal, and only return an error.

Extract from a recent test run:

```
2023/02/12 00:13:08 API REQUEST   DELETE :: https://discord.com/api/v9/guilds/***
2023/02/12 00:13:08 API REQUEST  PAYLOAD :: []
2023/02/12 00:13:08 API REQUEST   HEADER :: [Authorization] = [Bot ***]
2023/02/12 00:13:08 API REQUEST   HEADER :: [User-Agent] = [DiscordBot (https://github.com/bwmarrin/discordgo, v0.25.0)]
2023/02/12 00:13:09 API RESPONSE  STATUS :: 204 No Content
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Date] = [Sun, 12 Feb 2023 00:13:08 GMT]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [X-Ratelimit-Remaining] = [3]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Cf-Cache-Status] = [DYNAMIC]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Nel] = [{"success_fraction":0,"report_to":"cf-nel","max_age":604800}]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Set-Cookie] = ***
2023/02/12 00:13:09 API RESPONSE  HEADER :: [X-Ratelimit-Bucket] = [***]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Via] = [1.1 google]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [X-Content-Type-Options] = [nosniff]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Server] = [cloudflare]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Content-Type] = [text/html; charset=utf-8]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Strict-Transport-Security] = [max-age=31536000; includeSubDomains; preload]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [X-Ratelimit-Reset-After] = [278.305]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Alt-Svc] = [h3=":443"; ma=86400, h3-29=":443"; ma=86400]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Cf-Ray] = [79811dde0ffa3859-LHR]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [X-Ratelimit-Limit] = [5]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [X-Ratelimit-Reset] = [1676161066.543]
2023/02/12 00:13:09 API RESPONSE  HEADER :: [Report-To] = [{"endpoints":[{"url":"***"}],"group":"cf-nel","max_age":604800}]
2023/02/12 00:13:09 API RESPONSE    BODY :: []


panic: json unmarshal: unexpected end of JSON input
```