### PR TITLE
nil send/receive channels on Close()

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -210,6 +210,11 @@ func (v *VoiceConnection) Close() {
 
 		v.wsConn = nil
 	}
+
+	// Nil the send/receive channels in case the VoiceChannel gets reused,
+	// otherwise the nil check in onEvent means we attempt to send to a closed channel.
+	v.OpusSend = nil
+	v.OpusRecv = nil
 }
 
 // AddHandler adds a Handler for VoiceSpeakingUpdate events.


### PR DESCRIPTION
Without the below (or handling this explicitly by the caller), reusing the VoiceChannel causes a panic attempting to send on a closed channel. This ensures the channels are nil'd on Close(), meaning they can be reused without this additional protection.