### PR TITLE
Add fail_if_not_exists to MessageReference

### DIFF
--- a/message.go
+++ b/message.go
@@ -476,7 +476,7 @@ func (m *Message) reference(failIfNotExists bool) *MessageReference {
 	}
 }
 
-// Reference returns a MessageReference of the given message
+// Reference returns a MessageReference of the given message.
 func (m *Message) Reference() *MessageReference {
 	return m.reference(true)
 }

--- a/message.go
+++ b/message.go
@@ -461,18 +461,30 @@ type MessageApplication struct {
 
 // MessageReference contains reference data sent with crossposted messages
 type MessageReference struct {
-	MessageID string `json:"message_id"`
-	ChannelID string `json:"channel_id,omitempty"`
-	GuildID   string `json:"guild_id,omitempty"`
+	MessageID       string `json:"message_id"`
+	ChannelID       string `json:"channel_id,omitempty"`
+	GuildID         string `json:"guild_id,omitempty"`
+	FailIfNotExists *bool  `json:"fail_if_not_exists,omitempty"`
 }
 
-// Reference returns MessageReference of given message
-func (m *Message) Reference() *MessageReference {
+func (m *Message) reference(failIfNotExists bool) *MessageReference {
 	return &MessageReference{
-		GuildID:   m.GuildID,
-		ChannelID: m.ChannelID,
-		MessageID: m.ID,
+		GuildID:         m.GuildID,
+		ChannelID:       m.ChannelID,
+		MessageID:       m.ID,
+		FailIfNotExists: &failIfNotExists,
 	}
+}
+
+// Reference returns a MessageReference of the given message
+func (m *Message) Reference() *MessageReference {
+	return m.reference(true)
+}
+
+// SoftReference returns a MessageReference of the given message.
+// If the message doesn't exist it will instead be sent as a non-reply message.
+func (m *Message) SoftReference() *MessageReference {
+	return m.reference(false)
 }
 
 // ContentWithMentionsReplaced will replace all @<id> mentions with the


### PR DESCRIPTION
https://discord.com/developers/docs/resources/channel#message-reference-object

I wanted to make this a parameter of the `Reference` function where you can pass in false if needed. Go doesn't support default parameter values so I don't know how I should go about doing that. Any pointer are appreciated.