### PR TITLE
Adding sync_id for presences

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1970,6 +1970,7 @@ type Activity struct {
 	Secrets       Secrets      `json:"secrets,omitempty"`
 	Instance      bool         `json:"instance,omitempty"`
 	Flags         int          `json:"flags,omitempty"`
+	SyncId        string       `json:"sync_id,omitempty"`
 }
 
 // UnmarshalJSON is a custom unmarshaljson to make CreatedAt a time.Time instead of an int
@@ -1989,6 +1990,7 @@ func (activity *Activity) UnmarshalJSON(b []byte) error {
 		Secrets       Secrets      `json:"secrets,omitempty"`
 		Instance      bool         `json:"instance,omitempty"`
 		Flags         int          `json:"flags,omitempty"`
+		SyncId        string       `json:"sync_id,omitempty"`
 	}{}
 	err := Unmarshal(b, &temp)
 	if err != nil {
@@ -2008,6 +2010,7 @@ func (activity *Activity) UnmarshalJSON(b []byte) error {
 	activity.Timestamps = temp.Timestamps
 	activity.Type = temp.Type
 	activity.URL = temp.URL
+	activity.SyncId = temp.SyncId
 	return nil
 }
 


### PR DESCRIPTION
Adding support for `sync_Id` when unpacking Presence activities. This will give users the ability to get the `Spotify Track ID` from a presence event