### PR TITLE
fix: ThreadMember flags not serialized

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -527,7 +527,7 @@ type ThreadMember struct {
 	// The time the current user last joined the thread
 	JoinTimestamp time.Time `json:"join_timestamp"`
 	// Any user-thread settings, currently only used for notifications
-	Flags int
+	Flags int `json:"flags"`
 }
 
 // ThreadsList represents a list of threads alongisde with thread member objects for the current user.


### PR DESCRIPTION
The `Flags` field was being incorrectly de/serialized as `"Flags"`.

ThreadMember spec: https://discord.com/developers/docs/resources/channel#thread-member-object

I caught this with the `musttag` linter, so I went ahead and added it to the linter config.