### PR TITLE
feat(auditlog): add status to options

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1752,6 +1752,7 @@ type AuditLogOptions struct {
 	ApplicationID                 string               `json:"application_id"`
 	AutoModerationRuleName        string               `json:"auto_moderation_rule_name"`
 	AutoModerationRuleTriggerType string               `json:"auto_moderation_rule_trigger_type"`
+	Status                        string               `json:"status"`
 }
 
 // AuditLogOptionsType of the AuditLogOption


### PR DESCRIPTION
This is not documented at the moment. The field contains the text you provide when setting a custom voice channel status.

![image](https://github.com/bwmarrin/discordgo/assets/14981592/9ca75834-866b-4d59-b72f-5cf6238c19b9)
![image](https://github.com/bwmarrin/discordgo/assets/14981592/fe2cfc5c-d56d-49d4-ba8c-e71d4e339aeb)
