### PR TITLE
fix(auditlog): Use correct values for AuditLogOptionsType

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1760,8 +1760,8 @@ type AuditLogOptionsType string
 
 // Valid Types for AuditLogOptionsType
 const (
-	AuditLogOptionsTypeMember AuditLogOptionsType = "member"
-	AuditLogOptionsTypeRole   AuditLogOptionsType = "role"
+	AuditLogOptionsTypeRole   AuditLogOptionsType = "0"
+	AuditLogOptionsTypeMember AuditLogOptionsType = "1"
 )
 
 // AuditLogAction is the Action of the AuditLog (see AuditLogAction* consts)


### PR DESCRIPTION
Perhaps they had this value previously but that is not the case right now.

Per the docs at https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info

> type | Type of overwritten entity - role ("0") or member ("1")

role_name makes that even more clearer:

> role_name | Name of the role if type is "0" (not present if type is "1")