### PR TITLE
feat(member): add helper function for display name

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1394,6 +1394,15 @@ func (m *Member) AvatarURL(size string) string {
 
 }
 
+// DisplayName returns the member's guild nickname if they have one,
+// otherwise it returns their discord display name.
+func (m *Member) DisplayName() string {
+	if m.Nick != "" {
+		return m.Nick
+	}
+	return m.User.GlobalName
+}
+
 // ClientStatus stores the online, offline, idle, or dnd status of each device of a Guild member.
 type ClientStatus struct {
 	Desktop Status `json:"desktop"`

--- a/structs_test.go
+++ b/structs_test.go
@@ -1,0 +1,36 @@
+// Discordgo - Discord bindings for Go
+// Available at https://github.com/bwmarrin/discordgo
+
+// Copyright 2015-2016 Bruce Marriner <bruce@sqls.net>.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package discordgo
+
+import (
+	"testing"
+)
+
+func TestMember_DisplayName(t *testing.T) {
+	user := &User{
+		GlobalName: "Global",
+	}
+	t.Run("no server nickname set", func(t *testing.T) {
+		m := &Member{
+			Nick: "",
+			User: user,
+		}
+		if dn := m.DisplayName(); dn != user.GlobalName {
+			t.Errorf("Member.DisplayName() = %v, want %v", dn, user.GlobalName)
+		}
+	})
+	t.Run("server nickname set", func(t *testing.T) {
+		m := &Member{
+			Nick: "Server",
+			User: user,
+		}
+		if dn := m.DisplayName(); dn != m.Nick {
+			t.Errorf("Member.DisplayName() = %v, want %v", dn, m.Nick)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds a simple helper on the `Member` struct to retrieve a member display name on the server, by either using the member nick if one is set, or the profile display name (called `GlobalName` in the API)

Would love to see this as part of https://github.com/bwmarrin/discordgo/milestone/25 :)