### PR TITLE
Add GlobalName field to User

### DIFF
--- a/user.go
+++ b/user.go
@@ -34,6 +34,9 @@ type User struct {
 	// The user's username.
 	Username string `json:"username"`
 
+	// the user's display name, if it is set. For bots, this is the application name
+	GlobalName string `json:"global_name"`
+
 	// The hash of the user's avatar. Use Session.UserAvatar
 	// to retrieve the avatar itself.
 	Avatar string `json:"avatar"`


### PR DESCRIPTION
This field is being introduced with the username change and is displayed pretty much everywhere instead of the actual username.

https://discord.com/developers/docs/resources/user#user-object