### PR TITLE
Remove remove duplicated slash in template endpoint

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -104,7 +104,7 @@ var (
 	EndpointGuildScheduledEvents     = func(gID string) string { return EndpointGuilds + gID + "/scheduled-events" }
 	EndpointGuildScheduledEvent      = func(gID, eID string) string { return EndpointGuilds + gID + "/scheduled-events/" + eID }
 	EndpointGuildScheduledEventUsers = func(gID, eID string) string { return EndpointGuildScheduledEvent(gID, eID) + "/users" }
-	EndpointGuildTemplate            = func(tID string) string { return EndpointGuilds + "/templates/" + tID }
+	EndpointGuildTemplate            = func(tID string) string { return EndpointGuilds + "templates/" + tID }
 	EndpointGuildTemplates           = func(gID string) string { return EndpointGuilds + gID + "/templates" }
 	EndpointGuildTemplateSync        = func(gID, tID string) string { return EndpointGuilds + gID + "/templates/" + tID }
 	EndpointGuildMemberAvatar        = func(gId, uID, aID string) string {


### PR DESCRIPTION
`EndpointGuilds` already has a slash at the end so we end up with `/guilds//templates` which is not ideal. The Discord API ignores the double slash but if you are using some kind of proxy it doesn't work.