### PR TITLE
Add missing `thread_name` field for creating forum posts with webhooks

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -37,7 +37,8 @@ type WebhookParams struct {
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	// Only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set.
 	// MessageFlagsEphemeral can only be set when using Followup Message Create endpoint.
-	Flags MessageFlags `json:"flags,omitempty"`
+	Flags      MessageFlags `json:"flags,omitempty"`
+	ThreadName string       `json:"thread_name,omitempty"`
 }
 
 // WebhookEdit stores data for editing of a webhook message.

--- a/webhook.go
+++ b/webhook.go
@@ -37,8 +37,10 @@ type WebhookParams struct {
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	// Only MessageFlagsSuppressEmbeds and MessageFlagsEphemeral can be set.
 	// MessageFlagsEphemeral can only be set when using Followup Message Create endpoint.
-	Flags      MessageFlags `json:"flags,omitempty"`
-	ThreadName string       `json:"thread_name,omitempty"`
+	Flags MessageFlags `json:"flags,omitempty"`
+	// Name of the thread to create.
+	// NOTE: can only be set if the webhook channel is a forum.
+	ThreadName string `json:"thread_name,omitempty"`
 }
 
 // WebhookEdit stores data for editing of a webhook message.


### PR DESCRIPTION
https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params