### PR TITLE
Fix bug with error not being returned in WebhookEditWithToken

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -2302,8 +2302,9 @@ func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string, op
 		Name   string `json:"name,omitempty"`
 		Avatar string `json:"avatar,omitempty"`
 	}{name, avatar}
-
-	body, err := s.RequestWithBucketID("PATCH", EndpointWebhookToken(webhookID, token), data, EndpointWebhookToken("", ""), options...)
+	
+	var body []byte
+	body, err = s.RequestWithBucketID("PATCH", EndpointWebhookToken(webhookID, token), data, EndpointWebhookToken("", ""), options...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Earlier, if there was an error it would not be returned since the `:=` operator was used instead of a `=` operator.