### PR TITLE
Implement custom status

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -389,6 +389,26 @@ func (s *Session) UpdateListeningStatus(name string) (err error) {
 	return s.UpdateStatusComplex(*newUpdateStatusData(0, ActivityTypeListening, name, ""))
 }
 
+// UpdateCustomStatus is used to update the user's custom status.
+// If state!="" then set the custom status.
+// Else, set user to active and remove the custom status.
+func (s *Session) UpdateCustomStatus(state string) (err error) {
+	data := UpdateStatusData{
+		Status: "online",
+	}
+
+	if state != "" {
+		// Discord requires a non-empty activity name, therefore we provide "Custom Status" as a placeholder.
+		data.Activities = []*Activity{{
+			Name:  "Custom Status",
+			Type:  ActivityTypeCustom,
+			State: state,
+		}}
+	}
+
+	return s.UpdateStatusComplex(data)
+}
+
 // UpdateStatusComplex allows for sending the raw status update data untouched by discordgo.
 func (s *Session) UpdateStatusComplex(usd UpdateStatusData) (err error) {
 	// The comment does say "untouched by discordgo", but we might need to lie a bit here.


### PR DESCRIPTION
Discord has recently allowed bots to have a custom status, this PR adds a new utility function - `UpdateCustomStatus`, which would let you set and reset such status.