### PR TITLE
feat(session): Adding an event handler for monitoring purposes.

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -134,6 +134,9 @@ type Session struct {
 
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
+
+	// eventNotifier is used to notify the event handler of events
+	eventNotifier chan<- any
 }
 
 // Application stores values for a Discord Application

--- a/wsapi.go
+++ b/wsapi.go
@@ -521,6 +521,17 @@ func (s *Session) requestGuildMembers(data requestGuildMembersData) (err error) 
 // "OnEvent" event then all events will be passed to that handler.
 func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 
+	// If the eventNotifier channel is not full and not nil then send to channel.
+	if s.eventNotifier != nil {
+		select {
+		case s.eventNotifier <- message:
+		default:
+			// If the channel is full, drop the event. This is to prevent blocking the gateway. This is not a problem
+			// as the eventNotifier channel is only used for monitoring purposes. If you want to handle events, use
+			// AddHandler.
+		}
+	}
+
 	var err error
 	var reader io.Reader
 	reader = bytes.NewBuffer(message)
@@ -662,10 +673,10 @@ type voiceChannelJoinOp struct {
 
 // ChannelVoiceJoin joins the session user to a voice channel.
 //
-//    gID     : Guild ID of the channel to join.
-//    cID     : Channel ID of the channel to join.
-//    mute    : If true, you will be set to muted upon joining.
-//    deaf    : If true, you will be set to deafened upon joining.
+//	gID     : Guild ID of the channel to join.
+//	cID     : Channel ID of the channel to join.
+//	mute    : If true, you will be set to muted upon joining.
+//	deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *VoiceConnection, err error) {
 
 	s.log(LogInformational, "called")
@@ -709,10 +720,10 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 //
 // This should only be used when the VoiceServerUpdate will be intercepted and used elsewhere.
 //
-//    gID     : Guild ID of the channel to join.
-//    cID     : Channel ID of the channel to join, leave empty to disconnect.
-//    mute    : If true, you will be set to muted upon joining.
-//    deaf    : If true, you will be set to deafened upon joining.
+//	gID     : Guild ID of the channel to join.
+//	cID     : Channel ID of the channel to join, leave empty to disconnect.
+//	mute    : If true, you will be set to muted upon joining.
+//	deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err error) {
 
 	s.log(LogInformational, "called")


### PR DESCRIPTION
Adding an event notifier to be used for monitoring purposes. The change can be used for things such as Prometheus monitoring. This is the result as there is no way to intercept messages through a middleware before the events are pushed to their respective handlers. This approach will force the events through the channel if it is not full.

I have included a respective code example below:

```go
func (a *App) Run() error {
	// Register bot.
	if err := a.RegisterBot(); err != nil {
		return fmt.Errorf("error registering bot: %w", err)
	}

	a.s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
		a.Info(fmt.Sprintf("Logged in as %s#%s", r.User.Username, r.User.Discriminator))
	})

	// Register commands.
	if err := a.RegisterCommands(); err != nil {
		return fmt.Errorf("error registering commands: %w", err)
	}

	if err := a.RegisterDiscordHandlers(); err != nil {
		return fmt.Errorf("error registering discord handlers: %w", err)
	}

	// Start event listener.
	go a.eventListener()

	// Open websocket.
	if err := a.s.Open(); err != nil {
		return fmt.Errorf("error opening connection to Discord: %w", err)
	}
	return nil
}

func (a *App) eventListener() {
	for e := range a.eventNotifier {
		switch t := e.(type) {
		case *discordgo.Event:
			monitoring.TotalDiscordEvents.WithLabelValues(t.Type).Inc()
		default:
			a.Error("Unknown event type", slog.String("type", fmt.Sprintf("%T", e)))
			monitoring.TotalDiscordEvents.WithLabelValues("unknown").Inc()
		}
	}
}
```

The code above will produce the respective graphs in Grafana by using the rate query with Prometheus.

![image](https://github.com/bwmarrin/discordgo/assets/75381570/fc086dac-fac9-4804-8c06-6e2ea4f20df1)
