### PR TITLE
feat(role): add flags

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -42,6 +42,10 @@ var (
 	EndpointCDNChannelIcons = EndpointCDN + "channel-icons/"
 	EndpointCDNBanners      = EndpointCDN + "banners/"
 	EndpointCDNGuilds       = EndpointCDN + "guilds/"
+	EndpointCDNRoleIcons    = EndpointCDN + "role-icons/"
+	EndpointRoleIcon        = func(rID, cID string) string {
+		return EndpointCDNRoleIcons + rID + "/" + cID + ".png"
+	}
 
 	EndpointVoice        = EndpointAPI + "/voice/"
 	EndpointVoiceRegions = EndpointVoice + "regions"

--- a/structs.go
+++ b/structs.go
@@ -1239,11 +1239,34 @@ type Role struct {
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the permission.
 	Permissions int64 `json:"permissions,string"`
+
+	// The hash of the role icon. Use Role.IconURL to retrieve the icon's URL.
+	Icon string `json:"icon"`
+
+	// The emoji assigned to this role.
+	UnicodeEmoji string `json:"unicode_emoji"`
 }
 
 // Mention returns a string which mentions the role
 func (r *Role) Mention() string {
 	return fmt.Sprintf("<@&%s>", r.ID)
+}
+
+// IconURL returns the URL of the users's banner image.
+//
+//	size:    The size of the desired role icon as a power of two
+//	         Image size can be any power of two between 16 and 4096.
+func (r *Role) IconURL(size string) string {
+	if r.Icon == "" {
+		return ""
+	}
+
+	URL := EndpointRoleIcon(r.ID, r.Icon)
+
+	if size != "" {
+		return URL + "?size=" + size
+	}
+	return URL
 }
 
 // RoleParams represents the parameters needed to create or update a Role

--- a/structs.go
+++ b/structs.go
@@ -1256,7 +1256,7 @@ type Role struct {
 // https://discord.com/developers/docs/topics/permissions#role-object-role-flags
 type RoleFlags int
 
-// Block containing known RoleFlags values
+// Block containing known RoleFlags values.
 const (
 	// RoleFlagInPrompt Role can be selected by members in an onboarding prompt.
 	RoleFlagInPrompt RoleFlags = 1 << 0

--- a/structs.go
+++ b/structs.go
@@ -1258,7 +1258,7 @@ type RoleFlags int
 
 // Block containing known RoleFlags values.
 const (
-	// RoleFlagInPrompt Role can be selected by members in an onboarding prompt.
+	// RoleFlagInPrompt indicates a Role to be selectable by members in an onboarding prompt.
 	RoleFlagInPrompt RoleFlags = 1 << 0
 )
 

--- a/structs.go
+++ b/structs.go
@@ -1245,7 +1245,22 @@ type Role struct {
 
 	// The emoji assigned to this role.
 	UnicodeEmoji string `json:"unicode_emoji"`
+
+	// The flags of the role, which describe extra features of a role.
+	// This is a combination of bit masks; the presence of a certain permission can
+	// be checked by performing a bitwise AND between this int and the flag.
+	Flags RoleFlags `json:"flags"`
 }
+
+// RoleFlags is the flags of "role" (see RoleFlags* consts)
+// https://discord.com/developers/docs/topics/permissions#role-object-role-flags
+type RoleFlags int
+
+// Block containing known RoleFlags values
+const (
+	// RoleFlagInPrompt Role can be selected by members in an onboarding prompt.
+	RoleFlagInPrompt RoleFlags = 1 << 0
+)
 
 // Mention returns a string which mentions the role
 func (r *Role) Mention() string {

--- a/structs.go
+++ b/structs.go
@@ -1356,7 +1356,7 @@ type Role struct {
 	// The emoji assigned to this role.
 	UnicodeEmoji string `json:"unicode_emoji"`
 
-	// The flags of the role, which describe extra features of a role.
+	// The flags of the role, which describe its extra features.
 	// This is a combination of bit masks; the presence of a certain permission can
 	// be checked by performing a bitwise AND between this int and the flag.
 	Flags RoleFlags `json:"flags"`

--- a/structs.go
+++ b/structs.go
@@ -1362,7 +1362,7 @@ type Role struct {
 	Flags RoleFlags `json:"flags"`
 }
 
-// RoleFlags is the flags of "role" (see RoleFlags* consts)
+// RoleFlags represent the flags of a Role.
 // https://discord.com/developers/docs/topics/permissions#role-object-role-flags
 type RoleFlags int
 

--- a/structs.go
+++ b/structs.go
@@ -1357,7 +1357,7 @@ type Role struct {
 	UnicodeEmoji string `json:"unicode_emoji"`
 
 	// The flags of the role, which describe its extra features.
-	// This is a combination of bit masks; the presence of a certain permission can
+	// This is a combination of bit masks; the presence of a certain flag can
 	// be checked by performing a bitwise AND between this int and the flag.
 	Flags RoleFlags `json:"flags"`
 }

--- a/structs.go
+++ b/structs.go
@@ -1368,7 +1368,7 @@ type RoleFlags int
 
 // Block containing known RoleFlags values.
 const (
-	// RoleFlagInPrompt indicates a Role to be selectable by members in an onboarding prompt.
+	// RoleFlagInPrompt indicates whether the Role is selectable by members in an onboarding prompt.
 	RoleFlagInPrompt RoleFlags = 1 << 0
 )
 


### PR DESCRIPTION
Depends on #1334

https://discord.com/developers/docs/topics/permissions#role-object-role-flags

A better solution to what I was doing in my onboarding pr, wasn't documented at the time though.
I also thought about adding the `tags` field as per #1316 but that has weird nullable types I didn't want to bother with. The issue should also be reopened as the PR doesn't address it fully and isn't merged.