### PR TITLE
Add toggle for voice reconnect on session reconnect

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -38,7 +38,7 @@ func New(token string) (s *Session, err error) {
 		StateEnabled:                    true,
 		Compress:                        true,
 		ShouldReconnectOnError:          true,
-		ShouldReconnectVoiceConnOnError: true,
+		ShouldReconnectVoiceOnSessionError: true,
 		ShouldRetryOnRateLimit:          true,
 		ShardID:                         0,
 		ShardCount:                      1,

--- a/discord.go
+++ b/discord.go
@@ -33,20 +33,21 @@ func New(token string) (s *Session, err error) {
 
 	// Create an empty Session interface.
 	s = &Session{
-		State:                  NewState(),
-		Ratelimiter:            NewRatelimiter(),
-		StateEnabled:           true,
-		Compress:               true,
-		ShouldReconnectOnError: true,
-		ShouldRetryOnRateLimit: true,
-		ShardID:                0,
-		ShardCount:             1,
-		MaxRestRetries:         3,
-		Client:                 &http.Client{Timeout: (20 * time.Second)},
-		Dialer:                 websocket.DefaultDialer,
-		UserAgent:              "DiscordBot (https://github.com/bwmarrin/discordgo, v" + VERSION + ")",
-		sequence:               new(int64),
-		LastHeartbeatAck:       time.Now().UTC(),
+		State:                           NewState(),
+		Ratelimiter:                     NewRatelimiter(),
+		StateEnabled:                    true,
+		Compress:                        true,
+		ShouldReconnectOnError:          true,
+		ShouldReconnectVoiceConnOnError: true,
+		ShouldRetryOnRateLimit:          true,
+		ShardID:                         0,
+		ShardCount:                      1,
+		MaxRestRetries:                  3,
+		Client:                          &http.Client{Timeout: (20 * time.Second)},
+		Dialer:                          websocket.DefaultDialer,
+		UserAgent:                       "DiscordBot (https://github.com/bwmarrin/discordgo, v" + VERSION + ")",
+		sequence:                        new(int64),
+		LastHeartbeatAck:                time.Now().UTC(),
 	}
 
 	// Initialize the Identify Package with defaults

--- a/discord.go
+++ b/discord.go
@@ -33,21 +33,21 @@ func New(token string) (s *Session, err error) {
 
 	// Create an empty Session interface.
 	s = &Session{
-		State:                           NewState(),
-		Ratelimiter:                     NewRatelimiter(),
-		StateEnabled:                    true,
-		Compress:                        true,
-		ShouldReconnectOnError:          true,
+		State:                              NewState(),
+		Ratelimiter:                        NewRatelimiter(),
+		StateEnabled:                       true,
+		Compress:                           true,
+		ShouldReconnectOnError:             true,
 		ShouldReconnectVoiceOnSessionError: true,
-		ShouldRetryOnRateLimit:          true,
-		ShardID:                         0,
-		ShardCount:                      1,
-		MaxRestRetries:                  3,
-		Client:                          &http.Client{Timeout: (20 * time.Second)},
-		Dialer:                          websocket.DefaultDialer,
-		UserAgent:                       "DiscordBot (https://github.com/bwmarrin/discordgo, v" + VERSION + ")",
-		sequence:                        new(int64),
-		LastHeartbeatAck:                time.Now().UTC(),
+		ShouldRetryOnRateLimit:             true,
+		ShardID:                            0,
+		ShardCount:                         1,
+		MaxRestRetries:                     3,
+		Client:                             &http.Client{Timeout: (20 * time.Second)},
+		Dialer:                             websocket.DefaultDialer,
+		UserAgent:                          "DiscordBot (https://github.com/bwmarrin/discordgo, v" + VERSION + ")",
+		sequence:                           new(int64),
+		LastHeartbeatAck:                   time.Now().UTC(),
 	}
 
 	// Initialize the Identify Package with defaults

--- a/structs.go
+++ b/structs.go
@@ -42,6 +42,9 @@ type Session struct {
 	// Should the session reconnect the websocket on errors.
 	ShouldReconnectOnError bool
 
+	// Should the session reconnect also trigger voice connections reconnect.
+	ShouldReconnectVoiceConnOnError bool
+
 	// Should the session retry requests when rate limited.
 	ShouldRetryOnRateLimit bool
 

--- a/structs.go
+++ b/structs.go
@@ -42,8 +42,8 @@ type Session struct {
 	// Should the session reconnect the websocket on errors.
 	ShouldReconnectOnError bool
 
-	// Should the session reconnect also trigger voice connections reconnect.
-	ShouldReconnectVoiceConnOnError bool
+	// Should voice connections reconnect on session websocket errors.
+	ShouldReconnectVoiceOnSessionError bool
 
 	// Should the session retry requests when rate limited.
 	ShouldRetryOnRateLimit bool

--- a/structs.go
+++ b/structs.go
@@ -42,7 +42,7 @@ type Session struct {
 	// Should the session reconnect the websocket on errors.
 	ShouldReconnectOnError bool
 
-	// Should voice connections reconnect on session websocket errors.
+	// Should voice connections reconnect on a session reconnect.
 	ShouldReconnectVoiceOnSessionError bool
 
 	// Should the session retry requests when rate limited.

--- a/wsapi.go
+++ b/wsapi.go
@@ -862,7 +862,7 @@ func (s *Session) reconnect() {
 				// However, there seems to be cases where something "weird"
 				// happens.  So we're doing this for now just to improve
 				// stability in those edge cases.
-				if s.ShouldReconnectVoiceConnOnError {
+				if s.ShouldReconnectVoiceOnSessionError {
 					s.RLock()
 					defer s.RUnlock()
 					for _, v := range s.VoiceConnections {

--- a/wsapi.go
+++ b/wsapi.go
@@ -862,17 +862,18 @@ func (s *Session) reconnect() {
 				// However, there seems to be cases where something "weird"
 				// happens.  So we're doing this for now just to improve
 				// stability in those edge cases.
-				s.RLock()
-				defer s.RUnlock()
-				for _, v := range s.VoiceConnections {
+				if s.ShouldReconnectVoiceConnOnError {
+					s.RLock()
+					defer s.RUnlock()
+					for _, v := range s.VoiceConnections {
 
-					s.log(LogInformational, "reconnecting voice connection to guild %s", v.GuildID)
-					go v.reconnect()
+						s.log(LogInformational, "reconnecting voice connection to guild %s", v.GuildID)
+						go v.reconnect()
 
-					// This is here just to prevent violently spamming the
-					// voice reconnects
-					time.Sleep(1 * time.Second)
-
+						// This is here just to prevent violently spamming the
+						// voice reconnects
+						time.Sleep(1 * time.Second)
+					}
 				}
 				return
 			}


### PR DESCRIPTION
This PR adds a flag in order to prevent voice reconnect on session reconnect. The default value is set to `true` so it should not affect the initial behaviour.

Resolves #1349 