### PR TITLE
Added support for the icon and unicode_emoji role struct fields

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -42,6 +42,10 @@ var (
 	EndpointCDNChannelIcons = EndpointCDN + "channel-icons/"
 	EndpointCDNBanners      = EndpointCDN + "banners/"
 	EndpointCDNGuilds       = EndpointCDN + "guilds/"
+	EndpointCDNRoleIcons    = EndpointCDN + "role-icons/"
+	EndpointRoleIcon        = func(rID, cID string) string {
+		return EndpointCDNRoleIcons + rID + "/" + cID + ".png"
+	}
 
 	EndpointVoice        = EndpointAPI + "/voice/"
 	EndpointVoiceRegions = EndpointVoice + "regions"

--- a/structs.go
+++ b/structs.go
@@ -1252,7 +1252,7 @@ func (r *Role) Mention() string {
 	return fmt.Sprintf("<@&%s>", r.ID)
 }
 
-// IconURL returns the URL of the users's banner image.
+// IconURL returns the URL of the role's icon.
 //
 //	size:    The size of the desired role icon as a power of two
 //	         Image size can be any power of two between 16 and 4096.

--- a/structs.go
+++ b/structs.go
@@ -1239,11 +1239,34 @@ type Role struct {
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the permission.
 	Permissions int64 `json:"permissions,string"`
+
+	// The hash of the role icon. Use Role.IconURL to retrieve the icon's URL.
+	Icon string `json:"icon"`
+
+	// The emoji assigned to this role.
+	UnicodeEmoji string `json:"unicode_emoji"`
 }
 
 // Mention returns a string which mentions the role
 func (r *Role) Mention() string {
 	return fmt.Sprintf("<@&%s>", r.ID)
+}
+
+// IconURL returns the URL of the users's banner image.
+//
+//	size:    The size of the desired role icon as a power of two
+//	         Image size can be any power of two between 16 and 4096.
+func (r *Role) IconURL(size string) string {
+	if r.Icon == "" {
+		return ""
+	}
+
+	URL := EndpointRoleIcon(r.ID, r.Icon)
+
+	if size != "" {
+		return URL + "?size=" + size
+	}
+	return URL
 }
 
 // RoleParams represents the parameters needed to create or update a Role

--- a/structs.go
+++ b/structs.go
@@ -1281,6 +1281,12 @@ type RoleParams struct {
 	Permissions *int64 `json:"permissions,omitempty,string"`
 	// Whether this role is mentionable
 	Mentionable *bool `json:"mentionable,omitempty"`
+	// The role's unicode emoji.
+	// NOTE: can only be set if the guild has the ROLE_ICONS feature.
+	UnicodeEmoji *string `json:"unicode_emoji,omitempty"`
+	// The role's icon image encoded in base64.
+	// NOTE: can only be set if the guild has the ROLE_ICONS feature.
+	Icon *string `json:"icon,omitempty"`
 }
 
 // Roles are a collection of Role


### PR DESCRIPTION
This partially addresses #1316 by adding support for the fields mentioned in this PR's title. 
I tested this on a server with role icons and emoji and encountered no issues.