### PR TITLE
feat(auditlog): add application_id to AuditLogOptions

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1746,6 +1746,7 @@ type AuditLogOptions struct {
 	ID                            string               `json:"id"`
 	Type                          *AuditLogOptionsType `json:"type"`
 	RoleName                      string               `json:"role_name"`
+	ApplicationID                 string               `json:"application_id"`
 	AutoModerationRuleName        string               `json:"auto_moderation_rule_name"`
 	AutoModerationRuleTriggerType string               `json:"auto_moderation_rule_trigger_type"`
 }


### PR DESCRIPTION
Put into a seperate PR as per #1371

I added it above the moderator fields because that is the order they were added to the api.