### PR TITLE
ChannelEdit: omit empty Position

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -440,7 +440,7 @@ type ChannelEdit struct {
 	Name                          string                 `json:"name,omitempty"`
 	Topic                         string                 `json:"topic,omitempty"`
 	NSFW                          *bool                  `json:"nsfw,omitempty"`
-	Position                      int                    `json:"position"`
+	Position                      *int                   `json:"position,omitempty"`
 	Bitrate                       int                    `json:"bitrate,omitempty"`
 	UserLimit                     int                    `json:"user_limit,omitempty"`
 	PermissionOverwrites          []*PermissionOverwrite `json:"permission_overwrites,omitempty"`


### PR DESCRIPTION
Convert `ChannelEdit.Position` to a pointer and add `omitempty` JSON option.

