### PR TITLE
feat(user): Add UserPremiumType type

### DIFF
--- a/user.go
+++ b/user.go
@@ -30,7 +30,7 @@ const (
 // https://discord.com/developers/docs/resources/user#user-object-premium-types
 type UserPremiumType int
 
-// Valid UserFlags values
+// Valid UserPremiumType values
 const (
 	UserPremiumTypeNone         UserPremiumType = 0
 	UserPremiumTypeNitroClassic UserPremiumType = 1

--- a/user.go
+++ b/user.go
@@ -26,11 +26,11 @@ const (
 	UserFlagDiscordCertifiedModerator UserFlags = 1 << 18
 )
 
-// UserPremiumType is the premium type of a user (see UserPremiumType* consts)
+// UserPremiumType is the premium type of a user (see UserPremiumType* consts).
 // https://discord.com/developers/docs/resources/user#user-object-premium-types
 type UserPremiumType int
 
-// Valid UserPremiumType values
+// Valid UserPremiumType values.
 const (
 	UserPremiumTypeNone         UserPremiumType = 0
 	UserPremiumTypeNitroClassic UserPremiumType = 1

--- a/user.go
+++ b/user.go
@@ -26,6 +26,18 @@ const (
 	UserFlagDiscordCertifiedModerator UserFlags = 1 << 18
 )
 
+// UserPremiumType is the premium type of a user (see UserPremiumType* consts)
+// https://discord.com/developers/docs/resources/user#user-object-premium-types
+type UserPremiumType int
+
+// Valid UserFlags values
+const (
+	UserPremiumTypeNone         UserPremiumType = 0
+	UserPremiumTypeNitroClassic UserPremiumType = 1
+	UserPremiumTypeNitro        UserPremiumType = 2
+	UserPremiumTypeNitroBasic   UserPremiumType = 3
+)
+
 // A User stores all data for an individual Discord user.
 type User struct {
 	// The ID of the user.
@@ -78,7 +90,7 @@ type User struct {
 
 	// The type of Nitro subscription on a user's account.
 	// Only available when the request is authorized via a Bearer token.
-	PremiumType int `json:"premium_type"`
+	PremiumType UserPremiumType `json:"premium_type"`
 
 	// Whether the user is an Official Discord System user (part of the urgent message system).
 	System bool `json:"system"`

--- a/user.go
+++ b/user.go
@@ -26,7 +26,7 @@ const (
 	UserFlagDiscordCertifiedModerator UserFlags = 1 << 18
 )
 
-// UserPremiumType is the premium type of a user (see UserPremiumType* consts).
+// UserPremiumType is the type of premium (nitro) subscription a user has (see UserPremiumType* consts).
 // https://discord.com/developers/docs/resources/user#user-object-premium-types
 type UserPremiumType int
 


### PR DESCRIPTION
I noticed the PremiumType field on the User struct has no specific type (and instead has type int).

Because of this, I had to define the type/consts myself or use magic numbers. I think it should be added in the library, as other fields do have their own types (like User.PublicFlags).

See the Discord documentation at https://discord.com/developers/docs/resources/user#user-object-premium-types