### PR TITLE
You can use RequestOption when establishing an open connection

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -47,7 +47,7 @@ type resumePacket struct {
 
 // Open creates a websocket connection to Discord.
 // See: https://discord.com/developers/docs/topics/gateway#connecting
-func (s *Session) Open() error {
+func (s *Session) Open(options ...RequestOption) error {
 	s.log(LogInformational, "called")
 
 	var err error
@@ -64,7 +64,7 @@ func (s *Session) Open() error {
 
 	// Get the gateway to use for the Websocket connection
 	if s.gateway == "" {
-		s.gateway, err = s.Gateway()
+		s.gateway, err = s.Gateway(options...)
 		if err != nil {
 			return err
 		}
@@ -662,10 +662,10 @@ type voiceChannelJoinOp struct {
 
 // ChannelVoiceJoin joins the session user to a voice channel.
 //
-//    gID     : Guild ID of the channel to join.
-//    cID     : Channel ID of the channel to join.
-//    mute    : If true, you will be set to muted upon joining.
-//    deaf    : If true, you will be set to deafened upon joining.
+//	gID     : Guild ID of the channel to join.
+//	cID     : Channel ID of the channel to join.
+//	mute    : If true, you will be set to muted upon joining.
+//	deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *VoiceConnection, err error) {
 
 	s.log(LogInformational, "called")
@@ -709,10 +709,10 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 //
 // This should only be used when the VoiceServerUpdate will be intercepted and used elsewhere.
 //
-//    gID     : Guild ID of the channel to join.
-//    cID     : Channel ID of the channel to join, leave empty to disconnect.
-//    mute    : If true, you will be set to muted upon joining.
-//    deaf    : If true, you will be set to deafened upon joining.
+//	gID     : Guild ID of the channel to join.
+//	cID     : Channel ID of the channel to join, leave empty to disconnect.
+//	mute    : If true, you will be set to muted upon joining.
+//	deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err error) {
 
 	s.log(LogInformational, "called")


### PR DESCRIPTION
`s.gateway, err = s.Gateway()`
open The gateway requests the connection, and the http proxy cannot be used