### PR TITLE
Fix session ID deadlockwhen opening a VoiceConnection

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -76,7 +76,8 @@ type VoiceSpeakingUpdateHandler func(vc *VoiceConnection, vs *VoiceSpeakingUpdat
 // Speaking sends a speaking notification to Discord over the voice websocket.
 // This must be sent as true prior to sending audio and should be set to false
 // once finished sending audio.
-//  b  : Send true if speaking, false if not.
+//
+//	b  : Send true if speaking, false if not.
 func (v *VoiceConnection) Speaking(b bool) (err error) {
 
 	v.log(LogDebug, "called (%t)", b)
@@ -291,9 +292,14 @@ func (v *VoiceConnection) open() (err error) {
 	// TODO temp? loop to wait for the SessionID
 	i := 0
 	for {
-		if v.sessionID != "" {
+		v.Unlock()
+		sessionID := v.sessionID
+		v.Lock()
+
+		if sessionID != "" {
 			break
 		}
+
 		if i > 20 { // only loop for up to 1 second total
 			return fmt.Errorf("did not receive voice Session ID in time")
 		}

--- a/voice.go
+++ b/voice.go
@@ -298,7 +298,7 @@ func (v *VoiceConnection) open() (err error) {
 		if i > 20 { // only loop for up to 1 second total
 			return fmt.Errorf("did not receive voice Session ID in time")
 		}
-		// release the lock so other processes can populate the sessionID if a ws message is received
+		// Release the lock, so sessionID can be populated upon receiving a VoiceStateUpdate event.
 		v.Unlock()
 		time.Sleep(50 * time.Millisecond)
 		i++

--- a/voice.go
+++ b/voice.go
@@ -292,19 +292,18 @@ func (v *VoiceConnection) open() (err error) {
 	// TODO temp? loop to wait for the SessionID
 	i := 0
 	for {
-		v.Unlock()
-		sessionID := v.sessionID
-		v.Lock()
-
-		if sessionID != "" {
+		if v.sessionID != "" {
 			break
 		}
 
 		if i > 20 { // only loop for up to 1 second total
 			return fmt.Errorf("did not receive voice Session ID in time")
 		}
+		// release the lock so other processes can populate the sessionID if a ws message is received
+		v.Unlock()
 		time.Sleep(50 * time.Millisecond)
 		i++
+		v.Lock()
 	}
 
 	// Connect to VoiceConnection Websocket

--- a/voice.go
+++ b/voice.go
@@ -76,8 +76,7 @@ type VoiceSpeakingUpdateHandler func(vc *VoiceConnection, vs *VoiceSpeakingUpdat
 // Speaking sends a speaking notification to Discord over the voice websocket.
 // This must be sent as true prior to sending audio and should be set to false
 // once finished sending audio.
-//
-//	b  : Send true if speaking, false if not.
+// b : Send true if speaking, false if not.
 func (v *VoiceConnection) Speaking(b bool) (err error) {
 
 	v.log(LogDebug, "called (%t)", b)


### PR DESCRIPTION
Closes https://github.com/bwmarrin/discordgo/issues/829

When checking the Voice Session ID in `VoiceConnection.open()`, the sessionID is populated asynchronously when websocket messages come in, see [wsapi.go](https://github.com/bwmarrin/discordgo/blob/master/wsapi.go#L736C19-L736C19). 

However, `open()` still holds the lock on the session, so the ID can never be populated, and we loop and accomplish nothing until releasing the lock upon exiting the function. 

This PR addresses this deadlock bug by momentarily releasing the lock anytime the process sleeps, allowing other processes to populate the sessionID appropriately - while not sacrificing concurrency safety by releasing the lock entirely.