### PR TITLE
Add new permissions

### DIFF
--- a/examples/slash_commands/main.go
+++ b/examples/slash_commands/main.go
@@ -35,7 +35,7 @@ func init() {
 var (
 	integerOptionMinValue          = 1.0
 	dmPermission                   = false
-	defaultMemberPermissions int64 = discordgo.PermissionManageServer
+	defaultMemberPermissions int64 = discordgo.PermissionManageGuild
 
 	commands = []*discordgo.ApplicationCommand{
 		{

--- a/structs.go
+++ b/structs.go
@@ -2435,6 +2435,9 @@ const (
 
 	// Allows for sending messages in threads.
 	PermissionSendMessagesInThreads = 1 << 38
+
+	// Allows sending voice messages.
+	PermissionSendVoiceMessages = 1 << 46
 )
 
 // Constants for the different bit offsets of voice permissions
@@ -2468,6 +2471,12 @@ const (
 
 	// Allows for using Activities (applications with the EMBEDDED flag) in a voice channel.
 	PermissionUseActivities = 1 << 39
+
+	// Allows for using soundboard in a voice channel.
+	PermissionUseSoundboard = 1 << 42
+
+	// Allows the usage of custom soundboard sounds from other servers.
+	PermissionUseExternalSounds = 1 << 45
 )
 
 // Constants for general management.
@@ -2489,6 +2498,9 @@ const (
 
 	// Allows for creating, editing, and deleting scheduled events.
 	PermissionManageEvents = 1 << 33
+
+	// Allows for viewing role subscription insights.
+	PermissionViewCreatorMonetizationAnalytics = 1 << 41
 )
 
 // Constants for the different bit offsets of general permissions

--- a/structs.go
+++ b/structs.go
@@ -2418,8 +2418,11 @@ const (
 	// Allows the usage of custom emojis from other servers.
 	PermissionUseExternalEmojis = 1 << 18
 
-	// Allows members to use application commands, including slash commands and context menu commands.
+	// Deprecated: PermissionUseSlashCommands has been replaced by PermissionUseApplicationCommands
 	PermissionUseSlashCommands = 1 << 31
+
+	// Allows members to use application commands, including slash commands and context menu commands.
+	PermissionUseApplicationCommands = 1 << 31
 
 	// Allows for deleting and archiving threads, and viewing all private threads.
 	PermissionManageThreads = 1 << 34
@@ -2469,8 +2472,11 @@ const (
 	// Allows for requesting to speak in stage channels.
 	PermissionVoiceRequestToSpeak = 1 << 32
 
-	// Allows for using Activities (applications with the EMBEDDED flag) in a voice channel.
+	// Deprecated: PermissionUseActivities has been replaced by PermissionUseEmbeddedActivities.
 	PermissionUseActivities = 1 << 39
+
+	// Allows for using Activities (applications with the EMBEDDED flag) in a voice channel.
+	PermissionUseEmbeddedActivities = 1 << 39
 
 	// Allows for using soundboard in a voice channel.
 	PermissionUseSoundboard = 1 << 42
@@ -2493,8 +2499,11 @@ const (
 	// Allows management and editing of webhooks.
 	PermissionManageWebhooks = 1 << 29
 
-	// Allows management and editing of emojis, stickers, and soundboard sounds.
+	// Deprecated: PermissionManageEmojis has been replaced by PermissionManageGuildExpressions.
 	PermissionManageEmojis = 1 << 30
+
+	// Allows management and editing of emojis, stickers, and soundboard sounds.
+	PermissionManageGuildExpressions = 1 << 30
 
 	// Allows for creating, editing, and deleting scheduled events.
 	PermissionManageEvents = 1 << 33
@@ -2520,8 +2529,11 @@ const (
 	// Allows management and editing of channels.
 	PermissionManageChannels = 1 << 4
 
-	// Allows management and editing of the guil.
+	// Deprecated: PermissionManageServer has been replaced by PermissionManageGuild.
 	PermissionManageServer = 1 << 5
+
+	// Allows management and editing of the guild.
+	PermissionManageGuild = 1 << 5
 
 	// Allows for the addition of reactions to messages.
 	PermissionAddReactions = 1 << 6

--- a/structs.go
+++ b/structs.go
@@ -2392,60 +2392,139 @@ type Poll struct {
 // Constants for the different bit offsets of text channel permissions
 const (
 	// Deprecated: PermissionReadMessages has been replaced with PermissionViewChannel for text and voice channels
-	PermissionReadMessages          = 0x0000000000000400
-	PermissionSendMessages          = 0x0000000000000800
-	PermissionSendTTSMessages       = 0x0000000000001000
-	PermissionManageMessages        = 0x0000000000002000
-	PermissionEmbedLinks            = 0x0000000000004000
-	PermissionAttachFiles           = 0x0000000000008000
-	PermissionReadMessageHistory    = 0x0000000000010000
-	PermissionMentionEveryone       = 0x0000000000020000
-	PermissionUseExternalEmojis     = 0x0000000000040000
-	PermissionUseSlashCommands      = 0x0000000080000000
-	PermissionManageThreads         = 0x0000000400000000
-	PermissionCreatePublicThreads   = 0x0000000800000000
-	PermissionCreatePrivateThreads  = 0x0000001000000000
-	PermissionUseExternalStickers   = 0x0000002000000000
-	PermissionSendMessagesInThreads = 0x0000004000000000
+	PermissionReadMessages = 1 << 10
+
+	// Allows for sending messages in a channel and creating threads in a forum (does not allow sending messages in threads).
+	PermissionSendMessages = 1 << 11
+
+	// Allows for sending of /tts messages.
+	PermissionSendTTSMessages = 1 << 12
+
+	// Allows for deletion of other users messages.
+	PermissionManageMessages = 1 << 13
+
+	// Links sent by users with this permission will be auto-embedded.
+	PermissionEmbedLinks = 1 << 14
+
+	// Allows for uploading images and files.
+	PermissionAttachFiles = 1 << 15
+
+	// Allows for reading of message history.
+	PermissionReadMessageHistory = 1 << 16
+
+	// Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all online users in a channel.
+	PermissionMentionEveryone = 1 << 17
+
+	// Allows the usage of custom emojis from other servers.
+	PermissionUseExternalEmojis = 1 << 18
+
+	// Allows members to use application commands, including slash commands and context menu commands.
+	PermissionUseSlashCommands = 1 << 31
+
+	// Allows for deleting and archiving threads, and viewing all private threads.
+	PermissionManageThreads = 1 << 34
+
+	// Allows for creating public and announcement threads.
+	PermissionCreatePublicThreads = 1 << 35
+
+	// Allows for creating private threads.
+	PermissionCreatePrivateThreads = 1 << 36
+
+	// Allows the usage of custom stickers from other servers.
+	PermissionUseExternalStickers = 1 << 37
+
+	// Allows for sending messages in threads.
+	PermissionSendMessagesInThreads = 1 << 38
 )
 
 // Constants for the different bit offsets of voice permissions
 const (
-	PermissionVoicePrioritySpeaker = 0x0000000000000100
-	PermissionVoiceStreamVideo     = 0x0000000000000200
-	PermissionVoiceConnect         = 0x0000000000100000
-	PermissionVoiceSpeak           = 0x0000000000200000
-	PermissionVoiceMuteMembers     = 0x0000000000400000
-	PermissionVoiceDeafenMembers   = 0x0000000000800000
-	PermissionVoiceMoveMembers     = 0x0000000001000000
-	PermissionVoiceUseVAD          = 0x0000000002000000
-	PermissionVoiceRequestToSpeak  = 0x0000000100000000
-	PermissionUseActivities        = 0x0000008000000000
+	// Allows for using priority speaker in a voice channel.
+	PermissionVoicePrioritySpeaker = 1 << 8
+
+	// Allows the user to go live.
+	PermissionVoiceStreamVideo = 1 << 9
+
+	// Allows for joining of a voice channel.
+	PermissionVoiceConnect = 1 << 20
+
+	// Allows for speaking in a voice channel.
+	PermissionVoiceSpeak = 1 << 21
+
+	// Allows for muting members in a voice channel.
+	PermissionVoiceMuteMembers = 1 << 22
+
+	// Allows for deafening of members in a voice channel.
+	PermissionVoiceDeafenMembers = 1 << 23
+
+	// Allows for moving of members between voice channels.
+	PermissionVoiceMoveMembers = 1 << 24
+
+	// Allows for using voice-activity-detection in a voice channel.
+	PermissionVoiceUseVAD = 1 << 25
+
+	// Allows for requesting to speak in stage channels.
+	PermissionVoiceRequestToSpeak = 1 << 32
+
+	// Allows for using Activities (applications with the EMBEDDED flag) in a voice channel.
+	PermissionUseActivities = 1 << 39
 )
 
 // Constants for general management.
 const (
-	PermissionChangeNickname  = 0x0000000004000000
-	PermissionManageNicknames = 0x0000000008000000
-	PermissionManageRoles     = 0x0000000010000000
-	PermissionManageWebhooks  = 0x0000000020000000
-	PermissionManageEmojis    = 0x0000000040000000
-	PermissionManageEvents    = 0x0000000200000000
+	// Allows for modification of own nickname.
+	PermissionChangeNickname = 1 << 26
+
+	// Allows for modification of other users nicknames.
+	PermissionManageNicknames = 1 << 27
+
+	// Allows management and editing of roles.
+	PermissionManageRoles = 1 << 28
+
+	// Allows management and editing of webhooks.
+	PermissionManageWebhooks = 1 << 29
+
+	// Allows management and editing of emojis, stickers, and soundboard sounds.
+	PermissionManageEmojis = 1 << 30
+
+	// Allows for creating, editing, and deleting scheduled events.
+	PermissionManageEvents = 1 << 33
 )
 
 // Constants for the different bit offsets of general permissions
 const (
-	PermissionCreateInstantInvite = 0x0000000000000001
-	PermissionKickMembers         = 0x0000000000000002
-	PermissionBanMembers          = 0x0000000000000004
-	PermissionAdministrator       = 0x0000000000000008
-	PermissionManageChannels      = 0x0000000000000010
-	PermissionManageServer        = 0x0000000000000020
-	PermissionAddReactions        = 0x0000000000000040
-	PermissionViewAuditLogs       = 0x0000000000000080
-	PermissionViewChannel         = 0x0000000000000400
-	PermissionViewGuildInsights   = 0x0000000000080000
-	PermissionModerateMembers     = 0x0000010000000000
+	// Allows creation of instant invites.
+	PermissionCreateInstantInvite = 1 << 0
+
+	// Allows kicking members.
+	PermissionKickMembers = 1 << 1
+
+	// Allows banning members.
+	PermissionBanMembers = 1 << 2
+
+	// Allows all permissions and bypasses channel permission overwrites.
+	PermissionAdministrator = 1 << 3
+
+	// Allows management and editing of channels.
+	PermissionManageChannels = 1 << 4
+
+	// Allows management and editing of the guil.
+	PermissionManageServer = 1 << 5
+
+	// Allows for the addition of reactions to messages.
+	PermissionAddReactions = 1 << 6
+
+	// Allows for viewing of audit logs.
+	PermissionViewAuditLogs = 1 << 7
+
+	// Allows guild members to view a channel, which includes reading messages in text channels and joining voice channels.
+	PermissionViewChannel = 1 << 10
+
+	// Allows for viewing guild insights.
+	PermissionViewGuildInsights = 1 << 19
+
+	// Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels.
+	PermissionModerateMembers = 1 << 40
 
 	PermissionAllText = PermissionViewChannel |
 		PermissionSendMessages |

--- a/structs.go
+++ b/structs.go
@@ -2441,6 +2441,12 @@ const (
 
 	// Allows sending voice messages.
 	PermissionSendVoiceMessages = 1 << 46
+
+	// Allows sending polls.
+	PermissionSendPolls = 1 << 49
+
+	// Allows user-installed apps to send public responses. When disabled, users will still be allowed to use their apps but the responses will be ephemeral. This only applies to apps not also installed to the server.
+	PermissionUseExternalApps = 1 << 50
 )
 
 // Constants for the different bit offsets of voice permissions
@@ -2502,14 +2508,20 @@ const (
 	// Deprecated: PermissionManageEmojis has been replaced by PermissionManageGuildExpressions.
 	PermissionManageEmojis = 1 << 30
 
-	// Allows management and editing of emojis, stickers, and soundboard sounds.
+	// Allows for editing and deleting emojis, stickers, and soundboard sounds created by all users.
 	PermissionManageGuildExpressions = 1 << 30
 
-	// Allows for creating, editing, and deleting scheduled events.
+	// Allows for editing and deleting scheduled events created by all users.
 	PermissionManageEvents = 1 << 33
 
 	// Allows for viewing role subscription insights.
 	PermissionViewCreatorMonetizationAnalytics = 1 << 41
+
+	// Allows for creating emojis, stickers, and soundboard sounds, and editing and deleting those created by the current user.
+	PermissionCreateGuildExpressions = 1 << 43
+
+	// Allows for creating scheduled events, and editing and deleting those created by the current user.
+	PermissionCreateEvents = 1 << 44
 )
 
 // Constants for the different bit offsets of general permissions


### PR DESCRIPTION
First commit makes the numbers bitflags which I find easier to parse and follows all the other flags in the repo. I also added docs for them.

Second commit adds missing flags currently documented at https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags

Third commit renames some fields to what they are now called on discords docs page.

Fourth commit adds currently undocumented flags, but there is a pending pr for those at https://github.com/discord/discord-api-docs/pull/6305