### PR TITLE
Add Attachment options to interactions

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -554,6 +554,7 @@ type InteractionResponseData struct {
 	Embeds          []*MessageEmbed         `json:"embeds"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Files           []*File                 `json:"-"`
+	Attachments     *[]*MessageAttachment   `json:"attachments,omitempty"`
 
 	// NOTE: only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set.
 	Flags MessageFlags `json:"flags,omitempty"`

--- a/webhook.go
+++ b/webhook.go
@@ -34,7 +34,7 @@ type WebhookParams struct {
 	Files           []*File                 `json:"-"`
 	Components      []MessageComponent      `json:"components"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
-	Attachments     *[]*MessageAttachment   `json:"attachments,omitempty"`
+	Attachments     []*MessageAttachment    `json:"attachments,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	// Only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set.
 	// MessageFlagsEphemeral can only be set when using Followup Message Create endpoint.

--- a/webhook.go
+++ b/webhook.go
@@ -34,6 +34,7 @@ type WebhookParams struct {
 	Files           []*File                 `json:"-"`
 	Components      []MessageComponent      `json:"components"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
+	Attachments     *[]*MessageAttachment   `json:"attachments,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	// Only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set.
 	// MessageFlagsEphemeral can only be set when using Followup Message Create endpoint.
@@ -46,5 +47,6 @@ type WebhookEdit struct {
 	Components      *[]MessageComponent     `json:"components,omitempty"`
 	Embeds          *[]*MessageEmbed        `json:"embeds,omitempty"`
 	Files           []*File                 `json:"-"`
+	Attachments     *[]*MessageAttachment   `json:"attachments,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 }


### PR DESCRIPTION
Add Attachment options to interactions so that editing uploaded files is possible.
Behavior documented here: https://discord.com/developers/docs/resources/webhook#edit-webhook-message