### PR TITLE
IP Discovery use 74-byte UDP packets

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -611,10 +611,8 @@ func (v *VoiceConnection) udpOpen() (err error) {
     ssrc := make([]byte, 4)
     binary.BigEndian.PutUint32(ssrc, v.op2.SSRC)
 
-	// Create a byte slice of length 64 filled with null bytes
+	// Create byte slices filled with null bytes for padding (packet must be 74 bytes long)
     nullAdress := make([]byte, 64)
-
-    // Create a byte slice of length 2 filled with null bytes
     nullPort := make([]byte, 2)
 
 	// Concatenate all fields to create the packet
@@ -644,8 +642,8 @@ func (v *VoiceConnection) udpOpen() (err error) {
 		return fmt.Errorf("received udp packet too small")
 	}
 
-	// Loop over position 4 through 20 to grab the IP address
-	// Should never be beyond position 20.
+	// Loop over position 8 through 72 to grab the IP address
+	// Should never be beyond position 72.
 	var ip string
 	for i := 8; i < 72; i++ {
 		if rb[i] == 0 {
@@ -654,7 +652,7 @@ func (v *VoiceConnection) udpOpen() (err error) {
 		ip += string(rb[i])
 	}
 
-	// Grab port from position 68 and 69
+	// Grab port from position 72 and 74
 	port := binary.BigEndian.Uint16(rb[72:74])
 
 	// Take the data from above and send it back to Discord to finalize

--- a/voice.go
+++ b/voice.go
@@ -600,26 +600,26 @@ func (v *VoiceConnection) udpOpen() (err error) {
 	}
 	// https://discord.com/developers/docs/topics/voice-connections#ip-discovery
 	// Set packet type to request (0x1)
-    packetType := make([]byte, 2)
+	packetType := make([]byte, 2)
 	binary.BigEndian.PutUint16(packetType, 0x1)
 
-    // Set message length to 70
-    length := make([]byte, 2)
-    binary.BigEndian.PutUint16(length, 70)
+	// Set message length to 70
+	length := make([]byte, 2)
+	binary.BigEndian.PutUint16(length, 70)
 
-    // Set SSRC
-    ssrc := make([]byte, 4)
-    binary.BigEndian.PutUint32(ssrc, v.op2.SSRC)
+	// Set SSRC
+	ssrc := make([]byte, 4)
+	binary.BigEndian.PutUint32(ssrc, v.op2.SSRC)
 
 	// Create byte slices filled with null bytes for padding (packet must be 74 bytes long)
-    nullAdress := make([]byte, 64)
-    nullPort := make([]byte, 2)
+	nullAdress := make([]byte, 64)
+	nullPort := make([]byte, 2)
 
 	// Concatenate all fields to create the packet
-    packet := append(packetType, length...)
-    packet = append(packet, ssrc...)
+	packet := append(packetType, length...)
+	packet = append(packet, ssrc...)
 	packet = append(packet, nullAdress...)
-    packet = append(packet, nullPort...)
+	packet = append(packet, nullPort...)
 
 	_, err = v.udpConn.Write(packet)
 	if err != nil {

--- a/voice.go
+++ b/voice.go
@@ -616,12 +616,12 @@ func (v *VoiceConnection) udpOpen() (err error) {
 	nullPort := make([]byte, 2)
 
 	// Concatenate all fields to create the packet
-	packet := append(packetType, length...)
-	packet = append(packet, ssrc...)
-	packet = append(packet, nullAdress...)
-	packet = append(packet, nullPort...)
+	sb := append(packetType, length...)
+	sb = append(sb, ssrc...)
+	sb = append(sb, nullAdress...)
+	sb = append(sb, nullPort...)
 
-	_, err = v.udpConn.Write(packet)
+	_, err = v.udpConn.Write(sb)
 	if err != nil {
 		v.log(LogWarning, "udp write error to %s, %s", addr.String(), err)
 		return


### PR DESCRIPTION
70-byte UDP packets for IP Discovery were deprecated in [2019 ](https://discord.com/developers/docs/change-log#december-6-2019), but they will keep working until 15 march 2023 ([source from discord developers server](https://discord.com/channels/613425648685547541/697138785317814292/1080623873629884486)). I updated it so the library uses the newer 74-byte packet.

[Documentation](https://discord.com/developers/docs/topics/voice-connections#ip-discovery)