### PR TITLE
feat(guild): implement onboarding

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -104,6 +104,7 @@ var (
 	EndpointGuildScheduledEvents     = func(gID string) string { return EndpointGuilds + gID + "/scheduled-events" }
 	EndpointGuildScheduledEvent      = func(gID, eID string) string { return EndpointGuilds + gID + "/scheduled-events/" + eID }
 	EndpointGuildScheduledEventUsers = func(gID, eID string) string { return EndpointGuildScheduledEvent(gID, eID) + "/users" }
+	EndpointGuildOnboarding          = func(gID string) string { return EndpointGuilds + gID + "/onboarding" }
 	EndpointGuildTemplate            = func(tID string) string { return EndpointGuilds + "/templates/" + tID }
 	EndpointGuildTemplates           = func(gID string) string { return EndpointGuilds + gID + "/templates" }
 	EndpointGuildTemplateSync        = func(gID, tID string) string { return EndpointGuilds + gID + "/templates/" + tID }

--- a/restapi.go
+++ b/restapi.go
@@ -3250,8 +3250,8 @@ func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, w
 	return
 }
 
-// GuildOnboarding returns the onboarding flow for a guild.
-// guildID   : The ID of a Guild
+// GuildOnboarding returns onboarding configuration of a guild.
+// guildID   : The ID of the guild
 func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
 	endpoint := EndpointGuildOnboarding(guildID)
 
@@ -3265,9 +3265,9 @@ func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onb
 	return
 }
 
-// GuildOnboardingEdit edits Onboarding for a Guild.
-// guildID   : The ID of a Guild.
-// o 		     : A GuildOnboarding struct.
+// GuildOnboardingEdit edits onboarding configuration of a guild.
+// guildID   : The ID of the guild
+// o 		     : New GuildOnboarding data
 func (s *Session) GuildOnboardingEdit(guildID string, o *GuildOnboarding, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
 	endpoint := EndpointGuildOnboarding(guildID)
 

--- a/restapi.go
+++ b/restapi.go
@@ -3265,6 +3265,22 @@ func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onb
 	return
 }
 
+// GuildOnboardingEdit edits Onboarding for a Guild.
+// guildID   : The ID of a Guild.
+// o 		     : A GuildOnboardingParams struct.
+func (s *Session) GuildOnboardingEdit(guildID string, o *GuildOnboardingParams, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
+	endpoint := EndpointGuildOnboarding(guildID)
+
+	var body []byte
+	body, err = s.RequestWithBucketID("PUT", endpoint, o, endpoint, options...)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &onboarding)
+	return
+}
+
 // ----------------------------------------------------------------------
 // Functions specific to auto moderation
 // ----------------------------------------------------------------------

--- a/restapi.go
+++ b/restapi.go
@@ -3267,7 +3267,7 @@ func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onb
 
 // GuildOnboardingEdit edits onboarding configuration of a guild.
 // guildID   : The ID of the guild
-// o 		     : New GuildOnboarding data
+// o         : New GuildOnboarding data
 func (s *Session) GuildOnboardingEdit(guildID string, o *GuildOnboarding, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
 	endpoint := EndpointGuildOnboarding(guildID)
 

--- a/restapi.go
+++ b/restapi.go
@@ -3267,8 +3267,8 @@ func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onb
 
 // GuildOnboardingEdit edits Onboarding for a Guild.
 // guildID   : The ID of a Guild.
-// o 		     : A GuildOnboardingParams struct.
-func (s *Session) GuildOnboardingEdit(guildID string, o *GuildOnboardingParams, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
+// o 		     : A GuildOnboarding struct.
+func (s *Session) GuildOnboardingEdit(guildID string, o *GuildOnboarding, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
 	endpoint := EndpointGuildOnboarding(guildID)
 
 	var body []byte

--- a/restapi.go
+++ b/restapi.go
@@ -3250,9 +3250,9 @@ func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, w
 	return
 }
 
-// GuildOnboarding returns the onboarding flow for a guild
+// GuildOnboarding returns the onboarding flow for a guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onboarding GuildOnboarding, err error) {
+func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
 	endpoint := EndpointGuildOnboarding(guildID)
 
 	var body []byte

--- a/restapi.go
+++ b/restapi.go
@@ -3250,6 +3250,21 @@ func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, w
 	return
 }
 
+// GuildOnboarding returns the onboarding flow for a guild
+// guildID   : The ID of a Guild
+func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onboarding GuildOnboarding, err error) {
+	endpoint := EndpointGuildOnboarding(guildID)
+
+	var body []byte
+	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &onboarding)
+	return
+}
+
 // ----------------------------------------------------------------------
 // Functions specific to auto moderation
 // ----------------------------------------------------------------------

--- a/structs.go
+++ b/structs.go
@@ -1077,9 +1077,9 @@ type GuildOnboardingMode int
 // Block containing known GuildOnboardingMode values
 const (
 	// GuildOnboardingModeDefault counts default channels towards constraints
-	GuildOnboardingModeDefault = 0
+	GuildOnboardingModeDefault GuildOnboardingMode = 0
 	// GuildOnboardingModeAdvanced counts default channels and questions towards constraints
-	GuildOnboardingModeAdvanced = 1
+	GuildOnboardingModeAdvanced GuildOnboardingMode = 1
 )
 
 // GuildOnboarding represents the onboarding flow for a guild.

--- a/structs.go
+++ b/structs.go
@@ -1109,7 +1109,7 @@ type GuildOnboardingPrompt struct {
 	// https://github.com/discord/discord-api-docs/issues/6320 for more information.
 	ID string `json:"id,omitempty"`
 
-	// Type of prompt.
+	// Type of the prompt.
 	Type GuildOnboardingPromptType `json:"type"`
 
 	// Options available within the prompt.

--- a/structs.go
+++ b/structs.go
@@ -1070,6 +1070,79 @@ type GuildScheduledEventUser struct {
 	Member                *Member `json:"member"`
 }
 
+// GuildOnboarding represents the onboarding flow for a guild
+// https://discord.com/developers/docs/resources/guild#guild-onboarding-object
+type GuildOnboarding struct {
+	// ID of the guild this onboarding is part of
+	GuildID string `json:"guild_id"`
+
+	// Prompts shown during onboarding and in customize community
+	Prompts []GuildOnboardingPrompt `json:"prompts"`
+
+	// Channel IDs that members get opted into automatically
+	DefaultChannelIDs []string `json:"default_channel_ids"`
+
+	// 	Whether onboarding is enabled in the guild
+	Enabled bool `json:"enabled"`
+}
+
+// GuildOnboardingPrompt is a prompt shown during onboarding and in customize community
+// https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-prompt-structure
+type GuildOnboardingPrompt struct {
+	// ID of the prompt
+	ID string `json:"id"`
+
+	// Type of prompt
+	Type GuildOnboardingPromptType `json:"type"`
+
+	// Options available within the prompt
+	Options []GuildOnboardingPromptOption `json:"options"`
+
+	// Title of the prompt
+	Title string `json:"title"`
+
+	// Indicates whether users are limited to selecting one option for the prompt
+	SingleSelect bool `json:"single_select"`
+
+	// Indicates whether the prompt is required before a user completes the onboarding flow
+	Required bool `json:"required"`
+
+	// Indicates whether the prompt is present in the onboarding flow. If false, the prompt will only appear in the Channels & Roles tab
+	InOnboarding bool `json:"in_onboarding"`
+}
+
+// GuildOnboardingPromptType is the type of prompt during onboarding
+// https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-types
+type GuildOnboardingPromptType int
+
+// Block containing known GuildOnboardingPromptType values
+const (
+	GuildOnboardingPromptTypeMultipleChoice GuildOnboardingPromptType = 0
+	GuildOnboardingPromptTypeDropdown       GuildOnboardingPromptType = 1
+)
+
+// GuildOnboardingPromptOption is an option available within an onboarding prompt
+// https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-option-structure
+type GuildOnboardingPromptOption struct {
+	// ID of the prompt option
+	ID string `json:"id"`
+
+	// IDs for channels a member is added to when the option is selected
+	ChannelIDs []string `json:"channel_ids"`
+
+	// IDs for roles assigned to a member when the option is selected
+	RoleIDs []string `json:"role_ids"`
+
+	// Emoji of the option
+	Emoji Emoji `json:"emoji"`
+
+	// Title of the option
+	Title string `json:"title"`
+
+	// Description of the option
+	Description string `json:"description,omitempty"`
+}
+
 // A GuildTemplate represents a replicable template for guild creation
 type GuildTemplate struct {
 	// The unique code for the guild template

--- a/structs.go
+++ b/structs.go
@@ -1070,6 +1070,17 @@ type GuildScheduledEventUser struct {
 	Member                *Member `json:"member"`
 }
 
+// GuildOnboardingMode defines the criteria used to satisfy constraints that are required for enabling onboarding.
+// https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-mode
+type GuildOnboardingMode int
+
+const (
+	// GuildOnboardingModeDefault counts default channels towards constraints
+	GuildOnboardingModeDefault = 0
+	// GuildOnboardingModeDefault counts default channels and questions towards constraints
+	GuildOnboardingModeAdvanced = 1
+)
+
 // GuildOnboarding represents the onboarding flow for a guild
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object
 type GuildOnboarding struct {
@@ -1082,8 +1093,11 @@ type GuildOnboarding struct {
 	// Channel IDs that members get opted into automatically
 	DefaultChannelIDs []string `json:"default_channel_ids"`
 
-	// 	Whether onboarding is enabled in the guild
+	// Whether onboarding is enabled in the guild
 	Enabled bool `json:"enabled"`
+
+	// Current mode of onboarding
+	Mode GuildOnboardingMode `json:"mode"`
 }
 
 // GuildOnboardingPrompt is a prompt shown during onboarding and in customize community

--- a/structs.go
+++ b/structs.go
@@ -1086,35 +1086,19 @@ const (
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object
 type GuildOnboarding struct {
 	// ID of the guild this onboarding is part of.
-	GuildID string `json:"guild_id"`
+	GuildID string `json:"guild_id,omitempty"`
 
-	// Prompts shown during onboarding and in the Channel & Roles tab.
-	Prompts []GuildOnboardingPrompt `json:"prompts"`
-
-	// Channel IDs that members get opted into automatically.
-	DefaultChannelIDs []string `json:"default_channel_ids"`
-
-	// Whether onboarding is enabled in the guild.
-	Enabled bool `json:"enabled"`
-
-	// Current mode of onboarding.
-	Mode GuildOnboardingMode `json:"mode"`
-}
-
-// GuildOnboardingParams stores all the data needed to update discord onboarding settings.
-// https://discord.com/developers/docs/resources/guild#modify-guild-onboarding-json-params
-type GuildOnboardingParams struct {
 	// Prompts shown during onboarding and in the Channel & Roles tab.
 	Prompts []GuildOnboardingPrompt `json:"prompts,omitempty"`
 
 	// Channel IDs that members get opted into automatically.
 	DefaultChannelIDs []string `json:"default_channel_ids,omitempty"`
 
-	// Whether onboarding is enabled.
+	// Whether onboarding is enabled in the guild.
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Mode of onboarding.
-	Mode GuildOnboardingMode `json:"mode,omitempty"`
+	Mode *GuildOnboardingMode `json:"mode,omitempty"`
 }
 
 // GuildOnboardingPrompt is a prompt shown during onboarding and in customize community.

--- a/structs.go
+++ b/structs.go
@@ -1074,58 +1074,59 @@ type GuildScheduledEventUser struct {
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-mode
 type GuildOnboardingMode int
 
+// Block containing known GuildOnboardingMode values
 const (
 	// GuildOnboardingModeDefault counts default channels towards constraints
 	GuildOnboardingModeDefault = 0
-	// GuildOnboardingModeDefault counts default channels and questions towards constraints
+	// GuildOnboardingModeAdvanced counts default channels and questions towards constraints
 	GuildOnboardingModeAdvanced = 1
 )
 
-// GuildOnboarding represents the onboarding flow for a guild
+// GuildOnboarding represents the onboarding flow for a guild.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object
 type GuildOnboarding struct {
-	// ID of the guild this onboarding is part of
+	// ID of the guild this onboarding is part of.
 	GuildID string `json:"guild_id"`
 
-	// Prompts shown during onboarding and in customize community
+	// Prompts shown during onboarding and in customize community.
 	Prompts []GuildOnboardingPrompt `json:"prompts"`
 
-	// Channel IDs that members get opted into automatically
+	// Channel IDs that members get opted into automatically.
 	DefaultChannelIDs []string `json:"default_channel_ids"`
 
-	// Whether onboarding is enabled in the guild
+	// Whether onboarding is enabled in the guild.
 	Enabled bool `json:"enabled"`
 
-	// Current mode of onboarding
+	// Current mode of onboarding.
 	Mode GuildOnboardingMode `json:"mode"`
 }
 
-// GuildOnboardingPrompt is a prompt shown during onboarding and in customize community
+// GuildOnboardingPrompt is a prompt shown during onboarding and in customize community.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-prompt-structure
 type GuildOnboardingPrompt struct {
-	// ID of the prompt
+	// ID of the prompt.
 	ID string `json:"id"`
 
-	// Type of prompt
+	// Type of prompt.
 	Type GuildOnboardingPromptType `json:"type"`
 
-	// Options available within the prompt
+	// Options available within the prompt.
 	Options []GuildOnboardingPromptOption `json:"options"`
 
-	// Title of the prompt
+	// Title of the prompt.
 	Title string `json:"title"`
 
-	// Indicates whether users are limited to selecting one option for the prompt
+	// Indicates whether users are limited to selecting one option for the prompt.
 	SingleSelect bool `json:"single_select"`
 
-	// Indicates whether the prompt is required before a user completes the onboarding flow
+	// Indicates whether the prompt is required before a user completes the onboarding flow.
 	Required bool `json:"required"`
 
-	// Indicates whether the prompt is present in the onboarding flow. If false, the prompt will only appear in the Channels & Roles tab
+	// Indicates whether the prompt is present in the onboarding flow. If false, the prompt will only appear in the Channels & Roles tab.
 	InOnboarding bool `json:"in_onboarding"`
 }
 
-// GuildOnboardingPromptType is the type of prompt during onboarding
+// GuildOnboardingPromptType is the type of prompt during onboarding.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-types
 type GuildOnboardingPromptType int
 
@@ -1135,26 +1136,26 @@ const (
 	GuildOnboardingPromptTypeDropdown       GuildOnboardingPromptType = 1
 )
 
-// GuildOnboardingPromptOption is an option available within an onboarding prompt
+// GuildOnboardingPromptOption is an option available within an onboarding prompt.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-option-structure
 type GuildOnboardingPromptOption struct {
-	// ID of the prompt option
+	// ID of the prompt option.
 	ID string `json:"id"`
 
-	// IDs for channels a member is added to when the option is selected
+	// IDs for channels a member is added to when the option is selected.
 	ChannelIDs []string `json:"channel_ids"`
 
-	// IDs for roles assigned to a member when the option is selected
+	// IDs for roles assigned to a member when the option is selected.
 	RoleIDs []string `json:"role_ids"`
 
-	// Emoji of the option
+	// Emoji of the option.
 	Emoji Emoji `json:"emoji"`
 
-	// Title of the option
+	// Title of the option.
 	Title string `json:"title"`
 
-	// Description of the option
-	Description string `json:"description,omitempty"`
+	// Description of the option.
+	Description *string `json:"description"`
 }
 
 // A GuildTemplate represents a replicable template for guild creation

--- a/structs.go
+++ b/structs.go
@@ -1089,7 +1089,7 @@ type GuildOnboarding struct {
 	GuildID string `json:"guild_id,omitempty"`
 
 	// Prompts shown during onboarding and in the Channel & Roles tab.
-	Prompts []GuildOnboardingPrompt `json:"prompts,omitempty"`
+	Prompts *[]GuildOnboardingPrompt `json:"prompts,omitempty"`
 
 	// Channel IDs that members get opted into automatically.
 	DefaultChannelIDs []string `json:"default_channel_ids,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -1101,6 +1101,22 @@ type GuildOnboarding struct {
 	Mode GuildOnboardingMode `json:"mode"`
 }
 
+// GuildOnboardingParams stores all the data needed to update discord onboarding settings.
+// https://discord.com/developers/docs/resources/guild#modify-guild-onboarding-json-params
+type GuildOnboardingParams struct {
+	// Prompts shown during onboarding and in the Channel & Roles tab.
+	Prompts []GuildOnboardingPrompt `json:"prompts,omitempty"`
+
+	// Channel IDs that members get opted into automatically.
+	DefaultChannelIDs []string `json:"default_channel_ids,omitempty"`
+
+	// Whether onboarding is enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Mode of onboarding.
+	Mode GuildOnboardingMode `json:"mode,omitempty"`
+}
+
 // GuildOnboardingPrompt is a prompt shown during onboarding and in customize community.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-prompt-structure
 type GuildOnboardingPrompt struct {
@@ -2442,6 +2458,9 @@ const (
 
 	ErrCodeCannotUpdateAFinishedEvent             = 180000
 	ErrCodeFailedToCreateStageNeededForStageEvent = 180002
+
+	ErrCodeCannotEnableOnboardingRequirementsAreNotMet  = 350000
+	ErrCodeCannotUpdateOnboardingWhileBelowRequirements = 350001
 )
 
 // Intent is the type of a Gateway Intent

--- a/structs.go
+++ b/structs.go
@@ -1074,11 +1074,11 @@ type GuildScheduledEventUser struct {
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-mode
 type GuildOnboardingMode int
 
-// Block containing known GuildOnboardingMode values
+// Block containing known GuildOnboardingMode values.
 const (
-	// GuildOnboardingModeDefault counts default channels towards constraints
+	// GuildOnboardingModeDefault counts default channels towards constraints.
 	GuildOnboardingModeDefault GuildOnboardingMode = 0
-	// GuildOnboardingModeAdvanced counts default channels and questions towards constraints
+	// GuildOnboardingModeAdvanced counts default channels and questions towards constraints.
 	GuildOnboardingModeAdvanced GuildOnboardingMode = 1
 )
 

--- a/structs.go
+++ b/structs.go
@@ -1105,7 +1105,9 @@ type GuildOnboarding struct {
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-prompt-structure
 type GuildOnboardingPrompt struct {
 	// ID of the prompt.
-	ID string `json:"id"`
+	// NOTE: always requires to be a valid snowflake (e.g. "0"), see
+	// https://github.com/discord/discord-api-docs/issues/6320 for more information.
+	ID string `json:"id,omitempty"`
 
 	// Type of prompt.
 	Type GuildOnboardingPromptType `json:"type"`
@@ -1140,7 +1142,7 @@ const (
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-option-structure
 type GuildOnboardingPromptOption struct {
 	// ID of the prompt option.
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 
 	// IDs for channels a member is added to when the option is selected.
 	ChannelIDs []string `json:"channel_ids"`

--- a/structs.go
+++ b/structs.go
@@ -1088,7 +1088,7 @@ type GuildOnboarding struct {
 	// ID of the guild this onboarding is part of.
 	GuildID string `json:"guild_id"`
 
-	// Prompts shown during onboarding and in customize community.
+	// Prompts shown during onboarding and in the Channel & Roles tab.
 	Prompts []GuildOnboardingPrompt `json:"prompts"`
 
 	// Channel IDs that members get opted into automatically.

--- a/structs.go
+++ b/structs.go
@@ -1151,13 +1151,25 @@ type GuildOnboardingPromptOption struct {
 	RoleIDs []string `json:"role_ids"`
 
 	// Emoji of the option.
-	Emoji Emoji `json:"emoji"`
+	// NOTE: when creating or updating a prompt option
+	// EmojiID, EmojiName and EmojiAnimated should be used instead.
+	Emoji *Emoji `json:"emoji,omitempty"`
 
 	// Title of the option.
 	Title string `json:"title"`
 
 	// Description of the option.
 	Description string `json:"description"`
+
+	// ID of the option's emoji.
+	// NOTE: only used when creating or updating a prompt option.
+	EmojiID string `json:"emoji_id,omitempty"`
+	// Name of the option's emoji.
+	// NOTE: only used when creating or updating a prompt option.
+	EmojiName string `json:"emoji_name,omitempty"`
+	// Whether the option's emoji is animated.
+	// NOTE: only used when creating or updating a prompt option.
+	EmojiAnimated *bool `json:"emoji_animated,omitempty"`
 }
 
 // A GuildTemplate represents a replicable template for guild creation

--- a/structs.go
+++ b/structs.go
@@ -1101,6 +1101,16 @@ type GuildOnboarding struct {
 	Mode *GuildOnboardingMode `json:"mode,omitempty"`
 }
 
+// GuildOnboardingPromptType is the type of an onboarding prompt.
+// https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-types
+type GuildOnboardingPromptType int
+
+// Block containing known GuildOnboardingPromptType values.
+const (
+	GuildOnboardingPromptTypeMultipleChoice GuildOnboardingPromptType = 0
+	GuildOnboardingPromptTypeDropdown       GuildOnboardingPromptType = 1
+)
+
 // GuildOnboardingPrompt is a prompt shown during onboarding and in the customize community (Channels & Roles) tab.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-prompt-structure
 type GuildOnboardingPrompt struct {
@@ -1128,16 +1138,6 @@ type GuildOnboardingPrompt struct {
 	// If false, the prompt will only appear in the customize community (Channels & Roles) tab.
 	InOnboarding bool `json:"in_onboarding"`
 }
-
-// GuildOnboardingPromptType is the type of an onboarding prompt.
-// https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-types
-type GuildOnboardingPromptType int
-
-// Block containing known GuildOnboardingPromptType values.
-const (
-	GuildOnboardingPromptTypeMultipleChoice GuildOnboardingPromptType = 0
-	GuildOnboardingPromptTypeDropdown       GuildOnboardingPromptType = 1
-)
 
 // GuildOnboardingPromptOption is an option available within an onboarding prompt.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-option-structure

--- a/structs.go
+++ b/structs.go
@@ -1128,7 +1128,7 @@ type GuildOnboardingPrompt struct {
 	InOnboarding bool `json:"in_onboarding"`
 }
 
-// GuildOnboardingPromptType is the type of prompt during onboarding.
+// GuildOnboardingPromptType is the type of onboarding prompt.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-types
 type GuildOnboardingPromptType int
 

--- a/structs.go
+++ b/structs.go
@@ -1085,7 +1085,7 @@ const (
 // GuildOnboarding represents the onboarding flow for a guild.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object
 type GuildOnboarding struct {
-	// ID of the guild this onboarding is part of.
+	// ID of the guild this onboarding flow is part of.
 	GuildID string `json:"guild_id,omitempty"`
 
 	// Prompts shown during onboarding and in the customize community (Channels & Roles) tab.
@@ -1129,11 +1129,11 @@ type GuildOnboardingPrompt struct {
 	InOnboarding bool `json:"in_onboarding"`
 }
 
-// GuildOnboardingPromptType is the type of onboarding prompt.
+// GuildOnboardingPromptType is the type of an onboarding prompt.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-prompt-types
 type GuildOnboardingPromptType int
 
-// Block containing known GuildOnboardingPromptType values
+// Block containing known GuildOnboardingPromptType values.
 const (
 	GuildOnboardingPromptTypeMultipleChoice GuildOnboardingPromptType = 0
 	GuildOnboardingPromptTypeDropdown       GuildOnboardingPromptType = 1

--- a/structs.go
+++ b/structs.go
@@ -1124,7 +1124,8 @@ type GuildOnboardingPrompt struct {
 	// Indicates whether the prompt is required before a user completes the onboarding flow.
 	Required bool `json:"required"`
 
-	// Indicates whether the prompt is present in the onboarding flow. If false, the prompt will only appear in the Channels & Roles tab.
+	// Indicates whether the prompt is present in the onboarding flow.
+	// If false, the prompt will only appear in the customize community (Channels & Roles) tab.
 	InOnboarding bool `json:"in_onboarding"`
 }
 

--- a/structs.go
+++ b/structs.go
@@ -1157,7 +1157,7 @@ type GuildOnboardingPromptOption struct {
 	Title string `json:"title"`
 
 	// Description of the option.
-	Description *string `json:"description"`
+	Description string `json:"description"`
 }
 
 // A GuildTemplate represents a replicable template for guild creation

--- a/structs.go
+++ b/structs.go
@@ -1088,7 +1088,7 @@ type GuildOnboarding struct {
 	// ID of the guild this onboarding is part of.
 	GuildID string `json:"guild_id,omitempty"`
 
-	// Prompts shown during onboarding and in the Channel & Roles tab.
+	// Prompts shown during onboarding and in the customize community (Channels & Roles) tab.
 	Prompts *[]GuildOnboardingPrompt `json:"prompts,omitempty"`
 
 	// Channel IDs that members get opted into automatically.
@@ -1101,7 +1101,7 @@ type GuildOnboarding struct {
 	Mode *GuildOnboardingMode `json:"mode,omitempty"`
 }
 
-// GuildOnboardingPrompt is a prompt shown during onboarding and in customize community.
+// GuildOnboardingPrompt is a prompt shown during onboarding and in the customize community (Channels & Roles) tab.
 // https://discord.com/developers/docs/resources/guild#guild-onboarding-object-onboarding-prompt-structure
 type GuildOnboardingPrompt struct {
 	// ID of the prompt.


### PR DESCRIPTION
Adds support for inspecting the onboarding configuration of a guild.

https://discord.com/developers/docs/resources/guild#guild-onboarding-object

I want to know which roles are assignable by users through onboarding, which this is needed for.