### PR TITLE
Add `Snowflake` type, which is a string with a custom UnmarshalJSON.

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -26,9 +26,12 @@ const VERSION = "0.27.1"
 
 // New creates a new Discord session with provided token.
 // If the token is for a bot, it must be prefixed with "Bot "
-// 		e.g. "Bot ..."
+//
+//	e.g. "Bot ..."
+//
 // Or if it is an OAuth2 token, it must be prefixed with "Bearer "
-//		e.g. "Bearer ..."
+//
+//	e.g. "Bearer ..."
 func New(token string) (s *Session, err error) {
 
 	// Create an empty Session interface.

--- a/discord_test.go
+++ b/discord_test.go
@@ -9,18 +9,18 @@ import (
 	"time"
 )
 
-//////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////// VARS NEEDED FOR TESTING
+// ////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////// VARS NEEDED FOR TESTING
 var (
 	dg    *Session // Stores a global discordgo user session
 	dgBot *Session // Stores a global discordgo bot session
 
-	envOAuth2Token  = os.Getenv("DG_OAUTH2_TOKEN")  // Token to use when authenticating using OAuth2 token
-	envBotToken     = os.Getenv("DGB_TOKEN")        // Token to use when authenticating the bot account
-	envGuild        = os.Getenv("DG_GUILD")         // Guild ID to use for tests
-	envChannel      = os.Getenv("DG_CHANNEL")       // Channel ID to use for tests
-	envVoiceChannel = os.Getenv("DG_VOICE_CHANNEL") // Channel ID to use for tests
-	envAdmin        = os.Getenv("DG_ADMIN")         // User ID of admin user to use for tests
+	envOAuth2Token  = os.Getenv("DG_OAUTH2_TOKEN")             // Token to use when authenticating using OAuth2 token
+	envBotToken     = os.Getenv("DGB_TOKEN")                   // Token to use when authenticating the bot account
+	envGuild        = Snowflake(os.Getenv("DG_GUILD"))         // Guild ID to use for tests
+	envChannel      = Snowflake(os.Getenv("DG_CHANNEL"))       // Channel ID to use for tests
+	envVoiceChannel = Snowflake(os.Getenv("DG_VOICE_CHANNEL")) // Channel ID to use for tests
+	envAdmin        = Snowflake(os.Getenv("DG_ADMIN"))         // User ID of admin user to use for tests
 )
 
 func TestMain(m *testing.M) {

--- a/endpoints.go
+++ b/endpoints.go
@@ -11,7 +11,9 @@
 
 package discordgo
 
-import "strconv"
+import (
+	"strconv"
+)
 
 // APIVersion is the Discord API version used for the REST and Websocket API.
 var APIVersion = "9"
@@ -47,172 +49,196 @@ var (
 	EndpointVoice        = EndpointAPI + "/voice/"
 	EndpointVoiceRegions = EndpointVoice + "regions"
 
-	EndpointUser               = func(uID string) string { return EndpointUsers + uID }
-	EndpointUserAvatar         = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".png" }
-	EndpointUserAvatarAnimated = func(uID, aID string) string { return EndpointCDNAvatars + uID + "/" + aID + ".gif" }
-	EndpointDefaultUserAvatar  = func(idx int) string {
+	EndpointUser       = func(uID Snowflake) string { return EndpointUsers + string(uID) }
+	EndpointUserAvatar = func(uID Snowflake, hash string) string {
+		return EndpointCDNAvatars + string(uID) + "/" + hash + ".png"
+	}
+	EndpointUserAvatarAnimated = func(uID Snowflake, hash string) string {
+		return EndpointCDNAvatars + string(uID) + "/" + hash + ".gif"
+	}
+	EndpointDefaultUserAvatar = func(idx int) string {
 		return EndpointCDN + "embed/avatars/" + strconv.Itoa(idx) + ".png"
 	}
-	EndpointUserBanner = func(uID, cID string) string {
-		return EndpointCDNBanners + uID + "/" + cID + ".png"
+	EndpointUserBanner = func(uID Snowflake, hash string) string {
+		return EndpointCDNBanners + string(uID) + "/" + hash + ".png"
 	}
-	EndpointUserBannerAnimated = func(uID, cID string) string {
-		return EndpointCDNBanners + uID + "/" + cID + ".gif"
+	EndpointUserBannerAnimated = func(uID Snowflake, hash string) string {
+		return EndpointCDNBanners + string(uID) + "/" + hash + ".gif"
 	}
 
-	EndpointUserGuilds                    = func(uID string) string { return EndpointUsers + uID + "/guilds" }
-	EndpointUserGuild                     = func(uID, gID string) string { return EndpointUsers + uID + "/guilds/" + gID }
-	EndpointUserGuildMember               = func(uID, gID string) string { return EndpointUserGuild(uID, gID) + "/member" }
-	EndpointUserChannels                  = func(uID string) string { return EndpointUsers + uID + "/channels" }
-	EndpointUserApplicationRoleConnection = func(aID string) string { return EndpointUsers + "@me/applications/" + aID + "/role-connection" }
-	EndpointUserConnections               = func(uID string) string { return EndpointUsers + uID + "/connections" }
-
-	EndpointGuild                    = func(gID string) string { return EndpointGuilds + gID }
-	EndpointGuildAutoModeration      = func(gID string) string { return EndpointGuild(gID) + "/auto-moderation" }
-	EndpointGuildAutoModerationRules = func(gID string) string { return EndpointGuildAutoModeration(gID) + "/rules" }
-	EndpointGuildAutoModerationRule  = func(gID, rID string) string { return EndpointGuildAutoModerationRules(gID) + "/" + rID }
-	EndpointGuildThreads             = func(gID string) string { return EndpointGuild(gID) + "/threads" }
-	EndpointGuildActiveThreads       = func(gID string) string { return EndpointGuildThreads(gID) + "/active" }
-	EndpointGuildPreview             = func(gID string) string { return EndpointGuilds + gID + "/preview" }
-	EndpointGuildChannels            = func(gID string) string { return EndpointGuilds + gID + "/channels" }
-	EndpointGuildMembers             = func(gID string) string { return EndpointGuilds + gID + "/members" }
-	EndpointGuildMembersSearch       = func(gID string) string { return EndpointGuildMembers(gID) + "/search" }
-	EndpointGuildMember              = func(gID, uID string) string { return EndpointGuilds + gID + "/members/" + uID }
-	EndpointGuildMemberRole          = func(gID, uID, rID string) string { return EndpointGuilds + gID + "/members/" + uID + "/roles/" + rID }
-	EndpointGuildBans                = func(gID string) string { return EndpointGuilds + gID + "/bans" }
-	EndpointGuildBan                 = func(gID, uID string) string { return EndpointGuilds + gID + "/bans/" + uID }
-	EndpointGuildIntegrations        = func(gID string) string { return EndpointGuilds + gID + "/integrations" }
-	EndpointGuildIntegration         = func(gID, iID string) string { return EndpointGuilds + gID + "/integrations/" + iID }
-	EndpointGuildRoles               = func(gID string) string { return EndpointGuilds + gID + "/roles" }
-	EndpointGuildRole                = func(gID, rID string) string { return EndpointGuilds + gID + "/roles/" + rID }
-	EndpointGuildInvites             = func(gID string) string { return EndpointGuilds + gID + "/invites" }
-	EndpointGuildWidget              = func(gID string) string { return EndpointGuilds + gID + "/widget" }
-	EndpointGuildEmbed               = EndpointGuildWidget
-	EndpointGuildPrune               = func(gID string) string { return EndpointGuilds + gID + "/prune" }
-	EndpointGuildIcon                = func(gID, hash string) string { return EndpointCDNIcons + gID + "/" + hash + ".png" }
-	EndpointGuildIconAnimated        = func(gID, hash string) string { return EndpointCDNIcons + gID + "/" + hash + ".gif" }
-	EndpointGuildSplash              = func(gID, hash string) string { return EndpointCDNSplashes + gID + "/" + hash + ".png" }
-	EndpointGuildWebhooks            = func(gID string) string { return EndpointGuilds + gID + "/webhooks" }
-	EndpointGuildAuditLogs           = func(gID string) string { return EndpointGuilds + gID + "/audit-logs" }
-	EndpointGuildEmojis              = func(gID string) string { return EndpointGuilds + gID + "/emojis" }
-	EndpointGuildEmoji               = func(gID, eID string) string { return EndpointGuilds + gID + "/emojis/" + eID }
-	EndpointGuildBanner              = func(gID, hash string) string { return EndpointCDNBanners + gID + "/" + hash + ".png" }
-	EndpointGuildBannerAnimated      = func(gID, hash string) string { return EndpointCDNBanners + gID + "/" + hash + ".gif" }
-	EndpointGuildStickers            = func(gID string) string { return EndpointGuilds + gID + "/stickers" }
-	EndpointGuildSticker             = func(gID, sID string) string { return EndpointGuilds + gID + "/stickers/" + sID }
-	EndpointStageInstance            = func(cID string) string { return EndpointStageInstances + "/" + cID }
-	EndpointGuildScheduledEvents     = func(gID string) string { return EndpointGuilds + gID + "/scheduled-events" }
-	EndpointGuildScheduledEvent      = func(gID, eID string) string { return EndpointGuilds + gID + "/scheduled-events/" + eID }
-	EndpointGuildScheduledEventUsers = func(gID, eID string) string { return EndpointGuildScheduledEvent(gID, eID) + "/users" }
-	EndpointGuildOnboarding          = func(gID string) string { return EndpointGuilds + gID + "/onboarding" }
-	EndpointGuildTemplate            = func(tID string) string { return EndpointGuilds + "templates/" + tID }
-	EndpointGuildTemplates           = func(gID string) string { return EndpointGuilds + gID + "/templates" }
-	EndpointGuildTemplateSync        = func(gID, tID string) string { return EndpointGuilds + gID + "/templates/" + tID }
-	EndpointGuildMemberAvatar        = func(gId, uID, aID string) string {
-		return EndpointCDNGuilds + gId + "/users/" + uID + "/avatars/" + aID + ".png"
+	EndpointUserGuilds                    = func(uID Snowflake) string { return EndpointUsers + string(uID) + "/guilds" }
+	EndpointUserGuild                     = func(uID, gID Snowflake) string { return EndpointUsers + string(uID) + "/guilds/" + string(gID) }
+	EndpointUserGuildMember               = func(uID, gID Snowflake) string { return EndpointUserGuild(uID, gID) + "/member" }
+	EndpointUserChannels                  = func(uID Snowflake) string { return EndpointUsers + string(uID) + "/channels" }
+	EndpointUserApplicationRoleConnection = func(aID Snowflake) string {
+		return EndpointUsers + "@me/applications/" + string(aID) + "/role-connection"
 	}
-	EndpointGuildMemberAvatarAnimated = func(gId, uID, aID string) string {
-		return EndpointCDNGuilds + gId + "/users/" + uID + "/avatars/" + aID + ".gif"
+	EndpointUserConnections = func(uID Snowflake) string { return EndpointUsers + string(uID) + "/connections" }
+
+	EndpointGuild                    = func(gID Snowflake) string { return EndpointGuilds + string(gID) }
+	EndpointGuildAutoModeration      = func(gID Snowflake) string { return EndpointGuild(gID) + "/auto-moderation" }
+	EndpointGuildAutoModerationRules = func(gID Snowflake) string { return EndpointGuildAutoModeration(gID) + "/rules" }
+	EndpointGuildAutoModerationRule  = func(gID, rID Snowflake) string { return EndpointGuildAutoModerationRules(gID) + "/" + string(rID) }
+	EndpointGuildThreads             = func(gID Snowflake) string { return EndpointGuild(gID) + "/threads" }
+	EndpointGuildActiveThreads       = func(gID Snowflake) string { return EndpointGuildThreads(gID) + "/active" }
+	EndpointGuildPreview             = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/preview" }
+	EndpointGuildChannels            = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/channels" }
+	EndpointGuildMembers             = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/members" }
+	EndpointGuildMembersSearch       = func(gID Snowflake) string { return EndpointGuildMembers(gID) + "/search" }
+	EndpointGuildMember              = func(gID, uID Snowflake) string { return EndpointGuilds + string(gID) + "/members/" + string(uID) }
+	EndpointGuildMemberRole          = func(gID, uID, rID Snowflake) string {
+		return EndpointGuilds + string(gID) + "/members/" + string(uID) + "/roles/" + string(rID)
+	}
+	EndpointGuildBans         = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/bans" }
+	EndpointGuildBan          = func(gID, uID Snowflake) string { return EndpointGuilds + string(gID) + "/bans/" + string(uID) }
+	EndpointGuildIntegrations = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/integrations" }
+	EndpointGuildIntegration  = func(gID, iID Snowflake) string {
+		return EndpointGuilds + string(gID) + "/integrations/" + string(iID)
+	}
+	EndpointGuildRoles        = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/roles" }
+	EndpointGuildRole         = func(gID, rID Snowflake) string { return EndpointGuilds + string(gID) + "/roles/" + string(rID) }
+	EndpointGuildInvites      = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/invites" }
+	EndpointGuildWidget       = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/widget" }
+	EndpointGuildEmbed        = EndpointGuildWidget
+	EndpointGuildPrune        = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/prune" }
+	EndpointGuildIcon         = func(gID Snowflake, hash string) string { return EndpointCDNIcons + string(gID) + "/" + hash + ".png" }
+	EndpointGuildIconAnimated = func(gID Snowflake, hash string) string { return EndpointCDNIcons + string(gID) + "/" + hash + ".gif" }
+	EndpointGuildSplash       = func(gID Snowflake, hash string) string {
+		return EndpointCDNSplashes + string(gID) + "/" + hash + ".png"
+	}
+	EndpointGuildWebhooks  = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/webhooks" }
+	EndpointGuildAuditLogs = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/audit-logs" }
+	EndpointGuildEmojis    = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/emojis" }
+	EndpointGuildEmoji     = func(gID, eID Snowflake) string { return EndpointGuilds + string(gID) + "/emojis/" + string(eID) }
+	EndpointGuildBanner    = func(gID Snowflake, hash string) string {
+		return EndpointCDNBanners + string(gID) + "/" + hash + ".png"
+	}
+	EndpointGuildBannerAnimated = func(gID Snowflake, hash string) string {
+		return EndpointCDNBanners + string(gID) + "/" + hash + ".gif"
+	}
+	EndpointGuildStickers        = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/stickers" }
+	EndpointGuildSticker         = func(gID, sID Snowflake) string { return EndpointGuilds + string(gID) + "/stickers/" + string(sID) }
+	EndpointStageInstance        = func(cID Snowflake) string { return EndpointStageInstances + "/" + string(cID) }
+	EndpointGuildScheduledEvents = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/scheduled-events" }
+	EndpointGuildScheduledEvent  = func(gID, eID Snowflake) string {
+		return EndpointGuilds + string(gID) + "/scheduled-events/" + string(eID)
+	}
+	EndpointGuildScheduledEventUsers = func(gID, eID Snowflake) string { return EndpointGuildScheduledEvent(gID, eID) + "/users" }
+	EndpointGuildOnboarding          = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/onboarding" }
+	EndpointGuildTemplate            = func(code string) string { return EndpointGuilds + "templates/" + code }
+	EndpointGuildTemplates           = func(gID Snowflake) string { return EndpointGuilds + string(gID) + "/templates" }
+	EndpointGuildTemplateSync        = func(gID Snowflake, code string) string { return EndpointGuilds + string(gID) + "/templates/" + code }
+	EndpointGuildMemberAvatar        = func(gID, uID Snowflake, hash string) string {
+		return EndpointCDNGuilds + string(gID) + "/users/" + string(uID) + "/avatars/" + hash + ".png"
+	}
+	EndpointGuildMemberAvatarAnimated = func(gID, uID Snowflake, hash string) string {
+		return EndpointCDNGuilds + string(gID) + "/users/" + string(uID) + "/avatars/" + hash + ".gif"
 	}
 
 	EndpointRoleIcon = func(rID, hash string) string {
-		return EndpointCDNRoleIcons + rID + "/" + hash + ".png"
+		return EndpointCDNRoleIcons + string(rID) + "/" + hash + ".png"
 	}
 
-	EndpointChannel                             = func(cID string) string { return EndpointChannels + cID }
-	EndpointChannelThreads                      = func(cID string) string { return EndpointChannel(cID) + "/threads" }
-	EndpointChannelActiveThreads                = func(cID string) string { return EndpointChannelThreads(cID) + "/active" }
-	EndpointChannelPublicArchivedThreads        = func(cID string) string { return EndpointChannelThreads(cID) + "/archived/public" }
-	EndpointChannelPrivateArchivedThreads       = func(cID string) string { return EndpointChannelThreads(cID) + "/archived/private" }
-	EndpointChannelJoinedPrivateArchivedThreads = func(cID string) string { return EndpointChannel(cID) + "/users/@me/threads/archived/private" }
-	EndpointChannelPermissions                  = func(cID string) string { return EndpointChannels + cID + "/permissions" }
-	EndpointChannelPermission                   = func(cID, tID string) string { return EndpointChannels + cID + "/permissions/" + tID }
-	EndpointChannelInvites                      = func(cID string) string { return EndpointChannels + cID + "/invites" }
-	EndpointChannelTyping                       = func(cID string) string { return EndpointChannels + cID + "/typing" }
-	EndpointChannelMessages                     = func(cID string) string { return EndpointChannels + cID + "/messages" }
-	EndpointChannelMessage                      = func(cID, mID string) string { return EndpointChannels + cID + "/messages/" + mID }
-	EndpointChannelMessageThread                = func(cID, mID string) string { return EndpointChannelMessage(cID, mID) + "/threads" }
-	EndpointChannelMessagesBulkDelete           = func(cID string) string { return EndpointChannel(cID) + "/messages/bulk-delete" }
-	EndpointChannelMessagesPins                 = func(cID string) string { return EndpointChannel(cID) + "/pins" }
-	EndpointChannelMessagePin                   = func(cID, mID string) string { return EndpointChannel(cID) + "/pins/" + mID }
-	EndpointChannelMessageCrosspost             = func(cID, mID string) string { return EndpointChannel(cID) + "/messages/" + mID + "/crosspost" }
-	EndpointChannelFollow                       = func(cID string) string { return EndpointChannel(cID) + "/followers" }
-	EndpointThreadMembers                       = func(tID string) string { return EndpointChannel(tID) + "/thread-members" }
-	EndpointThreadMember                        = func(tID, mID string) string { return EndpointThreadMembers(tID) + "/" + mID }
+	EndpointChannel                             = func(cID Snowflake) string { return EndpointChannels + string(cID) }
+	EndpointChannelThreads                      = func(cID Snowflake) string { return EndpointChannel(cID) + "/threads" }
+	EndpointChannelActiveThreads                = func(cID Snowflake) string { return EndpointChannelThreads(cID) + "/active" }
+	EndpointChannelPublicArchivedThreads        = func(cID Snowflake) string { return EndpointChannelThreads(cID) + "/archived/public" }
+	EndpointChannelPrivateArchivedThreads       = func(cID Snowflake) string { return EndpointChannelThreads(cID) + "/archived/private" }
+	EndpointChannelJoinedPrivateArchivedThreads = func(cID Snowflake) string { return EndpointChannel(cID) + "/users/@me/threads/archived/private" }
+	EndpointChannelPermissions                  = func(cID Snowflake) string { return EndpointChannels + string(cID) + "/permissions" }
+	EndpointChannelPermission                   = func(cID, tID Snowflake) string {
+		return EndpointChannels + string(cID) + "/permissions/" + string(tID)
+	}
+	EndpointChannelInvites            = func(cID Snowflake) string { return EndpointChannels + string(cID) + "/invites" }
+	EndpointChannelTyping             = func(cID Snowflake) string { return EndpointChannels + string(cID) + "/typing" }
+	EndpointChannelMessages           = func(cID Snowflake) string { return EndpointChannels + string(cID) + "/messages" }
+	EndpointChannelMessage            = func(cID, mID Snowflake) string { return EndpointChannels + string(cID) + "/messages/" + string(mID) }
+	EndpointChannelMessageThread      = func(cID, mID Snowflake) string { return EndpointChannelMessage(cID, mID) + "/threads" }
+	EndpointChannelMessagesBulkDelete = func(cID Snowflake) string { return EndpointChannel(cID) + "/messages/bulk-delete" }
+	EndpointChannelMessagesPins       = func(cID Snowflake) string { return EndpointChannel(cID) + "/pins" }
+	EndpointChannelMessagePin         = func(cID, mID Snowflake) string { return EndpointChannel(cID) + "/pins/" + string(mID) }
+	EndpointChannelMessageCrosspost   = func(cID, mID Snowflake) string {
+		return EndpointChannel(cID) + "/messages/" + string(mID) + "/crosspost"
+	}
+	EndpointChannelFollow = func(cID Snowflake) string { return EndpointChannel(cID) + "/followers" }
+	EndpointThreadMembers = func(tID Snowflake) string { return EndpointChannel(tID) + "/thread-members" }
+	EndpointThreadMember  = func(tID, mID Snowflake) string { return EndpointThreadMembers(tID) + "/" + string(mID) }
 
-	EndpointGroupIcon = func(cID, hash string) string { return EndpointCDNChannelIcons + cID + "/" + hash + ".png" }
+	EndpointGroupIcon = func(cID Snowflake, hash string) string {
+		return EndpointCDNChannelIcons + string(cID) + "/" + hash + ".png"
+	}
 
-	EndpointSticker            = func(sID string) string { return EndpointStickers + sID }
+	EndpointSticker            = func(sID Snowflake) string { return EndpointStickers + string(sID) }
 	EndpointNitroStickersPacks = EndpointAPI + "/sticker-packs"
 
-	EndpointChannelWebhooks = func(cID string) string { return EndpointChannel(cID) + "/webhooks" }
-	EndpointWebhook         = func(wID string) string { return EndpointWebhooks + wID }
-	EndpointWebhookToken    = func(wID, token string) string { return EndpointWebhooks + wID + "/" + token }
-	EndpointWebhookMessage  = func(wID, token, messageID string) string {
-		return EndpointWebhookToken(wID, token) + "/messages/" + messageID
+	EndpointChannelWebhooks = func(cID Snowflake) string { return EndpointChannel(cID) + "/webhooks" }
+	EndpointWebhook         = func(wID Snowflake) string { return EndpointWebhooks + string(wID) }
+	EndpointWebhookToken    = func(wID Snowflake, token string) string { return EndpointWebhooks + string(wID) + "/" + token }
+	EndpointWebhookMessage  = func(wID Snowflake, token string, messageID Snowflake) string {
+		return EndpointWebhookToken(wID, token) + "/messages/" + string(messageID)
 	}
 
-	EndpointMessageReactionsAll = func(cID, mID string) string {
+	EndpointMessageReactionsAll = func(cID, mID Snowflake) string {
 		return EndpointChannelMessage(cID, mID) + "/reactions"
 	}
-	EndpointMessageReactions = func(cID, mID, eID string) string {
-		return EndpointChannelMessage(cID, mID) + "/reactions/" + eID
+	EndpointMessageReactions = func(cID, mID, eID Snowflake) string {
+		return EndpointChannelMessage(cID, mID) + "/reactions/" + string(eID)
 	}
-	EndpointMessageReaction = func(cID, mID, eID, uID string) string {
-		return EndpointMessageReactions(cID, mID, eID) + "/" + uID
+	EndpointMessageReaction = func(cID, mID, eID, uID Snowflake) string {
+		return EndpointMessageReactions(cID, mID, eID) + "/" + string(uID)
 	}
 
-	EndpointApplicationGlobalCommands = func(aID string) string {
+	EndpointApplicationGlobalCommands = func(aID Snowflake) string {
 		return EndpointApplication(aID) + "/commands"
 	}
-	EndpointApplicationGlobalCommand = func(aID, cID string) string {
-		return EndpointApplicationGlobalCommands(aID) + "/" + cID
+	EndpointApplicationGlobalCommand = func(aID, cID Snowflake) string {
+		return EndpointApplicationGlobalCommands(aID) + "/" + string(cID)
 	}
 
-	EndpointApplicationGuildCommands = func(aID, gID string) string {
-		return EndpointApplication(aID) + "/guilds/" + gID + "/commands"
+	EndpointApplicationGuildCommands = func(aID, gID Snowflake) string {
+		return EndpointApplication(aID) + "/guilds/" + string(gID) + "/commands"
 	}
-	EndpointApplicationGuildCommand = func(aID, gID, cID string) string {
-		return EndpointApplicationGuildCommands(aID, gID) + "/" + cID
+	EndpointApplicationGuildCommand = func(aID, gID, cID Snowflake) string {
+		return EndpointApplicationGuildCommands(aID, gID) + "/" + string(cID)
 	}
-	EndpointApplicationCommandPermissions = func(aID, gID, cID string) string {
+	EndpointApplicationCommandPermissions = func(aID, gID, cID Snowflake) string {
 		return EndpointApplicationGuildCommand(aID, gID, cID) + "/permissions"
 	}
-	EndpointApplicationCommandsGuildPermissions = func(aID, gID string) string {
+	EndpointApplicationCommandsGuildPermissions = func(aID, gID Snowflake) string {
 		return EndpointApplicationGuildCommands(aID, gID) + "/permissions"
 	}
-	EndpointInteraction = func(aID, iToken string) string {
-		return EndpointAPI + "interactions/" + aID + "/" + iToken
+	EndpointInteraction = func(aID Snowflake, iToken string) string {
+		return EndpointAPI + "interactions/" + string(aID) + "/" + iToken
 	}
-	EndpointInteractionResponse = func(iID, iToken string) string {
+	EndpointInteractionResponse = func(iID Snowflake, iToken string) string {
 		return EndpointInteraction(iID, iToken) + "/callback"
 	}
-	EndpointInteractionResponseActions = func(aID, iToken string) string {
+	EndpointInteractionResponseActions = func(aID Snowflake, iToken string) string {
 		return EndpointWebhookMessage(aID, iToken, "@original")
 	}
-	EndpointFollowupMessage = func(aID, iToken string) string {
+	EndpointFollowupMessage = func(aID Snowflake, iToken string) string {
 		return EndpointWebhookToken(aID, iToken)
 	}
-	EndpointFollowupMessageActions = func(aID, iToken, mID string) string {
+	EndpointFollowupMessageActions = func(aID Snowflake, iToken string, mID Snowflake) string {
 		return EndpointWebhookMessage(aID, iToken, mID)
 	}
 
 	EndpointGuildCreate = EndpointAPI + "guilds"
 
-	EndpointInvite = func(iID string) string { return EndpointAPI + "invites/" + iID }
+	EndpointInvite = func(code string) string { return EndpointAPI + "invites/" + code }
 
-	EndpointEmoji         = func(eID string) string { return EndpointCDN + "emojis/" + eID + ".png" }
-	EndpointEmojiAnimated = func(eID string) string { return EndpointCDN + "emojis/" + eID + ".gif" }
+	EndpointEmoji         = func(eID Snowflake) string { return EndpointCDN + "emojis/" + string(eID) + ".png" }
+	EndpointEmojiAnimated = func(eID Snowflake) string { return EndpointCDN + "emojis/" + string(eID) + ".gif" }
 
 	EndpointApplications                      = EndpointAPI + "applications"
-	EndpointApplication                       = func(aID string) string { return EndpointApplications + "/" + aID }
-	EndpointApplicationRoleConnectionMetadata = func(aID string) string { return EndpointApplication(aID) + "/role-connections/metadata" }
+	EndpointApplication                       = func(aID Snowflake) string { return EndpointApplications + "/" + string(aID) }
+	EndpointApplicationRoleConnectionMetadata = func(aID Snowflake) string { return EndpointApplication(aID) + "/role-connections/metadata" }
 
 	EndpointOAuth2                  = EndpointAPI + "oauth2/"
 	EndpointOAuth2Applications      = EndpointOAuth2 + "applications"
-	EndpointOAuth2Application       = func(aID string) string { return EndpointOAuth2Applications + "/" + aID }
-	EndpointOAuth2ApplicationsBot   = func(aID string) string { return EndpointOAuth2Applications + "/" + aID + "/bot" }
-	EndpointOAuth2ApplicationAssets = func(aID string) string { return EndpointOAuth2Applications + "/" + aID + "/assets" }
+	EndpointOAuth2Application       = func(aID Snowflake) string { return EndpointOAuth2Applications + "/" + string(aID) }
+	EndpointOAuth2ApplicationsBot   = func(aID Snowflake) string { return EndpointOAuth2Applications + "/" + string(aID) + "/bot" }
+	EndpointOAuth2ApplicationAssets = func(aID Snowflake) string { return EndpointOAuth2Applications + "/" + string(aID) + "/assets" }
 
 	// TODO: Deprecated, remove in the next release
 	EndpointOauth2                  = EndpointOAuth2

--- a/event.go
+++ b/event.go
@@ -51,7 +51,6 @@ func registerInterfaceProvider(eh EventInterfaceProvider) {
 		// fmt.Errorf("event %s already registered", eh.Type())
 	}
 	registeredInterfaceProviders[eh.Type()] = eh
-	return
 }
 
 // eventHandlerInstance is a wrapper around an event handler, as functions
@@ -102,12 +101,14 @@ func (s *Session) addEventHandlerOnce(eventHandler EventHandler) func() {
 // to a struct corresponding to the event for which you want to listen.
 //
 // eg:
-//     Session.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
-//     })
+//
+//	Session.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
+//	})
 //
 // or:
-//     Session.AddHandler(func(s *discordgo.Session, m *discordgo.PresenceUpdate) {
-//     })
+//
+//	Session.AddHandler(func(s *discordgo.Session, m *discordgo.PresenceUpdate) {
+//	})
 //
 // List of events can be found at this page, with corresponding names in the
 // library for each event: https://discord.com/developers/docs/topics/gateway#event-names

--- a/events.go
+++ b/events.go
@@ -62,9 +62,9 @@ type ChannelDelete struct {
 
 // ChannelPinsUpdate stores data for a ChannelPinsUpdate event.
 type ChannelPinsUpdate struct {
-	LastPinTimestamp string `json:"last_pin_timestamp"`
-	ChannelID        string `json:"channel_id"`
-	GuildID          string `json:"guild_id,omitempty"`
+	LastPinTimestamp string    `json:"last_pin_timestamp"`
+	ChannelID        Snowflake `json:"channel_id"`
+	GuildID          Snowflake `json:"guild_id,omitempty"`
 }
 
 // ThreadCreate is the data for a ThreadCreate event.
@@ -87,11 +87,11 @@ type ThreadDelete struct {
 // ThreadListSync is the data for a ThreadListSync event.
 type ThreadListSync struct {
 	// The id of the guild
-	GuildID string `json:"guild_id"`
+	GuildID Snowflake `json:"guild_id"`
 	// The parent channel ids whose threads are being synced.
 	// If omitted, then threads were synced for the entire guild.
 	// This array may contain channel_ids that have no active threads as well, so you know to clear that data.
-	ChannelIDs []string `json:"channel_ids"`
+	ChannelIDs []Snowflake `json:"channel_ids"`
 	// All active threads in the given channels that the current user can access
 	Threads []*Channel `json:"threads"`
 	// All thread member objects from the synced threads for the current user,
@@ -102,16 +102,16 @@ type ThreadListSync struct {
 // ThreadMemberUpdate is the data for a ThreadMemberUpdate event.
 type ThreadMemberUpdate struct {
 	*ThreadMember
-	GuildID string `json:"guild_id"`
+	GuildID Snowflake `json:"guild_id"`
 }
 
 // ThreadMembersUpdate is the data for a ThreadMembersUpdate event.
 type ThreadMembersUpdate struct {
-	ID             string              `json:"id"`
-	GuildID        string              `json:"guild_id"`
+	ID             Snowflake           `json:"id"`
+	GuildID        Snowflake           `json:"guild_id"`
 	MemberCount    int                 `json:"member_count"`
 	AddedMembers   []AddedThreadMember `json:"added_members"`
-	RemovedMembers []string            `json:"removed_member_ids"`
+	RemovedMembers []Snowflake         `json:"removed_member_ids"`
 }
 
 // GuildCreate is the data for a GuildCreate event.
@@ -132,14 +132,14 @@ type GuildDelete struct {
 
 // GuildBanAdd is the data for a GuildBanAdd event.
 type GuildBanAdd struct {
-	User    *User  `json:"user"`
-	GuildID string `json:"guild_id"`
+	User    *User     `json:"user"`
+	GuildID Snowflake `json:"guild_id"`
 }
 
 // GuildBanRemove is the data for a GuildBanRemove event.
 type GuildBanRemove struct {
-	User    *User  `json:"user"`
-	GuildID string `json:"guild_id"`
+	User    *User     `json:"user"`
+	GuildID Snowflake `json:"guild_id"`
 }
 
 // GuildMemberAdd is the data for a GuildMemberAdd event.
@@ -170,19 +170,19 @@ type GuildRoleUpdate struct {
 
 // A GuildRoleDelete is the data for a GuildRoleDelete event.
 type GuildRoleDelete struct {
-	RoleID  string `json:"role_id"`
-	GuildID string `json:"guild_id"`
+	RoleID  Snowflake `json:"role_id"`
+	GuildID Snowflake `json:"guild_id"`
 }
 
 // A GuildEmojisUpdate is the data for a guild emoji update event.
 type GuildEmojisUpdate struct {
-	GuildID string   `json:"guild_id"`
-	Emojis  []*Emoji `json:"emojis"`
+	GuildID Snowflake `json:"guild_id"`
+	Emojis  []*Emoji  `json:"emojis"`
 }
 
 // A GuildMembersChunk is the data for a GuildMembersChunk event.
 type GuildMembersChunk struct {
-	GuildID    string      `json:"guild_id"`
+	GuildID    Snowflake   `json:"guild_id"`
 	Members    []*Member   `json:"members"`
 	ChunkIndex int         `json:"chunk_index"`
 	ChunkCount int         `json:"chunk_count"`
@@ -193,7 +193,7 @@ type GuildMembersChunk struct {
 
 // GuildIntegrationsUpdate is the data for a GuildIntegrationsUpdate event.
 type GuildIntegrationsUpdate struct {
-	GuildID string `json:"guild_id"`
+	GuildID Snowflake `json:"guild_id"`
 }
 
 // StageInstanceEventCreate is the data for a StageInstanceEventCreate event.
@@ -228,16 +228,16 @@ type GuildScheduledEventDelete struct {
 
 // GuildScheduledEventUserAdd is the data for a GuildScheduledEventUserAdd event.
 type GuildScheduledEventUserAdd struct {
-	GuildScheduledEventID string `json:"guild_scheduled_event_id"`
-	UserID                string `json:"user_id"`
-	GuildID               string `json:"guild_id"`
+	GuildScheduledEventID Snowflake `json:"guild_scheduled_event_id"`
+	UserID                Snowflake `json:"user_id"`
+	GuildID               Snowflake `json:"guild_id"`
 }
 
 // GuildScheduledEventUserRemove is the data for a GuildScheduledEventUserRemove event.
 type GuildScheduledEventUserRemove struct {
-	GuildScheduledEventID string `json:"guild_scheduled_event_id"`
-	UserID                string `json:"user_id"`
-	GuildID               string `json:"guild_id"`
+	GuildScheduledEventID Snowflake `json:"guild_scheduled_event_id"`
+	UserID                Snowflake `json:"user_id"`
+	GuildID               Snowflake `json:"guild_id"`
 }
 
 // MessageCreate is the data for a MessageCreate event.
@@ -295,7 +295,7 @@ type PresencesReplace []*Presence
 // PresenceUpdate is the data for a PresenceUpdate event.
 type PresenceUpdate struct {
 	Presence
-	GuildID string `json:"guild_id"`
+	GuildID Snowflake `json:"guild_id"`
 }
 
 // Resumed is the data for a Resumed event.
@@ -305,10 +305,10 @@ type Resumed struct {
 
 // TypingStart is the data for a TypingStart event.
 type TypingStart struct {
-	UserID    string `json:"user_id"`
-	ChannelID string `json:"channel_id"`
-	GuildID   string `json:"guild_id,omitempty"`
-	Timestamp int    `json:"timestamp"`
+	UserID    Snowflake `json:"user_id"`
+	ChannelID Snowflake `json:"channel_id"`
+	GuildID   Snowflake `json:"guild_id,omitempty"`
+	Timestamp int       `json:"timestamp"`
 }
 
 // UserUpdate is the data for a UserUpdate event.
@@ -318,9 +318,9 @@ type UserUpdate struct {
 
 // VoiceServerUpdate is the data for a VoiceServerUpdate event.
 type VoiceServerUpdate struct {
-	Token    string `json:"token"`
-	GuildID  string `json:"guild_id"`
-	Endpoint string `json:"endpoint"`
+	Token    string    `json:"token"`
+	GuildID  Snowflake `json:"guild_id"`
+	Endpoint string    `json:"endpoint"`
 }
 
 // VoiceStateUpdate is the data for a VoiceStateUpdate event.
@@ -332,15 +332,15 @@ type VoiceStateUpdate struct {
 
 // MessageDeleteBulk is the data for a MessageDeleteBulk event
 type MessageDeleteBulk struct {
-	Messages  []string `json:"ids"`
-	ChannelID string   `json:"channel_id"`
-	GuildID   string   `json:"guild_id"`
+	Messages  []Snowflake `json:"ids"`
+	ChannelID Snowflake   `json:"channel_id"`
+	GuildID   Snowflake   `json:"guild_id"`
 }
 
 // WebhooksUpdate is the data for a WebhooksUpdate event
 type WebhooksUpdate struct {
-	GuildID   string `json:"guild_id"`
-	ChannelID string `json:"channel_id"`
+	GuildID   Snowflake `json:"guild_id"`
+	ChannelID Snowflake `json:"channel_id"`
 }
 
 // InteractionCreate is the data for a InteractionCreate event

--- a/interactions.go
+++ b/interactions.go
@@ -202,12 +202,12 @@ func (t InteractionType) String() string {
 
 // Interaction represents data of an interaction.
 type Interaction struct {
-	ID        string          `json:"id"`
-	AppID     string          `json:"application_id"`
+	ID        Snowflake       `json:"id"`
+	AppID     Snowflake       `json:"application_id"`
 	Type      InteractionType `json:"type"`
 	Data      InteractionData `json:"data"`
-	GuildID   string          `json:"guild_id"`
-	ChannelID string          `json:"channel_id"`
+	GuildID   Snowflake       `json:"guild_id"`
+	ChannelID Snowflake       `json:"channel_id"`
 
 	// The message on which interaction was used.
 	// NOTE: this field is only filled when a button click triggered the interaction. Otherwise it will be nil.
@@ -454,7 +454,7 @@ func (o ApplicationCommandInteractionDataOption) ChannelValue(s *Session) *Chann
 	if o.Type != ApplicationCommandOptionChannel {
 		panic("ChannelValue called on data option of type " + o.Type.String())
 	}
-	chanID := o.Value.(string)
+	chanID := Snowflake(o.Value.(string))
 
 	if s == nil {
 		return &Channel{ID: chanID}
@@ -473,11 +473,11 @@ func (o ApplicationCommandInteractionDataOption) ChannelValue(s *Session) *Chann
 
 // RoleValue is a utility function for casting option value to role object.
 // s : Session object, if not nil, function additionally fetches all role's data
-func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID string) *Role {
+func (o ApplicationCommandInteractionDataOption) RoleValue(s *Session, gID Snowflake) *Role {
 	if o.Type != ApplicationCommandOptionRole && o.Type != ApplicationCommandOptionMentionable {
 		panic("RoleValue called on data option of type " + o.Type.String())
 	}
-	roleID := o.Value.(string)
+	roleID := Snowflake(o.Value.(string))
 
 	if s == nil || gID == "" {
 		return &Role{ID: roleID}
@@ -505,7 +505,7 @@ func (o ApplicationCommandInteractionDataOption) UserValue(s *Session) *User {
 	if o.Type != ApplicationCommandOptionUser && o.Type != ApplicationCommandOptionMentionable {
 		panic("UserValue called on data option of type " + o.Type.String())
 	}
-	userID := o.Value.(string)
+	userID := Snowflake(o.Value.(string))
 
 	if s == nil {
 		return &User{ID: userID}

--- a/logging.go
+++ b/logging.go
@@ -39,10 +39,11 @@ var Logger func(msgL, caller int, format string, a ...interface{})
 
 // msglog provides package wide logging consistency for discordgo
 // the format, a...  portion this command follows that of fmt.Printf
-//   msgL   : LogLevel of the message
-//   caller : 1 + the number of callers away from the message source
-//   format : Printf style message format
-//   a ...  : comma separated list of values to pass
+//
+//	msgL   : LogLevel of the message
+//	caller : 1 + the number of callers away from the message source
+//	format : Printf style message format
+//	a ...  : comma separated list of values to pass
 func msglog(msgL, caller int, format string, a ...interface{}) {
 
 	if Logger != nil {

--- a/message_test.go
+++ b/message_test.go
@@ -31,7 +31,7 @@ func TestContentWithMoreMentionsReplaced(t *testing.T) {
 	m := &Message{
 		Content:      "<@&role> <@!user> <@user> <#channel>",
 		ChannelID:    "channel",
-		MentionRoles: []string{"role"},
+		MentionRoles: []Snowflake{"role"},
 		Mentions:     []*User{user},
 	}
 	if result, _ := m.ContentWithMoreMentionsReplaced(s); result != "@Role Name @User Nick @User Name #Channel Name" {

--- a/oauth2.go
+++ b/oauth2.go
@@ -25,14 +25,14 @@ const (
 // A TeamMember struct stores values for a single Team Member, extending the normal User data - note that the user field is partial
 type TeamMember struct {
 	User            *User           `json:"user"`
-	TeamID          string          `json:"team_id"`
+	TeamID          Snowflake       `json:"team_id"`
 	MembershipState MembershipState `json:"membership_state"`
 	Permissions     []string        `json:"permissions"`
 }
 
 // A Team struct stores the members of a Discord Developer Team as well as some metadata about it
 type Team struct {
-	ID          string        `json:"id"`
+	ID          Snowflake     `json:"id"`
 	Name        string        `json:"name"`
 	Description string        `json:"description"`
 	Icon        string        `json:"icon"`
@@ -41,8 +41,9 @@ type Team struct {
 }
 
 // Application returns an Application structure of a specific Application
-//   appID : The ID of an Application
-func (s *Session) Application(appID string) (st *Application, err error) {
+//
+//	appID : The ID of an Application
+func (s *Session) Application(appID Snowflake) (st *Application, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointOAuth2Application(appID), nil, EndpointOAuth2Application(""))
 	if err != nil {
@@ -66,8 +67,9 @@ func (s *Session) Applications() (st []*Application, err error) {
 }
 
 // ApplicationCreate creates a new Application
-//    name : Name of Application / Bot
-//    uris : Redirect URIs (Not required)
+//
+//	name : Name of Application / Bot
+//	uris : Redirect URIs (Not required)
 func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error) {
 
 	data := struct {
@@ -85,8 +87,9 @@ func (s *Session) ApplicationCreate(ap *Application) (st *Application, err error
 }
 
 // ApplicationUpdate updates an existing Application
-//   var : desc
-func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Application, err error) {
+//
+//	var : desc
+func (s *Session) ApplicationUpdate(appID Snowflake, ap *Application) (st *Application, err error) {
 
 	data := struct {
 		Name        string `json:"name"`
@@ -103,8 +106,9 @@ func (s *Session) ApplicationUpdate(appID string, ap *Application) (st *Applicat
 }
 
 // ApplicationDelete deletes an existing Application
-//   appID : The ID of an Application
-func (s *Session) ApplicationDelete(appID string) (err error) {
+//
+//	appID : The ID of an Application
+func (s *Session) ApplicationDelete(appID Snowflake) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointOAuth2Application(appID), nil, EndpointOAuth2Application(""))
 	if err != nil {
@@ -122,7 +126,7 @@ type Asset struct {
 }
 
 // ApplicationAssets returns an application's assets
-func (s *Session) ApplicationAssets(appID string) (ass []*Asset, err error) {
+func (s *Session) ApplicationAssets(appID Snowflake) (ass []*Asset, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointOAuth2ApplicationAssets(appID), nil, EndpointOAuth2ApplicationAssets(""))
 	if err != nil {
@@ -139,10 +143,10 @@ func (s *Session) ApplicationAssets(appID string) (ass []*Asset, err error) {
 
 // ApplicationBotCreate creates an Application Bot Account
 //
-//   appID : The ID of an Application
+//	appID : The ID of an Application
 //
 // NOTE: func name may change, if I can think up something better.
-func (s *Session) ApplicationBotCreate(appID string) (st *User, err error) {
+func (s *Session) ApplicationBotCreate(appID Snowflake) (st *User, err error) {
 
 	body, err := s.RequestWithBucketID("POST", EndpointOAuth2ApplicationsBot(appID), nil, EndpointOAuth2ApplicationsBot(""))
 	if err != nil {

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -52,6 +52,4 @@ func ExampleApplication() {
 	// Delete the application we created.
 	err = dg.ApplicationDelete(ap.ID)
 	log.Printf("Delete: err: %+v\n", err)
-
-	return
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -74,7 +74,7 @@ func (r *RateLimiter) GetWaitTime(b *Bucket, minRemaining int) time.Duration {
 	// If we ran out of calls and the reset time is still ahead of us
 	// then we need to take it easy and relax a little
 	if b.Remaining < minRemaining && b.reset.After(time.Now()) {
-		return b.reset.Sub(time.Now())
+		return time.Until(b.reset)
 	}
 
 	// Check for global ratelimits
@@ -124,7 +124,7 @@ func (b *Bucket) Release(headers http.Header) error {
 
 	// Check if the bucket uses a custom ratelimiter
 	if rl := b.customRateLimit; rl != nil {
-		if time.Now().Sub(b.lastReset) >= rl.reset {
+		if time.Since(b.lastReset) >= rl.reset {
 			b.Remaining = rl.requests - 1
 			b.lastReset = time.Now()
 		}

--- a/restapi.go
+++ b/restapi.go
@@ -323,7 +323,7 @@ func unmarshal(data []byte, v interface{}) error {
 
 // User returns the user details of the given userID
 // userID    : A user ID or "@me" which is a shortcut of current user ID
-func (s *Session) User(userID string, options ...RequestOption) (st *User, err error) {
+func (s *Session) User(userID Snowflake, options ...RequestOption) (st *User, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointUser(userID), nil, EndpointUsers, options...)
 	if err != nil {
@@ -336,7 +336,7 @@ func (s *Session) User(userID string, options ...RequestOption) (st *User, err e
 
 // UserAvatar is deprecated. Please use UserAvatarDecode
 // userID    : A user ID or "@me" which is a shortcut of current user ID
-func (s *Session) UserAvatar(userID string, options ...RequestOption) (img image.Image, err error) {
+func (s *Session) UserAvatar(userID Snowflake, options ...RequestOption) (img image.Image, err error) {
 	u, err := s.User(userID, options...)
 	if err != nil {
 		return
@@ -396,10 +396,10 @@ func (s *Session) UserConnections(options ...RequestOption) (conn []*UserConnect
 
 // UserChannelCreate creates a new User (Private) Channel with another User
 // recipientID : A user ID for the user to which this channel is opened with.
-func (s *Session) UserChannelCreate(recipientID string, options ...RequestOption) (st *Channel, err error) {
+func (s *Session) UserChannelCreate(recipientID Snowflake, options ...RequestOption) (st *Channel, err error) {
 
 	data := struct {
-		RecipientID string `json:"recipient_id"`
+		RecipientID Snowflake `json:"recipient_id"`
 	}{recipientID}
 
 	body, err := s.RequestWithBucketID("POST", EndpointUserChannels("@me"), data, EndpointUserChannels(""), options...)
@@ -413,7 +413,7 @@ func (s *Session) UserChannelCreate(recipientID string, options ...RequestOption
 
 // UserGuildMember returns a guild member object for the current user in the given Guild.
 // guildID : ID of the guild
-func (s *Session) UserGuildMember(guildID string, options ...RequestOption) (st *Member, err error) {
+func (s *Session) UserGuildMember(guildID Snowflake, options ...RequestOption) (st *Member, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointUserGuildMember("@me", guildID), nil, EndpointUserGuildMember("@me", guildID), options...)
 	if err != nil {
 		return
@@ -427,7 +427,7 @@ func (s *Session) UserGuildMember(guildID string, options ...RequestOption) (st 
 // limit     : The number guilds that can be returned. (max 100)
 // beforeID  : If provided all guilds returned will be before given ID.
 // afterID   : If provided all guilds returned will be after given ID.
-func (s *Session) UserGuilds(limit int, beforeID, afterID string, options ...RequestOption) (st []*UserGuild, err error) {
+func (s *Session) UserGuilds(limit int, beforeID, afterID Snowflake, options ...RequestOption) (st []*UserGuild, err error) {
 
 	v := url.Values{}
 
@@ -435,10 +435,10 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string, options ...Req
 		v.Set("limit", strconv.Itoa(limit))
 	}
 	if afterID != "" {
-		v.Set("after", afterID)
+		v.Set("after", string(afterID))
 	}
 	if beforeID != "" {
-		v.Set("before", beforeID)
+		v.Set("before", string(beforeID))
 	}
 
 	uri := EndpointUserGuilds("@me")
@@ -463,7 +463,7 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string, options ...Req
 //
 // NOTE: This function is now deprecated and will be removed in the future.
 // Please see the same function inside state.go
-func (s *Session) UserChannelPermissions(userID, channelID string, fetchOptions ...RequestOption) (apermissions int64, err error) {
+func (s *Session) UserChannelPermissions(userID, channelID Snowflake, fetchOptions ...RequestOption) (apermissions int64, err error) {
 	// Try to just get permissions from state.
 	apermissions, err = s.State.UserChannelPermissions(userID, channelID)
 	if err == nil {
@@ -505,7 +505,7 @@ func (s *Session) UserChannelPermissions(userID, channelID string, fetchOptions 
 
 // Calculates the permissions for a member.
 // https://support.discord.com/hc/en-us/articles/206141927-How-is-the-permission-hierarchy-structured-
-func memberPermissions(guild *Guild, channel *Channel, userID string, roles []string) (apermissions int64) {
+func memberPermissions(guild *Guild, channel *Channel, userID Snowflake, roles []Snowflake) (apermissions int64) {
 	if userID == guild.OwnerID {
 		apermissions = PermissionAll
 		return
@@ -576,7 +576,7 @@ func memberPermissions(guild *Guild, channel *Channel, userID string, roles []st
 
 // Guild returns a Guild structure of a specific Guild.
 // guildID   : The ID of a Guild
-func (s *Session) Guild(guildID string, options ...RequestOption) (st *Guild, err error) {
+func (s *Session) Guild(guildID Snowflake, options ...RequestOption) (st *Guild, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointGuild(guildID), nil, EndpointGuild(guildID), options...)
 	if err != nil {
 		return
@@ -588,7 +588,7 @@ func (s *Session) Guild(guildID string, options ...RequestOption) (st *Guild, er
 
 // GuildWithCounts returns a Guild structure of a specific Guild with approximate member and presence counts.
 // guildID    : The ID of a Guild
-func (s *Session) GuildWithCounts(guildID string, options ...RequestOption) (st *Guild, err error) {
+func (s *Session) GuildWithCounts(guildID Snowflake, options ...RequestOption) (st *Guild, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuild(guildID)+"?with_counts=true", nil, EndpointGuild(guildID), options...)
 	if err != nil {
@@ -601,7 +601,7 @@ func (s *Session) GuildWithCounts(guildID string, options ...RequestOption) (st 
 
 // GuildPreview returns a GuildPreview structure of a specific public Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildPreview(guildID string, options ...RequestOption) (st *GuildPreview, err error) {
+func (s *Session) GuildPreview(guildID Snowflake, options ...RequestOption) (st *GuildPreview, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointGuildPreview(guildID), nil, EndpointGuildPreview(guildID), options...)
 	if err != nil {
 		return
@@ -631,7 +631,7 @@ func (s *Session) GuildCreate(name string, options ...RequestOption) (st *Guild,
 // GuildEdit edits a new Guild
 // guildID   : The ID of a Guild
 // g 		 : A GuildParams struct with the values Name, Region and VerificationLevel defined.
-func (s *Session) GuildEdit(guildID string, g *GuildParams, options ...RequestOption) (st *Guild, err error) {
+func (s *Session) GuildEdit(guildID Snowflake, g *GuildParams, options ...RequestOption) (st *Guild, err error) {
 
 	// Bounds checking for VerificationLevel, interval: [0, 4]
 	if g.VerificationLevel != nil {
@@ -672,7 +672,7 @@ func (s *Session) GuildEdit(guildID string, g *GuildParams, options ...RequestOp
 
 // GuildDelete deletes a Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildDelete(guildID string, options ...RequestOption) (err error) {
+func (s *Session) GuildDelete(guildID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuild(guildID), nil, EndpointGuild(guildID), options...)
 	return
@@ -680,7 +680,7 @@ func (s *Session) GuildDelete(guildID string, options ...RequestOption) (err err
 
 // GuildLeave leaves a Guild.
 // guildID   : The ID of a Guild
-func (s *Session) GuildLeave(guildID string, options ...RequestOption) (err error) {
+func (s *Session) GuildLeave(guildID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointUserGuild("@me", guildID), nil, EndpointUserGuild("", guildID), options...)
 	return
@@ -691,7 +691,7 @@ func (s *Session) GuildLeave(guildID string, options ...RequestOption) (err erro
 // limit     : Max number of bans to return (max 1000)
 // beforeID  : If not empty all returned users will be after the given id
 // afterID   : If not empty all returned users will be before the given id
-func (s *Session) GuildBans(guildID string, limit int, beforeID, afterID string, options ...RequestOption) (st []*GuildBan, err error) {
+func (s *Session) GuildBans(guildID Snowflake, limit int, beforeID, afterID string, options ...RequestOption) (st []*GuildBan, err error) {
 	uri := EndpointGuildBans(guildID)
 
 	v := url.Values{}
@@ -723,12 +723,12 @@ func (s *Session) GuildBans(guildID string, limit int, beforeID, afterID string,
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
 // days      : The number of days of previous comments to delete.
-func (s *Session) GuildBanCreate(guildID, userID string, days int, options ...RequestOption) (err error) {
+func (s *Session) GuildBanCreate(guildID, userID Snowflake, days int, options ...RequestOption) (err error) {
 	return s.GuildBanCreateWithReason(guildID, userID, "", days, options...)
 }
 
 // GuildBan finds ban by given guild and user id and returns GuildBan structure
-func (s *Session) GuildBan(guildID, userID string, options ...RequestOption) (st *GuildBan, err error) {
+func (s *Session) GuildBan(guildID, userID Snowflake, options ...RequestOption) (st *GuildBan, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, userID), options...)
 	if err != nil {
@@ -745,7 +745,7 @@ func (s *Session) GuildBan(guildID, userID string, options ...RequestOption) (st
 // userID    : The ID of a User
 // reason    : The reason for this ban
 // days      : The number of days of previous comments to delete.
-func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days int, options ...RequestOption) (err error) {
+func (s *Session) GuildBanCreateWithReason(guildID, userID Snowflake, reason string, days int, options ...RequestOption) (err error) {
 
 	uri := EndpointGuildBan(guildID, userID)
 
@@ -768,7 +768,7 @@ func (s *Session) GuildBanCreateWithReason(guildID, userID, reason string, days 
 // GuildBanDelete removes the given user from the guild bans
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-func (s *Session) GuildBanDelete(guildID, userID string, options ...RequestOption) (err error) {
+func (s *Session) GuildBanDelete(guildID, userID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildBan(guildID, userID), nil, EndpointGuildBan(guildID, ""), options...)
 	return
@@ -778,7 +778,7 @@ func (s *Session) GuildBanDelete(guildID, userID string, options ...RequestOptio
 // guildID  : The ID of a Guild.
 // after    : The id of the member to return members after
 // limit    : max number of members to return (max 1000)
-func (s *Session) GuildMembers(guildID string, after string, limit int, options ...RequestOption) (st []*Member, err error) {
+func (s *Session) GuildMembers(guildID Snowflake, after string, limit int, options ...RequestOption) (st []*Member, err error) {
 
 	uri := EndpointGuildMembers(guildID)
 
@@ -809,7 +809,7 @@ func (s *Session) GuildMembers(guildID string, after string, limit int, options 
 // guildID  : The ID of a Guild
 // query    : Query string to match username(s) and nickname(s) against
 // limit    : Max number of members to return (default 1, min 1, max 1000)
-func (s *Session) GuildMembersSearch(guildID, query string, limit int, options ...RequestOption) (st []*Member, err error) {
+func (s *Session) GuildMembersSearch(guildID Snowflake, query string, limit int, options ...RequestOption) (st []*Member, err error) {
 
 	uri := EndpointGuildMembersSearch(guildID)
 
@@ -831,7 +831,7 @@ func (s *Session) GuildMembersSearch(guildID, query string, limit int, options .
 // GuildMember returns a member of a guild.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-func (s *Session) GuildMember(guildID, userID string, options ...RequestOption) (st *Member, err error) {
+func (s *Session) GuildMember(guildID, userID Snowflake, options ...RequestOption) (st *Member, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildMember(guildID, userID), nil, EndpointGuildMember(guildID, ""), options...)
 	if err != nil {
@@ -848,7 +848,7 @@ func (s *Session) GuildMember(guildID, userID string, options ...RequestOption) 
 // guildID       : The ID of a Guild.
 // userID        : The ID of a User.
 // data          : Parameters of the user to add.
-func (s *Session) GuildMemberAdd(guildID, userID string, data *GuildMemberAddParams, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberAdd(guildID, userID Snowflake, data *GuildMemberAddParams, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	if err != nil {
@@ -861,7 +861,7 @@ func (s *Session) GuildMemberAdd(guildID, userID string, data *GuildMemberAddPar
 // GuildMemberDelete removes the given user from the given guild.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
-func (s *Session) GuildMemberDelete(guildID, userID string, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberDelete(guildID, userID Snowflake, options ...RequestOption) (err error) {
 
 	return s.GuildMemberDeleteWithReason(guildID, userID, "", options...)
 }
@@ -870,7 +870,7 @@ func (s *Session) GuildMemberDelete(guildID, userID string, options ...RequestOp
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User
 // reason    : The reason for the kick
-func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberDeleteWithReason(guildID, userID Snowflake, reason string, options ...RequestOption) (err error) {
 
 	uri := EndpointGuildMember(guildID, userID)
 	if reason != "" {
@@ -885,7 +885,7 @@ func (s *Session) GuildMemberDeleteWithReason(guildID, userID, reason string, op
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : Updated GuildMember data.
-func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberParams, options ...RequestOption) (st *Member, err error) {
+func (s *Session) GuildMemberEdit(guildID, userID Snowflake, data *GuildMemberParams, options ...RequestOption) (st *Member, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
 	if err != nil {
@@ -902,7 +902,7 @@ func (s *Session) GuildMemberEdit(guildID, userID string, data *GuildMemberParam
 // guildID  : The ID of a Guild.
 // userID   : The ID of a User.
 // data     : A GuildMemberEditData struct with the new nickname and roles
-func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemberParams, options ...RequestOption) (st *Member, err error) {
+func (s *Session) GuildMemberEditComplex(guildID, userID Snowflake, data *GuildMemberParams, options ...RequestOption) (st *Member, err error) {
 	return s.GuildMemberEdit(guildID, userID, data, options...)
 }
 
@@ -913,9 +913,9 @@ func (s *Session) GuildMemberEditComplex(guildID, userID string, data *GuildMemb
 //
 // NOTE : I am not entirely set on the name of this function and it may change
 // prior to the final 1.0.0 release of Discordgo
-func (s *Session) GuildMemberMove(guildID string, userID string, channelID *string, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberMove(guildID, userID Snowflake, channelID *Snowflake, options ...RequestOption) (err error) {
 	data := struct {
-		ChannelID *string `json:"channel_id"`
+		ChannelID *Snowflake `json:"channel_id"`
 	}{channelID}
 
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, userID), data, EndpointGuildMember(guildID, ""), options...)
@@ -927,7 +927,7 @@ func (s *Session) GuildMemberMove(guildID string, userID string, channelID *stri
 // userID    : The ID of a user
 // userID    : The ID of a user or "@me" which is a shortcut of the current user ID
 // nickname  : The nickname of the member, "" will reset their nickname
-func (s *Session) GuildMemberNickname(guildID, userID, nickname string, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberNickname(guildID, userID Snowflake, nickname string, options ...RequestOption) (err error) {
 
 	data := struct {
 		Nick string `json:"nick"`
@@ -945,7 +945,7 @@ func (s *Session) GuildMemberNickname(guildID, userID, nickname string, options 
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User.
 // mute      : boolean value for if the user should be muted
-func (s *Session) GuildMemberMute(guildID string, userID string, mute bool, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberMute(guildID, userID Snowflake, mute bool, options ...RequestOption) (err error) {
 	data := struct {
 		Mute bool `json:"mute"`
 	}{mute}
@@ -958,7 +958,7 @@ func (s *Session) GuildMemberMute(guildID string, userID string, mute bool, opti
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User.
 // until     : The timestamp for how long a member should be timed out. Set to nil to remove timeout.
-func (s *Session) GuildMemberTimeout(guildID string, userID string, until *time.Time, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberTimeout(guildID, userID Snowflake, until *time.Time, options ...RequestOption) (err error) {
 	data := struct {
 		CommunicationDisabledUntil *time.Time `json:"communication_disabled_until"`
 	}{until}
@@ -971,7 +971,7 @@ func (s *Session) GuildMemberTimeout(guildID string, userID string, until *time.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User.
 // deaf      : boolean value for if the user should be deafened
-func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberDeafen(guildID, userID Snowflake, deaf bool, options ...RequestOption) (err error) {
 	data := struct {
 		Deaf bool `json:"deaf"`
 	}{deaf}
@@ -984,7 +984,7 @@ func (s *Session) GuildMemberDeafen(guildID string, userID string, deaf bool, op
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User.
 // roleID    : The ID of a Role to be assigned to the user.
-func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""), options...)
 
@@ -995,7 +995,7 @@ func (s *Session) GuildMemberRoleAdd(guildID, userID, roleID string, options ...
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User.
 // roleID    : The ID of a Role to be removed from the user.
-func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string, options ...RequestOption) (err error) {
+func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildMemberRole(guildID, userID, roleID), nil, EndpointGuildMemberRole(guildID, "", ""), options...)
 
@@ -1005,7 +1005,7 @@ func (s *Session) GuildMemberRoleRemove(guildID, userID, roleID string, options 
 // GuildChannels returns an array of Channel structures for all channels of a
 // given guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildChannels(guildID string, options ...RequestOption) (st []*Channel, err error) {
+func (s *Session) GuildChannels(guildID Snowflake, options ...RequestOption) (st []*Channel, err error) {
 
 	body, err := s.request("GET", EndpointGuildChannels(guildID), "", nil, EndpointGuildChannels(guildID), 0, options...)
 	if err != nil {
@@ -1034,7 +1034,7 @@ type GuildChannelCreateData struct {
 // GuildChannelCreateComplex creates a new channel in the given guild
 // guildID      : The ID of a Guild
 // data         : A data struct describing the new Channel, Name and Type are mandatory, other fields depending on the type
-func (s *Session) GuildChannelCreateComplex(guildID string, data GuildChannelCreateData, options ...RequestOption) (st *Channel, err error) {
+func (s *Session) GuildChannelCreateComplex(guildID Snowflake, data GuildChannelCreateData, options ...RequestOption) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildChannels(guildID), data, EndpointGuildChannels(guildID), options...)
 	if err != nil {
 		return
@@ -1048,7 +1048,7 @@ func (s *Session) GuildChannelCreateComplex(guildID string, data GuildChannelCre
 // guildID   : The ID of a Guild.
 // name      : Name of the channel (2-100 chars length)
 // ctype     : Type of the channel
-func (s *Session) GuildChannelCreate(guildID, name string, ctype ChannelType, options ...RequestOption) (st *Channel, err error) {
+func (s *Session) GuildChannelCreate(guildID Snowflake, name string, ctype ChannelType, options ...RequestOption) (st *Channel, err error) {
 	return s.GuildChannelCreateComplex(guildID, GuildChannelCreateData{
 		Name: name,
 		Type: ctype,
@@ -1058,11 +1058,11 @@ func (s *Session) GuildChannelCreate(guildID, name string, ctype ChannelType, op
 // GuildChannelsReorder updates the order of channels in a guild
 // guildID   : The ID of a Guild.
 // channels  : Updated channels.
-func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel, options ...RequestOption) (err error) {
+func (s *Session) GuildChannelsReorder(guildID Snowflake, channels []*Channel, options ...RequestOption) (err error) {
 
 	data := make([]struct {
-		ID       string `json:"id"`
-		Position int    `json:"position"`
+		ID       Snowflake `json:"id"`
+		Position int       `json:"position"`
 	}, len(channels))
 
 	for i, c := range channels {
@@ -1076,7 +1076,7 @@ func (s *Session) GuildChannelsReorder(guildID string, channels []*Channel, opti
 
 // GuildInvites returns an array of Invite structures for the given guild
 // guildID   : The ID of a Guild.
-func (s *Session) GuildInvites(guildID string, options ...RequestOption) (st []*Invite, err error) {
+func (s *Session) GuildInvites(guildID Snowflake, options ...RequestOption) (st []*Invite, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointGuildInvites(guildID), nil, EndpointGuildInvites(guildID), options...)
 	if err != nil {
 		return
@@ -1088,7 +1088,7 @@ func (s *Session) GuildInvites(guildID string, options ...RequestOption) (st []*
 
 // GuildRoles returns all roles for a given guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildRoles(guildID string, options ...RequestOption) (st []*Role, err error) {
+func (s *Session) GuildRoles(guildID Snowflake, options ...RequestOption) (st []*Role, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildRoles(guildID), nil, EndpointGuildRoles(guildID), options...)
 	if err != nil {
@@ -1103,7 +1103,7 @@ func (s *Session) GuildRoles(guildID string, options ...RequestOption) (st []*Ro
 // GuildRoleCreate creates a new Guild Role and returns it.
 // guildID : The ID of a Guild.
 // data    : New Role parameters.
-func (s *Session) GuildRoleCreate(guildID string, data *RoleParams, options ...RequestOption) (st *Role, err error) {
+func (s *Session) GuildRoleCreate(guildID Snowflake, data *RoleParams, options ...RequestOption) (st *Role, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildRoles(guildID), data, EndpointGuildRoles(guildID), options...)
 	if err != nil {
 		return
@@ -1118,7 +1118,7 @@ func (s *Session) GuildRoleCreate(guildID string, data *RoleParams, options ...R
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
 // data 		 : Updated Role data.
-func (s *Session) GuildRoleEdit(guildID, roleID string, data *RoleParams, options ...RequestOption) (st *Role, err error) {
+func (s *Session) GuildRoleEdit(guildID, roleID Snowflake, data *RoleParams, options ...RequestOption) (st *Role, err error) {
 
 	// Prevent sending a color int that is too big.
 	if data.Color != nil && *data.Color > 0xFFFFFF {
@@ -1138,7 +1138,7 @@ func (s *Session) GuildRoleEdit(guildID, roleID string, data *RoleParams, option
 // GuildRoleReorder reoders guild roles
 // guildID   : The ID of a Guild.
 // roles     : A list of ordered roles.
-func (s *Session) GuildRoleReorder(guildID string, roles []*Role, options ...RequestOption) (st []*Role, err error) {
+func (s *Session) GuildRoleReorder(guildID Snowflake, roles []*Role, options ...RequestOption) (st []*Role, err error) {
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildRoles(guildID), roles, EndpointGuildRoles(guildID), options...)
 	if err != nil {
@@ -1153,7 +1153,7 @@ func (s *Session) GuildRoleReorder(guildID string, roles []*Role, options ...Req
 // GuildRoleDelete deletes an existing role.
 // guildID   : The ID of a Guild.
 // roleID    : The ID of a Role.
-func (s *Session) GuildRoleDelete(guildID, roleID string, options ...RequestOption) (err error) {
+func (s *Session) GuildRoleDelete(guildID, roleID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildRole(guildID, roleID), nil, EndpointGuildRole(guildID, ""), options...)
 
@@ -1164,7 +1164,7 @@ func (s *Session) GuildRoleDelete(guildID, roleID string, options ...RequestOpti
 // Requires 'KICK_MEMBER' permission.
 // guildID	: The ID of a Guild.
 // days		: The number of days to count prune for (1 or more).
-func (s *Session) GuildPruneCount(guildID string, days uint32, options ...RequestOption) (count uint32, err error) {
+func (s *Session) GuildPruneCount(guildID Snowflake, days uint32, options ...RequestOption) (count uint32, err error) {
 	count = 0
 
 	if days <= 0 {
@@ -1196,7 +1196,7 @@ func (s *Session) GuildPruneCount(guildID string, days uint32, options ...Reques
 // Returns an object with one 'pruned' key indicating the number of members that were removed in the prune operation.
 // guildID	: The ID of a Guild.
 // days		: The number of days to count prune for (1 or more).
-func (s *Session) GuildPrune(guildID string, days uint32, options ...RequestOption) (count uint32, err error) {
+func (s *Session) GuildPrune(guildID Snowflake, days uint32, options ...RequestOption) (count uint32, err error) {
 
 	count = 0
 
@@ -1230,7 +1230,7 @@ func (s *Session) GuildPrune(guildID string, days uint32, options ...RequestOpti
 
 // GuildIntegrations returns an array of Integrations for a guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildIntegrations(guildID string, options ...RequestOption) (st []*Integration, err error) {
+func (s *Session) GuildIntegrations(guildID Snowflake, options ...RequestOption) (st []*Integration, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildIntegrations(guildID), nil, EndpointGuildIntegrations(guildID), options...)
 	if err != nil {
@@ -1246,11 +1246,11 @@ func (s *Session) GuildIntegrations(guildID string, options ...RequestOption) (s
 // guildID          : The ID of a Guild.
 // integrationType  : The Integration type.
 // integrationID    : The ID of an integration.
-func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID string, options ...RequestOption) (err error) {
+func (s *Session) GuildIntegrationCreate(guildID Snowflake, integrationType string, integrationID Snowflake, options ...RequestOption) (err error) {
 
 	data := struct {
-		Type string `json:"type"`
-		ID   string `json:"id"`
+		Type string    `json:"type"`
+		ID   Snowflake `json:"id"`
 	}{integrationType, integrationID}
 
 	_, err = s.RequestWithBucketID("POST", EndpointGuildIntegrations(guildID), data, EndpointGuildIntegrations(guildID), options...)
@@ -1264,7 +1264,7 @@ func (s *Session) GuildIntegrationCreate(guildID, integrationType, integrationID
 // expireBehavior	      : The behavior when an integration subscription lapses (see the integration object documentation).
 // expireGracePeriod    : Period (in seconds) where the integration will ignore lapsed subscriptions.
 // enableEmoticons	    : Whether emoticons should be synced for this integration (twitch only currently).
-func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBehavior, expireGracePeriod int, enableEmoticons bool, options ...RequestOption) (err error) {
+func (s *Session) GuildIntegrationEdit(guildID, integrationID Snowflake, expireBehavior, expireGracePeriod int, enableEmoticons bool, options ...RequestOption) (err error) {
 
 	data := struct {
 		ExpireBehavior    int  `json:"expire_behavior"`
@@ -1279,7 +1279,7 @@ func (s *Session) GuildIntegrationEdit(guildID, integrationID string, expireBeha
 // GuildIntegrationDelete removes the given integration from the Guild.
 // guildID          : The ID of a Guild.
 // integrationID    : The ID of an integration.
-func (s *Session) GuildIntegrationDelete(guildID, integrationID string, options ...RequestOption) (err error) {
+func (s *Session) GuildIntegrationDelete(guildID, integrationID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildIntegration(guildID, integrationID), nil, EndpointGuildIntegration(guildID, ""), options...)
 	return
@@ -1287,7 +1287,7 @@ func (s *Session) GuildIntegrationDelete(guildID, integrationID string, options 
 
 // GuildIcon returns an image.Image of a guild icon.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildIcon(guildID string, options ...RequestOption) (img image.Image, err error) {
+func (s *Session) GuildIcon(guildID Snowflake, options ...RequestOption) (img image.Image, err error) {
 	g, err := s.Guild(guildID, options...)
 	if err != nil {
 		return
@@ -1309,7 +1309,7 @@ func (s *Session) GuildIcon(guildID string, options ...RequestOption) (img image
 
 // GuildSplash returns an image.Image of a guild splash image.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildSplash(guildID string, options ...RequestOption) (img image.Image, err error) {
+func (s *Session) GuildSplash(guildID Snowflake, options ...RequestOption) (img image.Image, err error) {
 	g, err := s.Guild(guildID, options...)
 	if err != nil {
 		return
@@ -1331,7 +1331,7 @@ func (s *Session) GuildSplash(guildID string, options ...RequestOption) (img ima
 
 // GuildEmbed returns the embed for a Guild.
 // guildID   : The ID of a Guild.
-func (s *Session) GuildEmbed(guildID string, options ...RequestOption) (st *GuildEmbed, err error) {
+func (s *Session) GuildEmbed(guildID Snowflake, options ...RequestOption) (st *GuildEmbed, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildEmbed(guildID), nil, EndpointGuildEmbed(guildID), options...)
 	if err != nil {
@@ -1345,7 +1345,7 @@ func (s *Session) GuildEmbed(guildID string, options ...RequestOption) (st *Guil
 // GuildEmbedEdit edits the embed of a Guild.
 // guildID   : The ID of a Guild.
 // data      : New GuildEmbed data.
-func (s *Session) GuildEmbedEdit(guildID string, data *GuildEmbed, options ...RequestOption) (err error) {
+func (s *Session) GuildEmbedEdit(guildID Snowflake, data *GuildEmbed, options ...RequestOption) (err error) {
 	_, err = s.RequestWithBucketID("PATCH", EndpointGuildEmbed(guildID), data, EndpointGuildEmbed(guildID), options...)
 	return
 }
@@ -1356,16 +1356,16 @@ func (s *Session) GuildEmbedEdit(guildID string, data *GuildEmbed, options ...Re
 // beforeID    : If provided all log entries returned will be before the given ID.
 // actionType  : If provided the log will be filtered for the given Action Type.
 // limit       : The number messages that can be returned. (default 50, min 1, max 100)
-func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, limit int, options ...RequestOption) (st *GuildAuditLog, err error) {
+func (s *Session) GuildAuditLog(guildID, userID, beforeID Snowflake, actionType, limit int, options ...RequestOption) (st *GuildAuditLog, err error) {
 
 	uri := EndpointGuildAuditLogs(guildID)
 
 	v := url.Values{}
 	if userID != "" {
-		v.Set("user_id", userID)
+		v.Set("user_id", string(userID))
 	}
 	if beforeID != "" {
-		v.Set("before", beforeID)
+		v.Set("before", string(beforeID))
 	}
 	if actionType > 0 {
 		v.Set("action_type", strconv.Itoa(actionType))
@@ -1388,7 +1388,7 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 
 // GuildEmojis returns all emoji
 // guildID : The ID of a Guild.
-func (s *Session) GuildEmojis(guildID string, options ...RequestOption) (emoji []*Emoji, err error) {
+func (s *Session) GuildEmojis(guildID Snowflake, options ...RequestOption) (emoji []*Emoji, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildEmojis(guildID), nil, EndpointGuildEmojis(guildID), options...)
 	if err != nil {
@@ -1402,7 +1402,7 @@ func (s *Session) GuildEmojis(guildID string, options ...RequestOption) (emoji [
 // GuildEmoji returns specified emoji.
 // guildID : The ID of a Guild
 // emojiID : The ID of an Emoji to retrieve
-func (s *Session) GuildEmoji(guildID, emojiID string, options ...RequestOption) (emoji *Emoji, err error) {
+func (s *Session) GuildEmoji(guildID, emojiID Snowflake, options ...RequestOption) (emoji *Emoji, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("GET", EndpointGuildEmoji(guildID, emojiID), nil, EndpointGuildEmoji(guildID, emojiID), options...)
 	if err != nil {
@@ -1416,7 +1416,7 @@ func (s *Session) GuildEmoji(guildID, emojiID string, options ...RequestOption) 
 // GuildEmojiCreate creates a new Emoji.
 // guildID : The ID of a Guild.
 // data    : New Emoji data.
-func (s *Session) GuildEmojiCreate(guildID string, data *EmojiParams, options ...RequestOption) (emoji *Emoji, err error) {
+func (s *Session) GuildEmojiCreate(guildID Snowflake, data *EmojiParams, options ...RequestOption) (emoji *Emoji, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildEmojis(guildID), data, EndpointGuildEmojis(guildID), options...)
 	if err != nil {
 		return
@@ -1430,7 +1430,7 @@ func (s *Session) GuildEmojiCreate(guildID string, data *EmojiParams, options ..
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
 // data    : Updated Emoji data.
-func (s *Session) GuildEmojiEdit(guildID, emojiID string, data *EmojiParams, options ...RequestOption) (emoji *Emoji, err error) {
+func (s *Session) GuildEmojiEdit(guildID, emojiID Snowflake, data *EmojiParams, options ...RequestOption) (emoji *Emoji, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildEmoji(guildID, emojiID), data, EndpointGuildEmojis(guildID), options...)
 	if err != nil {
 		return
@@ -1443,7 +1443,7 @@ func (s *Session) GuildEmojiEdit(guildID, emojiID string, data *EmojiParams, opt
 // GuildEmojiDelete deletes an Emoji.
 // guildID : The ID of a Guild.
 // emojiID : The ID of an Emoji.
-func (s *Session) GuildEmojiDelete(guildID, emojiID string, options ...RequestOption) (err error) {
+func (s *Session) GuildEmojiDelete(guildID, emojiID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildEmoji(guildID, emojiID), nil, EndpointGuildEmojis(guildID), options...)
 	return
@@ -1484,7 +1484,7 @@ func (s *Session) GuildCreateWithTemplate(templateCode, name, icon string, optio
 
 // GuildTemplates returns all of GuildTemplates
 // guildID: The ID of the guild
-func (s *Session) GuildTemplates(guildID string, options ...RequestOption) (st []*GuildTemplate, err error) {
+func (s *Session) GuildTemplates(guildID Snowflake, options ...RequestOption) (st []*GuildTemplate, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildTemplates(guildID), nil, EndpointGuildTemplates(guildID), options...)
 	if err != nil {
@@ -1498,7 +1498,7 @@ func (s *Session) GuildTemplates(guildID string, options ...RequestOption) (st [
 // GuildTemplateCreate creates a template for the guild
 // guildID : The ID of the guild
 // data    : Template metadata
-func (s *Session) GuildTemplateCreate(guildID string, data *GuildTemplateParams, options ...RequestOption) (st *GuildTemplate) {
+func (s *Session) GuildTemplateCreate(guildID Snowflake, data *GuildTemplateParams, options ...RequestOption) (st *GuildTemplate, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildTemplates(guildID), data, EndpointGuildTemplates(guildID), options...)
 	if err != nil {
 		return
@@ -1511,7 +1511,7 @@ func (s *Session) GuildTemplateCreate(guildID string, data *GuildTemplateParams,
 // GuildTemplateSync syncs the template to the guild's current state
 // guildID: The ID of the guild
 // templateCode: The code of the template
-func (s *Session) GuildTemplateSync(guildID, templateCode string, options ...RequestOption) (err error) {
+func (s *Session) GuildTemplateSync(guildID Snowflake, templateCode string, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""), options...)
 	return
@@ -1521,7 +1521,7 @@ func (s *Session) GuildTemplateSync(guildID, templateCode string, options ...Req
 // guildID      : The ID of the guild
 // templateCode : The code of the template
 // data         : New template metadata
-func (s *Session) GuildTemplateEdit(guildID, templateCode string, data *GuildTemplateParams, options ...RequestOption) (st *GuildTemplate, err error) {
+func (s *Session) GuildTemplateEdit(guildID Snowflake, templateCode string, data *GuildTemplateParams, options ...RequestOption) (st *GuildTemplate, err error) {
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildTemplateSync(guildID, templateCode), data, EndpointGuildTemplateSync(guildID, ""), options...)
 	if err != nil {
@@ -1535,7 +1535,7 @@ func (s *Session) GuildTemplateEdit(guildID, templateCode string, data *GuildTem
 // GuildTemplateDelete deletes the template
 // guildID: The ID of the guild
 // templateCode: The code of the template
-func (s *Session) GuildTemplateDelete(guildID, templateCode string, options ...RequestOption) (err error) {
+func (s *Session) GuildTemplateDelete(guildID Snowflake, templateCode string, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildTemplateSync(guildID, templateCode), nil, EndpointGuildTemplateSync(guildID, ""), options...)
 	return
@@ -1547,7 +1547,7 @@ func (s *Session) GuildTemplateDelete(guildID, templateCode string, options ...R
 
 // Channel returns a Channel structure of a specific Channel.
 // channelID  : The ID of the Channel you want returned.
-func (s *Session) Channel(channelID string, options ...RequestOption) (st *Channel, err error) {
+func (s *Session) Channel(channelID Snowflake, options ...RequestOption) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointChannel(channelID), nil, EndpointChannel(channelID), options...)
 	if err != nil {
 		return
@@ -1560,7 +1560,7 @@ func (s *Session) Channel(channelID string, options ...RequestOption) (st *Chann
 // ChannelEdit edits the given channel and returns the updated Channel data.
 // channelID  : The ID of a Channel.
 // data       : New Channel data.
-func (s *Session) ChannelEdit(channelID string, data *ChannelEdit, options ...RequestOption) (st *Channel, err error) {
+func (s *Session) ChannelEdit(channelID Snowflake, data *ChannelEdit, options ...RequestOption) (st *Channel, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointChannel(channelID), data, EndpointChannel(channelID), options...)
 	if err != nil {
 		return
@@ -1575,13 +1575,13 @@ func (s *Session) ChannelEdit(channelID string, data *ChannelEdit, options ...Re
 // NOTE: deprecated, use ChannelEdit instead
 // channelID     : The ID of a Channel
 // data          : The channel struct to send
-func (s *Session) ChannelEditComplex(channelID string, data *ChannelEdit, options ...RequestOption) (st *Channel, err error) {
+func (s *Session) ChannelEditComplex(channelID Snowflake, data *ChannelEdit, options ...RequestOption) (st *Channel, err error) {
 	return s.ChannelEdit(channelID, data, options...)
 }
 
 // ChannelDelete deletes the given channel
 // channelID  : The ID of a Channel
-func (s *Session) ChannelDelete(channelID string, options ...RequestOption) (st *Channel, err error) {
+func (s *Session) ChannelDelete(channelID Snowflake, options ...RequestOption) (st *Channel, err error) {
 
 	body, err := s.RequestWithBucketID("DELETE", EndpointChannel(channelID), nil, EndpointChannel(channelID), options...)
 	if err != nil {
@@ -1595,7 +1595,7 @@ func (s *Session) ChannelDelete(channelID string, options ...RequestOption) (st 
 // ChannelTyping broadcasts to all members that authenticated user is typing in
 // the given channel.
 // channelID  : The ID of a Channel
-func (s *Session) ChannelTyping(channelID string, options ...RequestOption) (err error) {
+func (s *Session) ChannelTyping(channelID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("POST", EndpointChannelTyping(channelID), nil, EndpointChannelTyping(channelID), options...)
 	return
@@ -1608,7 +1608,7 @@ func (s *Session) ChannelTyping(channelID string, options ...RequestOption) (err
 // beforeID  : If provided all messages returned will be before given ID.
 // afterID   : If provided all messages returned will be after given ID.
 // aroundID  : If provided all messages returned will be around given ID.
-func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID, aroundID string, options ...RequestOption) (st []*Message, err error) {
+func (s *Session) ChannelMessages(channelID Snowflake, limit int, beforeID, afterID, aroundID Snowflake, options ...RequestOption) (st []*Message, err error) {
 
 	uri := EndpointChannelMessages(channelID)
 
@@ -1617,13 +1617,13 @@ func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID
 		v.Set("limit", strconv.Itoa(limit))
 	}
 	if afterID != "" {
-		v.Set("after", afterID)
+		v.Set("after", string(afterID))
 	}
 	if beforeID != "" {
-		v.Set("before", beforeID)
+		v.Set("before", string(beforeID))
 	}
 	if aroundID != "" {
-		v.Set("around", aroundID)
+		v.Set("around", string(aroundID))
 	}
 	if len(v) > 0 {
 		uri += "?" + v.Encode()
@@ -1641,7 +1641,7 @@ func (s *Session) ChannelMessages(channelID string, limit int, beforeID, afterID
 // ChannelMessage gets a single message by ID from a given channel.
 // channeld  : The ID of a Channel
 // messageID : the ID of a Message
-func (s *Session) ChannelMessage(channelID, messageID string, options ...RequestOption) (st *Message, err error) {
+func (s *Session) ChannelMessage(channelID, messageID Snowflake, options ...RequestOption) (st *Message, err error) {
 
 	response, err := s.RequestWithBucketID("GET", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""), options...)
 	if err != nil {
@@ -1655,7 +1655,7 @@ func (s *Session) ChannelMessage(channelID, messageID string, options ...Request
 // ChannelMessageSend sends a message to the given channel.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSend(channelID string, content string, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageSend(channelID Snowflake, content string, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Content: content,
 	}, options...)
@@ -1666,7 +1666,7 @@ var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 // ChannelMessageSendComplex sends a message to the given channel.
 // channelID : The ID of a Channel.
 // data      : The message struct to send.
-func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend, options ...RequestOption) (st *Message, err error) {
+func (s *Session) ChannelMessageSendComplex(channelID Snowflake, data *MessageSend, options ...RequestOption) (st *Message, err error) {
 	// TODO: Remove this when compatibility is not required.
 	if data.Embed != nil {
 		if data.Embeds == nil {
@@ -1723,7 +1723,7 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend,
 // ChannelMessageSendTTS sends a message to the given channel with Text to Speech.
 // channelID : The ID of a Channel.
 // content   : The message to send.
-func (s *Session) ChannelMessageSendTTS(channelID string, content string, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageSendTTS(channelID Snowflake, content string, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Content: content,
 		TTS:     true,
@@ -1733,14 +1733,14 @@ func (s *Session) ChannelMessageSendTTS(channelID string, content string, option
 // ChannelMessageSendEmbed sends a message to the given channel with embedded data.
 // channelID : The ID of a Channel.
 // embed     : The embed data to send.
-func (s *Session) ChannelMessageSendEmbed(channelID string, embed *MessageEmbed, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbed(channelID Snowflake, embed *MessageEmbed, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendEmbeds(channelID, []*MessageEmbed{embed}, options...)
 }
 
 // ChannelMessageSendEmbeds sends a message to the given channel with multiple embedded data.
 // channelID : The ID of a Channel.
 // embeds    : The embeds data to send.
-func (s *Session) ChannelMessageSendEmbeds(channelID string, embeds []*MessageEmbed, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbeds(channelID Snowflake, embeds []*MessageEmbed, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{
 		Embeds: embeds,
 	}, options...)
@@ -1750,7 +1750,7 @@ func (s *Session) ChannelMessageSendEmbeds(channelID string, embeds []*MessageEm
 // channelID : The ID of a Channel.
 // content   : The message to send.
 // reference : The message reference to send.
-func (s *Session) ChannelMessageSendReply(channelID string, content string, reference *MessageReference, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageSendReply(channelID Snowflake, content string, reference *MessageReference, options ...RequestOption) (*Message, error) {
 	if reference == nil {
 		return nil, fmt.Errorf("reply attempted with nil message reference")
 	}
@@ -1764,7 +1764,7 @@ func (s *Session) ChannelMessageSendReply(channelID string, content string, refe
 // channelID : The ID of a Channel.
 // embed   : The embed data to send.
 // reference : The message reference to send.
-func (s *Session) ChannelMessageSendEmbedReply(channelID string, embed *MessageEmbed, reference *MessageReference, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbedReply(channelID Snowflake, embed *MessageEmbed, reference *MessageReference, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendEmbedsReply(channelID, []*MessageEmbed{embed}, reference, options...)
 }
 
@@ -1772,7 +1772,7 @@ func (s *Session) ChannelMessageSendEmbedReply(channelID string, embed *MessageE
 // channelID : The ID of a Channel.
 // embeds    : The embeds data to send.
 // reference : The message reference to send.
-func (s *Session) ChannelMessageSendEmbedsReply(channelID string, embeds []*MessageEmbed, reference *MessageReference, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageSendEmbedsReply(channelID Snowflake, embeds []*MessageEmbed, reference *MessageReference, options ...RequestOption) (*Message, error) {
 	if reference == nil {
 		return nil, fmt.Errorf("reply attempted with nil message reference")
 	}
@@ -1787,7 +1787,7 @@ func (s *Session) ChannelMessageSendEmbedsReply(channelID string, embeds []*Mess
 // channelID  : The ID of a Channel
 // messageID  : The ID of a Message
 // content    : The contents of the message
-func (s *Session) ChannelMessageEdit(channelID, messageID, content string, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageEdit(channelID, messageID Snowflake, content string, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetContent(content), options...)
 }
 
@@ -1834,7 +1834,7 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit, options ...RequestOp
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
 // embed     : The embed data to send
-func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *MessageEmbed, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageEditEmbed(channelID, messageID Snowflake, embed *MessageEmbed, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageEditEmbeds(channelID, messageID, []*MessageEmbed{embed}, options...)
 }
 
@@ -1842,12 +1842,12 @@ func (s *Session) ChannelMessageEditEmbed(channelID, messageID string, embed *Me
 // channelID : The ID of a Channel
 // messageID : The ID of a Message
 // embeds    : The embeds data to send
-func (s *Session) ChannelMessageEditEmbeds(channelID, messageID string, embeds []*MessageEmbed, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelMessageEditEmbeds(channelID, messageID Snowflake, embeds []*MessageEmbed, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageEditComplex(NewMessageEdit(channelID, messageID).SetEmbeds(embeds), options...)
 }
 
 // ChannelMessageDelete deletes a message from the Channel.
-func (s *Session) ChannelMessageDelete(channelID, messageID string, options ...RequestOption) (err error) {
+func (s *Session) ChannelMessageDelete(channelID, messageID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessage(channelID, messageID), nil, EndpointChannelMessage(channelID, ""), options...)
 	return
@@ -1858,7 +1858,7 @@ func (s *Session) ChannelMessageDelete(channelID, messageID string, options ...R
 // If the slice is empty do nothing.
 // channelID : The ID of the channel for the messages to delete.
 // messages  : The IDs of the messages to be deleted. A slice of string IDs. A maximum of 100 messages.
-func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string, options ...RequestOption) (err error) {
+func (s *Session) ChannelMessagesBulkDelete(channelID Snowflake, messages []Snowflake, options ...RequestOption) (err error) {
 
 	if len(messages) == 0 {
 		return
@@ -1874,7 +1874,7 @@ func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string,
 	}
 
 	data := struct {
-		Messages []string `json:"messages"`
+		Messages []Snowflake `json:"messages"`
 	}{messages}
 
 	_, err = s.RequestWithBucketID("POST", EndpointChannelMessagesBulkDelete(channelID), data, EndpointChannelMessagesBulkDelete(channelID), options...)
@@ -1884,7 +1884,7 @@ func (s *Session) ChannelMessagesBulkDelete(channelID string, messages []string,
 // ChannelMessagePin pins a message within a given channel.
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
-func (s *Session) ChannelMessagePin(channelID, messageID string, options ...RequestOption) (err error) {
+func (s *Session) ChannelMessagePin(channelID, messageID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("PUT", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""), options...)
 	return
@@ -1893,7 +1893,7 @@ func (s *Session) ChannelMessagePin(channelID, messageID string, options ...Requ
 // ChannelMessageUnpin unpins a message within a given channel.
 // channelID: The ID of a channel.
 // messageID: The ID of a message.
-func (s *Session) ChannelMessageUnpin(channelID, messageID string, options ...RequestOption) (err error) {
+func (s *Session) ChannelMessageUnpin(channelID, messageID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointChannelMessagePin(channelID, messageID), nil, EndpointChannelMessagePin(channelID, ""), options...)
 	return
@@ -1902,7 +1902,7 @@ func (s *Session) ChannelMessageUnpin(channelID, messageID string, options ...Re
 // ChannelMessagesPinned returns an array of Message structures for pinned messages
 // within a given channel
 // channelID : The ID of a Channel.
-func (s *Session) ChannelMessagesPinned(channelID string, options ...RequestOption) (st []*Message, err error) {
+func (s *Session) ChannelMessagesPinned(channelID Snowflake, options ...RequestOption) (st []*Message, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointChannelMessagesPins(channelID), nil, EndpointChannelMessagesPins(channelID), options...)
 
@@ -1918,7 +1918,7 @@ func (s *Session) ChannelMessagesPinned(channelID string, options ...RequestOpti
 // channelID : The ID of a Channel.
 // name: The name of the file.
 // io.Reader : A reader for the file contents.
-func (s *Session) ChannelFileSend(channelID, name string, r io.Reader, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelFileSend(channelID Snowflake, name string, r io.Reader, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}}, options...)
 }
 
@@ -1928,13 +1928,13 @@ func (s *Session) ChannelFileSend(channelID, name string, r io.Reader, options .
 // content: Optional Message content.
 // name: The name of the file.
 // io.Reader : A reader for the file contents.
-func (s *Session) ChannelFileSendWithMessage(channelID, content string, name string, r io.Reader, options ...RequestOption) (*Message, error) {
+func (s *Session) ChannelFileSendWithMessage(channelID Snowflake, content string, name string, r io.Reader, options ...RequestOption) (*Message, error) {
 	return s.ChannelMessageSendComplex(channelID, &MessageSend{File: &File{Name: name, Reader: r}, Content: content}, options...)
 }
 
 // ChannelInvites returns an array of Invite structures for the given channel
 // channelID   : The ID of a Channel
-func (s *Session) ChannelInvites(channelID string, options ...RequestOption) (st []*Invite, err error) {
+func (s *Session) ChannelInvites(channelID Snowflake, options ...RequestOption) (st []*Invite, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointChannelInvites(channelID), nil, EndpointChannelInvites(channelID), options...)
 	if err != nil {
@@ -1948,7 +1948,7 @@ func (s *Session) ChannelInvites(channelID string, options ...RequestOption) (st
 // ChannelInviteCreate creates a new invite for the given channel.
 // channelID   : The ID of a Channel
 // i           : An Invite struct with the values MaxAge, MaxUses and Temporary defined.
-func (s *Session) ChannelInviteCreate(channelID string, i Invite, options ...RequestOption) (st *Invite, err error) {
+func (s *Session) ChannelInviteCreate(channelID Snowflake, i Invite, options ...RequestOption) (st *Invite, err error) {
 
 	data := struct {
 		MaxAge    int  `json:"max_age"`
@@ -1969,10 +1969,10 @@ func (s *Session) ChannelInviteCreate(channelID string, i Invite, options ...Req
 // ChannelPermissionSet creates a Permission Override for the given channel.
 // NOTE: This func name may changed.  Using Set instead of Create because
 // you can both create a new override or update an override with this function.
-func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType PermissionOverwriteType, allow, deny int64, options ...RequestOption) (err error) {
+func (s *Session) ChannelPermissionSet(channelID, targetID Snowflake, targetType PermissionOverwriteType, allow, deny int64, options ...RequestOption) (err error) {
 
 	data := struct {
-		ID    string                  `json:"id"`
+		ID    Snowflake               `json:"id"`
 		Type  PermissionOverwriteType `json:"type"`
 		Allow int64                   `json:"allow,string"`
 		Deny  int64                   `json:"deny,string"`
@@ -1984,7 +1984,7 @@ func (s *Session) ChannelPermissionSet(channelID, targetID string, targetType Pe
 
 // ChannelPermissionDelete deletes a specific permission override for the given channel.
 // NOTE: Name of this func may change.
-func (s *Session) ChannelPermissionDelete(channelID, targetID string, options ...RequestOption) (err error) {
+func (s *Session) ChannelPermissionDelete(channelID, targetID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointChannelPermission(channelID, targetID), nil, EndpointChannelPermission(channelID, ""), options...)
 	return
@@ -1994,7 +1994,7 @@ func (s *Session) ChannelPermissionDelete(channelID, targetID string, options ..
 // of the channel
 // channelID   : The ID of a Channel
 // messageID   : The ID of a Message
-func (s *Session) ChannelMessageCrosspost(channelID, messageID string, options ...RequestOption) (st *Message, err error) {
+func (s *Session) ChannelMessageCrosspost(channelID, messageID Snowflake, options ...RequestOption) (st *Message, err error) {
 
 	endpoint := EndpointChannelMessageCrosspost(channelID, messageID)
 
@@ -2010,12 +2010,12 @@ func (s *Session) ChannelMessageCrosspost(channelID, messageID string, options .
 // ChannelNewsFollow follows a news channel in the targetID
 // channelID   : The ID of a News Channel
 // targetID    : The ID of a Channel where the News Channel should post to
-func (s *Session) ChannelNewsFollow(channelID, targetID string, options ...RequestOption) (st *ChannelFollow, err error) {
+func (s *Session) ChannelNewsFollow(channelID, targetID Snowflake, options ...RequestOption) (st *ChannelFollow, err error) {
 
 	endpoint := EndpointChannelFollow(channelID)
 
 	data := struct {
-		WebhookChannelID string `json:"webhook_channel_id"`
+		WebhookChannelID Snowflake `json:"webhook_channel_id"`
 	}{targetID}
 
 	body, err := s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
@@ -2032,10 +2032,10 @@ func (s *Session) ChannelNewsFollow(channelID, targetID string, options ...Reque
 // ------------------------------------------------------------------------------------------------
 
 // Invite returns an Invite structure of the given invite
-// inviteID : The invite code
-func (s *Session) Invite(inviteID string, options ...RequestOption) (st *Invite, err error) {
+// code : The invite code
+func (s *Session) Invite(code string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID), nil, EndpointInvite(""), options...)
+	body, err := s.RequestWithBucketID("GET", EndpointInvite(code), nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2045,10 +2045,10 @@ func (s *Session) Invite(inviteID string, options ...RequestOption) (st *Invite,
 }
 
 // InviteWithCounts returns an Invite structure of the given invite including approximate member counts
-// inviteID : The invite code
-func (s *Session) InviteWithCounts(inviteID string, options ...RequestOption) (st *Invite, err error) {
+// code : The invite code
+func (s *Session) InviteWithCounts(code string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("GET", EndpointInvite(inviteID)+"?with_counts=true", nil, EndpointInvite(""), options...)
+	body, err := s.RequestWithBucketID("GET", EndpointInvite(code)+"?with_counts=true", nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2058,15 +2058,15 @@ func (s *Session) InviteWithCounts(inviteID string, options ...RequestOption) (s
 }
 
 // InviteComplex returns an Invite structure of the given invite including specified fields.
-// inviteID                  : The invite code
+// code                      : The invite code
 // guildScheduledEventID     : If specified, includes specified guild scheduled event.
 // withCounts                : Whether to include approximate member counts or not
 // withExpiration            : Whether to include expiration time or not
-func (s *Session) InviteComplex(inviteID, guildScheduledEventID string, withCounts, withExpiration bool, options ...RequestOption) (st *Invite, err error) {
-	endpoint := EndpointInvite(inviteID)
+func (s *Session) InviteComplex(code string, guildScheduledEventID Snowflake, withCounts, withExpiration bool, options ...RequestOption) (st *Invite, err error) {
+	endpoint := EndpointInvite(code)
 	v := url.Values{}
 	if guildScheduledEventID != "" {
-		v.Set("guild_scheduled_event_id", guildScheduledEventID)
+		v.Set("guild_scheduled_event_id", string(guildScheduledEventID))
 	}
 	if withCounts {
 		v.Set("with_counts", "true")
@@ -2089,10 +2089,10 @@ func (s *Session) InviteComplex(inviteID, guildScheduledEventID string, withCoun
 }
 
 // InviteDelete deletes an existing invite
-// inviteID   : the code of an invite
-func (s *Session) InviteDelete(inviteID string, options ...RequestOption) (st *Invite, err error) {
+// code   : the code of an invite
+func (s *Session) InviteDelete(code string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("DELETE", EndpointInvite(inviteID), nil, EndpointInvite(""), options...)
+	body, err := s.RequestWithBucketID("DELETE", EndpointInvite(code), nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2103,9 +2103,9 @@ func (s *Session) InviteDelete(inviteID string, options ...RequestOption) (st *I
 
 // InviteAccept accepts an Invite to a Guild or Channel
 // inviteID : The invite code
-func (s *Session) InviteAccept(inviteID string, options ...RequestOption) (st *Invite, err error) {
+func (s *Session) InviteAccept(code string, options ...RequestOption) (st *Invite, err error) {
 
-	body, err := s.RequestWithBucketID("POST", EndpointInvite(inviteID), nil, EndpointInvite(""), options...)
+	body, err := s.RequestWithBucketID("POST", EndpointInvite(code), nil, EndpointInvite(""), options...)
 	if err != nil {
 		return
 	}
@@ -2190,7 +2190,7 @@ func (s *Session) GatewayBot(options ...RequestOption) (st *GatewayBotResponse, 
 // channelID: The ID of a Channel.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookCreate(channelID, name, avatar string, options ...RequestOption) (st *Webhook, err error) {
+func (s *Session) WebhookCreate(channelID Snowflake, name, avatar string, options ...RequestOption) (st *Webhook, err error) {
 
 	data := struct {
 		Name   string `json:"name"`
@@ -2209,7 +2209,7 @@ func (s *Session) WebhookCreate(channelID, name, avatar string, options ...Reque
 
 // ChannelWebhooks returns all webhooks for a given channel.
 // channelID: The ID of a channel.
-func (s *Session) ChannelWebhooks(channelID string, options ...RequestOption) (st []*Webhook, err error) {
+func (s *Session) ChannelWebhooks(channelID Snowflake, options ...RequestOption) (st []*Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointChannelWebhooks(channelID), nil, EndpointChannelWebhooks(channelID), options...)
 	if err != nil {
@@ -2223,7 +2223,7 @@ func (s *Session) ChannelWebhooks(channelID string, options ...RequestOption) (s
 
 // GuildWebhooks returns all webhooks for a given guild.
 // guildID: The ID of a Guild.
-func (s *Session) GuildWebhooks(guildID string, options ...RequestOption) (st []*Webhook, err error) {
+func (s *Session) GuildWebhooks(guildID Snowflake, options ...RequestOption) (st []*Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointGuildWebhooks(guildID), nil, EndpointGuildWebhooks(guildID), options...)
 	if err != nil {
@@ -2237,7 +2237,7 @@ func (s *Session) GuildWebhooks(guildID string, options ...RequestOption) (st []
 
 // Webhook returns a webhook for a given ID
 // webhookID: The ID of a webhook.
-func (s *Session) Webhook(webhookID string, options ...RequestOption) (st *Webhook, err error) {
+func (s *Session) Webhook(webhookID Snowflake, options ...RequestOption) (st *Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointWebhook(webhookID), nil, EndpointWebhooks, options...)
 	if err != nil {
@@ -2252,7 +2252,7 @@ func (s *Session) Webhook(webhookID string, options ...RequestOption) (st *Webho
 // WebhookWithToken returns a webhook for a given ID
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
-func (s *Session) WebhookWithToken(webhookID, token string, options ...RequestOption) (st *Webhook, err error) {
+func (s *Session) WebhookWithToken(webhookID Snowflake, token string, options ...RequestOption) (st *Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("GET", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""), options...)
 	if err != nil {
@@ -2268,12 +2268,12 @@ func (s *Session) WebhookWithToken(webhookID, token string, options ...RequestOp
 // webhookID: The ID of a webhook.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string, options ...RequestOption) (st *Role, err error) {
+func (s *Session) WebhookEdit(webhookID Snowflake, name, avatar string, channelID Snowflake, options ...RequestOption) (st *Role, err error) {
 
 	data := struct {
-		Name      string `json:"name,omitempty"`
-		Avatar    string `json:"avatar,omitempty"`
-		ChannelID string `json:"channel_id,omitempty"`
+		Name      string    `json:"name,omitempty"`
+		Avatar    string    `json:"avatar,omitempty"`
+		ChannelID Snowflake `json:"channel_id,omitempty"`
 	}{name, avatar, channelID}
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointWebhook(webhookID), data, EndpointWebhooks, options...)
@@ -2291,7 +2291,7 @@ func (s *Session) WebhookEdit(webhookID, name, avatar, channelID string, options
 // token    : The auth token for the webhook.
 // name     : The name of the webhook.
 // avatar   : The avatar of the webhook.
-func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string, options ...RequestOption) (st *Role, err error) {
+func (s *Session) WebhookEditWithToken(webhookID Snowflake, token, name, avatar string, options ...RequestOption) (st *Role, err error) {
 
 	data := struct {
 		Name   string `json:"name,omitempty"`
@@ -2311,7 +2311,7 @@ func (s *Session) WebhookEditWithToken(webhookID, token, name, avatar string, op
 
 // WebhookDelete deletes a webhook for a given ID
 // webhookID: The ID of a webhook.
-func (s *Session) WebhookDelete(webhookID string, options ...RequestOption) (err error) {
+func (s *Session) WebhookDelete(webhookID Snowflake, options ...RequestOption) (err error) {
 
 	_, err = s.RequestWithBucketID("DELETE", EndpointWebhook(webhookID), nil, EndpointWebhooks, options...)
 
@@ -2321,7 +2321,7 @@ func (s *Session) WebhookDelete(webhookID string, options ...RequestOption) (err
 // WebhookDeleteWithToken deletes a webhook for a given ID with an auth token.
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook.
-func (s *Session) WebhookDeleteWithToken(webhookID, token string, options ...RequestOption) (st *Webhook, err error) {
+func (s *Session) WebhookDeleteWithToken(webhookID Snowflake, token string, options ...RequestOption) (st *Webhook, err error) {
 
 	body, err := s.RequestWithBucketID("DELETE", EndpointWebhookToken(webhookID, token), nil, EndpointWebhookToken("", ""), options...)
 	if err != nil {
@@ -2333,7 +2333,7 @@ func (s *Session) WebhookDeleteWithToken(webhookID, token string, options ...Req
 	return
 }
 
-func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID string, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
+func (s *Session) webhookExecute(webhookID Snowflake, token string, wait bool, threadID Snowflake, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
 	uri := EndpointWebhookToken(webhookID, token)
 
 	v := url.Values{}
@@ -2342,7 +2342,7 @@ func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID st
 	}
 
 	if threadID != "" {
-		v.Set("thread_id", threadID)
+		v.Set("thread_id", string(threadID))
 	}
 	if len(v) != 0 {
 		uri += "?" + v.Encode()
@@ -2371,7 +2371,7 @@ func (s *Session) webhookExecute(webhookID, token string, wait bool, threadID st
 // webhookID: The ID of a webhook.
 // token    : The auth token for the webhook
 // wait     : Waits for server confirmation of message send and ensures that the return struct is populated (it is nil otherwise)
-func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
+func (s *Session) WebhookExecute(webhookID Snowflake, token string, wait bool, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
 	return s.webhookExecute(webhookID, token, wait, "", data, options...)
 }
 
@@ -2380,7 +2380,7 @@ func (s *Session) WebhookExecute(webhookID, token string, wait bool, data *Webho
 // token    : The auth token for the webhook
 // wait     : Waits for server confirmation of message send and ensures that the return struct is populated (it is nil otherwise)
 // threadID :	Sends a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.
-func (s *Session) WebhookThreadExecute(webhookID, token string, wait bool, threadID string, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
+func (s *Session) WebhookThreadExecute(webhookID Snowflake, token string, wait bool, threadID Snowflake, data *WebhookParams, options ...RequestOption) (st *Message, err error) {
 	return s.webhookExecute(webhookID, token, wait, threadID, data, options...)
 }
 
@@ -2388,7 +2388,7 @@ func (s *Session) WebhookThreadExecute(webhookID, token string, wait bool, threa
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
 // messageID : The ID of message to get
-func (s *Session) WebhookMessage(webhookID, token, messageID string, options ...RequestOption) (message *Message, err error) {
+func (s *Session) WebhookMessage(webhookID Snowflake, token string, messageID Snowflake, options ...RequestOption) (message *Message, err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
 	body, err := s.RequestWithBucketID("GET", uri, nil, EndpointWebhookToken("", ""), options...)
@@ -2405,7 +2405,7 @@ func (s *Session) WebhookMessage(webhookID, token, messageID string, options ...
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
 // messageID : The ID of message to edit
-func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *WebhookEdit, options ...RequestOption) (st *Message, err error) {
+func (s *Session) WebhookMessageEdit(webhookID Snowflake, token string, messageID Snowflake, data *WebhookEdit, options ...RequestOption) (st *Message, err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
 	var response []byte
@@ -2435,7 +2435,7 @@ func (s *Session) WebhookMessageEdit(webhookID, token, messageID string, data *W
 // webhookID : The ID of a webhook
 // token     : The auth token for the webhook
 // messageID : The ID of a message to edit
-func (s *Session) WebhookMessageDelete(webhookID, token, messageID string, options ...RequestOption) (err error) {
+func (s *Session) WebhookMessageDelete(webhookID Snowflake, token string, messageID Snowflake, options ...RequestOption) (err error) {
 	uri := EndpointWebhookMessage(webhookID, token, messageID)
 
 	_, err = s.RequestWithBucketID("DELETE", uri, nil, EndpointWebhookToken("", ""), options...)
@@ -2446,10 +2446,10 @@ func (s *Session) WebhookMessageDelete(webhookID, token, messageID string, optio
 // channelID : The channel ID.
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier in name:id format (e.g. "hello:1234567654321")
-func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string, options ...RequestOption) error {
+func (s *Session) MessageReactionAdd(channelID, messageID, emojiID Snowflake, options ...RequestOption) error {
 
 	// emoji such as  #⃣ need to have # escaped
-	emojiID = strings.Replace(emojiID, "#", "%23", -1)
+	emojiID = Snowflake(strings.Replace(string(emojiID), "#", "%23", -1))
 	_, err := s.RequestWithBucketID("PUT", EndpointMessageReaction(channelID, messageID, emojiID, "@me"), nil, EndpointMessageReaction(channelID, "", "", ""), options...)
 
 	return err
@@ -2460,10 +2460,10 @@ func (s *Session) MessageReactionAdd(channelID, messageID, emojiID string, optio
 // messageID : The message ID.
 // emojiID   : Either the unicode emoji for the reaction, or a guild emoji identifier.
 // userID	 : @me or ID of the user to delete the reaction for.
-func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID string, options ...RequestOption) error {
+func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID Snowflake, options ...RequestOption) error {
 
 	// emoji such as  #⃣ need to have # escaped
-	emojiID = strings.Replace(emojiID, "#", "%23", -1)
+	emojiID = Snowflake(strings.Replace(string(emojiID), "#", "%23", -1))
 	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReaction(channelID, messageID, emojiID, userID), nil, EndpointMessageReaction(channelID, "", "", ""), options...)
 
 	return err
@@ -2472,7 +2472,7 @@ func (s *Session) MessageReactionRemove(channelID, messageID, emojiID, userID st
 // MessageReactionsRemoveAll deletes all reactions from a message
 // channelID : The channel ID
 // messageID : The message ID.
-func (s *Session) MessageReactionsRemoveAll(channelID, messageID string, options ...RequestOption) error {
+func (s *Session) MessageReactionsRemoveAll(channelID, messageID Snowflake, options ...RequestOption) error {
 
 	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactionsAll(channelID, messageID), nil, EndpointMessageReactionsAll(channelID, messageID), options...)
 
@@ -2483,10 +2483,10 @@ func (s *Session) MessageReactionsRemoveAll(channelID, messageID string, options
 // channelID : The channel ID
 // messageID : The message ID
 // emojiID   : The emoji ID
-func (s *Session) MessageReactionsRemoveEmoji(channelID, messageID, emojiID string, options ...RequestOption) error {
+func (s *Session) MessageReactionsRemoveEmoji(channelID, messageID, emojiID Snowflake, options ...RequestOption) error {
 
 	// emoji such as  #⃣ need to have # escaped
-	emojiID = strings.Replace(emojiID, "#", "%23", -1)
+	emojiID = Snowflake(strings.Replace(string(emojiID), "#", "%23", -1))
 	_, err := s.RequestWithBucketID("DELETE", EndpointMessageReactions(channelID, messageID, emojiID), nil, EndpointMessageReactions(channelID, messageID, emojiID), options...)
 
 	return err
@@ -2499,9 +2499,9 @@ func (s *Session) MessageReactionsRemoveEmoji(channelID, messageID, emojiID stri
 // limit    : max number of users to return (max 100)
 // beforeID  : If provided all reactions returned will be before given ID.
 // afterID   : If provided all reactions returned will be after given ID.
-func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit int, beforeID, afterID string, options ...RequestOption) (st []*User, err error) {
+func (s *Session) MessageReactions(channelID, messageID, emojiID Snowflake, limit int, beforeID, afterID Snowflake, options ...RequestOption) (st []*User, err error) {
 	// emoji such as  #⃣ need to have # escaped
-	emojiID = strings.Replace(emojiID, "#", "%23", -1)
+	emojiID = Snowflake(strings.Replace(string(emojiID), "#", "%23", -1))
 	uri := EndpointMessageReactions(channelID, messageID, emojiID)
 
 	v := url.Values{}
@@ -2511,10 +2511,10 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 	}
 
 	if afterID != "" {
-		v.Set("after", afterID)
+		v.Set("after", string(afterID))
 	}
 	if beforeID != "" {
-		v.Set("before", beforeID)
+		v.Set("before", string(beforeID))
 	}
 
 	if len(v) > 0 {
@@ -2538,7 +2538,7 @@ func (s *Session) MessageReactions(channelID, messageID, emojiID string, limit i
 // channelID : Channel to create thread in
 // messageID : Message to start thread from
 // data : Parameters of the thread
-func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *ThreadStart, options ...RequestOption) (ch *Channel, err error) {
+func (s *Session) MessageThreadStartComplex(channelID, messageID Snowflake, data *ThreadStart, options ...RequestOption) (ch *Channel, err error) {
 	endpoint := EndpointChannelMessageThread(channelID, messageID)
 	var body []byte
 	body, err = s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
@@ -2555,7 +2555,7 @@ func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *T
 // messageID       : Message to start thread from
 // name            : Name of the thread
 // archiveDuration : Auto archive duration (in minutes)
-func (s *Session) MessageThreadStart(channelID, messageID string, name string, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
+func (s *Session) MessageThreadStart(channelID, messageID Snowflake, name string, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
 	return s.MessageThreadStartComplex(channelID, messageID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
@@ -2565,7 +2565,7 @@ func (s *Session) MessageThreadStart(channelID, messageID string, name string, a
 // ThreadStartComplex creates a new thread.
 // channelID : Channel to create thread in
 // data : Parameters of the thread
-func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart, options ...RequestOption) (ch *Channel, err error) {
+func (s *Session) ThreadStartComplex(channelID Snowflake, data *ThreadStart, options ...RequestOption) (ch *Channel, err error) {
 	endpoint := EndpointChannelThreads(channelID)
 	var body []byte
 	body, err = s.RequestWithBucketID("POST", endpoint, data, endpoint, options...)
@@ -2581,7 +2581,7 @@ func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart, option
 // channelID       : Channel to create thread in
 // name            : Name of the thread
 // archiveDuration : Auto archive duration (in minutes)
-func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
+func (s *Session) ThreadStart(channelID Snowflake, name string, typ ChannelType, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
 	return s.ThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		Type:                typ,
@@ -2593,7 +2593,7 @@ func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDu
 // channelID   : Channel to create thread in.
 // threadData  : Parameters of the thread.
 // messageData : Parameters of the starting message.
-func (s *Session) ForumThreadStartComplex(channelID string, threadData *ThreadStart, messageData *MessageSend, options ...RequestOption) (th *Channel, err error) {
+func (s *Session) ForumThreadStartComplex(channelID Snowflake, threadData *ThreadStart, messageData *MessageSend, options ...RequestOption) (th *Channel, err error) {
 	endpoint := EndpointChannelThreads(channelID)
 
 	// TODO: Remove this when compatibility is not required.
@@ -2652,7 +2652,7 @@ func (s *Session) ForumThreadStartComplex(channelID string, threadData *ThreadSt
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // content         : Content of the starting message.
-func (s *Session) ForumThreadStart(channelID, name string, archiveDuration int, content string, options ...RequestOption) (th *Channel, err error) {
+func (s *Session) ForumThreadStart(channelID Snowflake, name string, archiveDuration int, content string, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
@@ -2664,7 +2664,7 @@ func (s *Session) ForumThreadStart(channelID, name string, archiveDuration int, 
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // embed           : Embed data of the starting message.
-func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration int, embed *MessageEmbed, options ...RequestOption) (th *Channel, err error) {
+func (s *Session) ForumThreadStartEmbed(channelID Snowflake, name string, archiveDuration int, embed *MessageEmbed, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
@@ -2676,7 +2676,7 @@ func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration 
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // embeds          : Embeds data of the starting message.
-func (s *Session) ForumThreadStartEmbeds(channelID, name string, archiveDuration int, embeds []*MessageEmbed, options ...RequestOption) (th *Channel, err error) {
+func (s *Session) ForumThreadStartEmbeds(channelID Snowflake, name string, archiveDuration int, embeds []*MessageEmbed, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
@@ -2684,28 +2684,28 @@ func (s *Session) ForumThreadStartEmbeds(channelID, name string, archiveDuration
 }
 
 // ThreadJoin adds current user to a thread
-func (s *Session) ThreadJoin(id string, options ...RequestOption) error {
+func (s *Session) ThreadJoin(id Snowflake, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(id, "@me")
 	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint, options...)
 	return err
 }
 
 // ThreadLeave removes current user to a thread
-func (s *Session) ThreadLeave(id string, options ...RequestOption) error {
+func (s *Session) ThreadLeave(id Snowflake, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(id, "@me")
 	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 	return err
 }
 
 // ThreadMemberAdd adds another member to a thread
-func (s *Session) ThreadMemberAdd(threadID, memberID string, options ...RequestOption) error {
+func (s *Session) ThreadMemberAdd(threadID, memberID Snowflake, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(threadID, memberID)
 	_, err := s.RequestWithBucketID("PUT", endpoint, nil, endpoint, options...)
 	return err
 }
 
 // ThreadMemberRemove removes another member from a thread
-func (s *Session) ThreadMemberRemove(threadID, memberID string, options ...RequestOption) error {
+func (s *Session) ThreadMemberRemove(threadID, memberID Snowflake, options ...RequestOption) error {
 	endpoint := EndpointThreadMember(threadID, memberID)
 	_, err := s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 	return err
@@ -2713,7 +2713,7 @@ func (s *Session) ThreadMemberRemove(threadID, memberID string, options ...Reque
 
 // ThreadMember returns thread member object for the specified member of a thread.
 // withMember : Whether to include a guild member object.
-func (s *Session) ThreadMember(threadID, memberID string, withMember bool, options ...RequestOption) (member *ThreadMember, err error) {
+func (s *Session) ThreadMember(threadID, memberID Snowflake, withMember bool, options ...RequestOption) (member *ThreadMember, err error) {
 	uri := EndpointThreadMember(threadID, memberID)
 
 	queryParams := url.Values{}
@@ -2740,7 +2740,7 @@ func (s *Session) ThreadMember(threadID, memberID string, withMember bool, optio
 // limit      : Max number of thread members to return (1-100). Defaults to 100.
 // afterID    : Get thread members after this user ID.
 // withMember : Whether to include a guild member object for each thread member.
-func (s *Session) ThreadMembers(threadID string, limit int, withMember bool, afterID string, options ...RequestOption) (members []*ThreadMember, err error) {
+func (s *Session) ThreadMembers(threadID Snowflake, limit int, withMember bool, afterID string, options ...RequestOption) (members []*ThreadMember, err error) {
 	uri := EndpointThreadMembers(threadID)
 
 	queryParams := url.Values{}
@@ -2770,7 +2770,7 @@ func (s *Session) ThreadMembers(threadID string, limit int, withMember bool, aft
 }
 
 // ThreadsActive returns all active threads for specified channel.
-func (s *Session) ThreadsActive(channelID string, options ...RequestOption) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsActive(channelID Snowflake, options ...RequestOption) (threads *ThreadsList, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("GET", EndpointChannelActiveThreads(channelID), nil, EndpointChannelActiveThreads(channelID), options...)
 	if err != nil {
@@ -2782,7 +2782,7 @@ func (s *Session) ThreadsActive(channelID string, options ...RequestOption) (thr
 }
 
 // GuildThreadsActive returns all active threads for specified guild.
-func (s *Session) GuildThreadsActive(guildID string, options ...RequestOption) (threads *ThreadsList, err error) {
+func (s *Session) GuildThreadsActive(guildID Snowflake, options ...RequestOption) (threads *ThreadsList, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("GET", EndpointGuildActiveThreads(guildID), nil, EndpointGuildActiveThreads(guildID), options...)
 	if err != nil {
@@ -2796,7 +2796,7 @@ func (s *Session) GuildThreadsActive(guildID string, options ...RequestOption) (
 // ThreadsArchived returns archived threads for specified channel.
 // before : If specified returns only threads before the timestamp
 // limit  : Optional maximum amount of threads to return.
-func (s *Session) ThreadsArchived(channelID string, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsArchived(channelID Snowflake, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
 	endpoint := EndpointChannelPublicArchivedThreads(channelID)
 	v := url.Values{}
 	if before != nil {
@@ -2824,7 +2824,7 @@ func (s *Session) ThreadsArchived(channelID string, before *time.Time, limit int
 // ThreadsPrivateArchived returns archived private threads for specified channel.
 // before : If specified returns only threads before the timestamp
 // limit  : Optional maximum amount of threads to return.
-func (s *Session) ThreadsPrivateArchived(channelID string, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsPrivateArchived(channelID Snowflake, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
 	endpoint := EndpointChannelPrivateArchivedThreads(channelID)
 	v := url.Values{}
 	if before != nil {
@@ -2851,7 +2851,7 @@ func (s *Session) ThreadsPrivateArchived(channelID string, before *time.Time, li
 // ThreadsPrivateJoinedArchived returns archived joined private threads for specified channel.
 // before : If specified returns only threads before the timestamp
 // limit  : Optional maximum amount of threads to return.
-func (s *Session) ThreadsPrivateJoinedArchived(channelID string, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
+func (s *Session) ThreadsPrivateJoinedArchived(channelID Snowflake, before *time.Time, limit int, options ...RequestOption) (threads *ThreadsList, err error) {
 	endpoint := EndpointChannelJoinedPrivateArchivedThreads(channelID)
 	v := url.Values{}
 	if before != nil {
@@ -2883,7 +2883,7 @@ func (s *Session) ThreadsPrivateJoinedArchived(channelID string, before *time.Ti
 // appID       : The application ID.
 // guildID     : Guild ID to create guild-specific application command. If empty - creates global application command.
 // cmd         : New application command data.
-func (s *Session) ApplicationCommandCreate(appID string, guildID string, cmd *ApplicationCommand, options ...RequestOption) (ccmd *ApplicationCommand, err error) {
+func (s *Session) ApplicationCommandCreate(appID, guildID Snowflake, cmd *ApplicationCommand, options ...RequestOption) (ccmd *ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommands(appID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommands(appID, guildID)
@@ -2904,7 +2904,7 @@ func (s *Session) ApplicationCommandCreate(appID string, guildID string, cmd *Ap
 // cmdID       : Application command ID to edit.
 // guildID     : Guild ID to edit guild-specific application command. If empty - edits global application command.
 // cmd         : Updated application command data.
-func (s *Session) ApplicationCommandEdit(appID, guildID, cmdID string, cmd *ApplicationCommand, options ...RequestOption) (updated *ApplicationCommand, err error) {
+func (s *Session) ApplicationCommandEdit(appID, guildID, cmdID Snowflake, cmd *ApplicationCommand, options ...RequestOption) (updated *ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommand(appID, cmdID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommand(appID, guildID, cmdID)
@@ -2923,7 +2923,7 @@ func (s *Session) ApplicationCommandEdit(appID, guildID, cmdID string, cmd *Appl
 // ApplicationCommandBulkOverwrite Creates commands overwriting existing commands. Returns a list of commands.
 // appID    : The application ID.
 // commands : The commands to create.
-func (s *Session) ApplicationCommandBulkOverwrite(appID string, guildID string, commands []*ApplicationCommand, options ...RequestOption) (createdCommands []*ApplicationCommand, err error) {
+func (s *Session) ApplicationCommandBulkOverwrite(appID, guildID Snowflake, commands []*ApplicationCommand, options ...RequestOption) (createdCommands []*ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommands(appID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommands(appID, guildID)
@@ -2943,7 +2943,7 @@ func (s *Session) ApplicationCommandBulkOverwrite(appID string, guildID string, 
 // appID       : The application ID.
 // cmdID       : Application command ID to delete.
 // guildID     : Guild ID to delete guild-specific application command. If empty - deletes global application command.
-func (s *Session) ApplicationCommandDelete(appID, guildID, cmdID string, options ...RequestOption) error {
+func (s *Session) ApplicationCommandDelete(appID, guildID, cmdID Snowflake, options ...RequestOption) error {
 	endpoint := EndpointApplicationGlobalCommand(appID, cmdID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommand(appID, guildID, cmdID)
@@ -2958,7 +2958,7 @@ func (s *Session) ApplicationCommandDelete(appID, guildID, cmdID string, options
 // appID       : The application ID.
 // cmdID       : Application command ID.
 // guildID     : Guild ID to retrieve guild-specific application command. If empty - retrieves global application command.
-func (s *Session) ApplicationCommand(appID, guildID, cmdID string, options ...RequestOption) (cmd *ApplicationCommand, err error) {
+func (s *Session) ApplicationCommand(appID, guildID, cmdID Snowflake, options ...RequestOption) (cmd *ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommand(appID, cmdID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommand(appID, guildID, cmdID)
@@ -2977,7 +2977,7 @@ func (s *Session) ApplicationCommand(appID, guildID, cmdID string, options ...Re
 // ApplicationCommands retrieves all commands in application.
 // appID       : The application ID.
 // guildID     : Guild ID to retrieve all guild-specific application commands. If empty - retrieves global application commands.
-func (s *Session) ApplicationCommands(appID, guildID string, options ...RequestOption) (cmd []*ApplicationCommand, err error) {
+func (s *Session) ApplicationCommands(appID, guildID Snowflake, options ...RequestOption) (cmd []*ApplicationCommand, err error) {
 	endpoint := EndpointApplicationGlobalCommands(appID)
 	if guildID != "" {
 		endpoint = EndpointApplicationGuildCommands(appID, guildID)
@@ -2996,7 +2996,7 @@ func (s *Session) ApplicationCommands(appID, guildID string, options ...RequestO
 // GuildApplicationCommandsPermissions returns permissions for application commands in a guild.
 // appID       : The application ID
 // guildID     : Guild ID to retrieve application commands permissions for.
-func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string, options ...RequestOption) (permissions []*GuildApplicationCommandPermissions, err error) {
+func (s *Session) GuildApplicationCommandsPermissions(appID, guildID Snowflake, options ...RequestOption) (permissions []*GuildApplicationCommandPermissions, err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
 	var body []byte
@@ -3013,7 +3013,7 @@ func (s *Session) GuildApplicationCommandsPermissions(appID, guildID string, opt
 // appID       : The Application ID
 // guildID     : The guild ID containing the application command
 // cmdID       : The command ID to retrieve the permissions of
-func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string, options ...RequestOption) (permissions *GuildApplicationCommandPermissions, err error) {
+func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID Snowflake, options ...RequestOption) (permissions *GuildApplicationCommandPermissions, err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	var body []byte
@@ -3033,7 +3033,7 @@ func (s *Session) ApplicationCommandPermissions(appID, guildID, cmdID string, op
 // permissions : An object containing a list of permissions for the application command
 //
 // NOTE: Requires OAuth2 token with applications.commands.permissions.update scope
-func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string, permissions *ApplicationCommandPermissionsList, options ...RequestOption) (err error) {
+func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID Snowflake, permissions *ApplicationCommandPermissionsList, options ...RequestOption) (err error) {
 	endpoint := EndpointApplicationCommandPermissions(appID, guildID, cmdID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint, options...)
@@ -3046,7 +3046,7 @@ func (s *Session) ApplicationCommandPermissionsEdit(appID, guildID, cmdID string
 // permissions : A list of permissions paired with a command ID, guild ID, and application ID per application command
 //
 // NOTE: This endpoint has been disabled with updates to command permissions (Permissions v2). Please use ApplicationCommandPermissionsEdit instead.
-func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID string, permissions []*GuildApplicationCommandPermissions, options ...RequestOption) (err error) {
+func (s *Session) ApplicationCommandPermissionsBatchEdit(appID, guildID Snowflake, permissions []*GuildApplicationCommandPermissions, options ...RequestOption) (err error) {
 	endpoint := EndpointApplicationCommandsGuildPermissions(appID, guildID)
 
 	_, err = s.RequestWithBucketID("PUT", endpoint, permissions, endpoint, options...)
@@ -3108,14 +3108,14 @@ func (s *Session) FollowupMessageCreate(interaction *Interaction, wait bool, dat
 // interaction : Interaction instance.
 // messageID   : The followup message ID.
 // data        : Data to update the message
-func (s *Session) FollowupMessageEdit(interaction *Interaction, messageID string, data *WebhookEdit, options ...RequestOption) (*Message, error) {
+func (s *Session) FollowupMessageEdit(interaction *Interaction, messageID Snowflake, data *WebhookEdit, options ...RequestOption) (*Message, error) {
 	return s.WebhookMessageEdit(interaction.AppID, interaction.Token, messageID, data, options...)
 }
 
 // FollowupMessageDelete deletes a followup message of an interaction.
 // interaction : Interaction instance.
 // messageID   : The followup message ID.
-func (s *Session) FollowupMessageDelete(interaction *Interaction, messageID string, options ...RequestOption) error {
+func (s *Session) FollowupMessageDelete(interaction *Interaction, messageID Snowflake, options ...RequestOption) error {
 	return s.WebhookMessageDelete(interaction.AppID, interaction.Token, messageID, options...)
 }
 
@@ -3138,7 +3138,7 @@ func (s *Session) StageInstanceCreate(data *StageInstanceParams, options ...Requ
 
 // StageInstance will retrieve a Stage instance by ID of the Stage channel.
 // channelID : The ID of the Stage channel
-func (s *Session) StageInstance(channelID string, options ...RequestOption) (si *StageInstance, err error) {
+func (s *Session) StageInstance(channelID Snowflake, options ...RequestOption) (si *StageInstance, err error) {
 	body, err := s.RequestWithBucketID("GET", EndpointStageInstance(channelID), nil, EndpointStageInstance(channelID), options...)
 	if err != nil {
 		return
@@ -3151,7 +3151,7 @@ func (s *Session) StageInstance(channelID string, options ...RequestOption) (si 
 // StageInstanceEdit will edit a Stage instance by ID of the Stage channel.
 // channelID : The ID of the Stage channel
 // data : The data to edit the Stage instance
-func (s *Session) StageInstanceEdit(channelID string, data *StageInstanceParams, options ...RequestOption) (si *StageInstance, err error) {
+func (s *Session) StageInstanceEdit(channelID Snowflake, data *StageInstanceParams, options ...RequestOption) (si *StageInstance, err error) {
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointStageInstance(channelID), data, EndpointStageInstance(channelID), options...)
 	if err != nil {
@@ -3164,7 +3164,7 @@ func (s *Session) StageInstanceEdit(channelID string, data *StageInstanceParams,
 
 // StageInstanceDelete will delete a Stage instance by ID of the Stage channel.
 // channelID : The ID of the Stage channel
-func (s *Session) StageInstanceDelete(channelID string, options ...RequestOption) (err error) {
+func (s *Session) StageInstanceDelete(channelID Snowflake, options ...RequestOption) (err error) {
 	_, err = s.RequestWithBucketID("DELETE", EndpointStageInstance(channelID), nil, EndpointStageInstance(channelID), options...)
 	return
 }
@@ -3176,7 +3176,7 @@ func (s *Session) StageInstanceDelete(channelID string, options ...RequestOption
 // GuildScheduledEvents returns an array of GuildScheduledEvent for a guild
 // guildID        : The ID of a Guild
 // userCount      : Whether to include the user count in the response
-func (s *Session) GuildScheduledEvents(guildID string, userCount bool, options ...RequestOption) (st []*GuildScheduledEvent, err error) {
+func (s *Session) GuildScheduledEvents(guildID Snowflake, userCount bool, options ...RequestOption) (st []*GuildScheduledEvent, err error) {
 	uri := EndpointGuildScheduledEvents(guildID)
 	if userCount {
 		uri += "?with_user_count=true"
@@ -3195,7 +3195,7 @@ func (s *Session) GuildScheduledEvents(guildID string, userCount bool, options .
 // guildID        : The ID of a Guild
 // eventID        : The ID of the event
 // userCount      : Whether to include the user count in the response
-func (s *Session) GuildScheduledEvent(guildID, eventID string, userCount bool, options ...RequestOption) (st *GuildScheduledEvent, err error) {
+func (s *Session) GuildScheduledEvent(guildID, eventID Snowflake, userCount bool, options ...RequestOption) (st *GuildScheduledEvent, err error) {
 	uri := EndpointGuildScheduledEvent(guildID, eventID)
 	if userCount {
 		uri += "?with_user_count=true"
@@ -3213,7 +3213,7 @@ func (s *Session) GuildScheduledEvent(guildID, eventID string, userCount bool, o
 // GuildScheduledEventCreate creates a GuildScheduledEvent for a guild and returns it
 // guildID   : The ID of a Guild
 // eventID   : The ID of the event
-func (s *Session) GuildScheduledEventCreate(guildID string, event *GuildScheduledEventParams, options ...RequestOption) (st *GuildScheduledEvent, err error) {
+func (s *Session) GuildScheduledEventCreate(guildID Snowflake, event *GuildScheduledEventParams, options ...RequestOption) (st *GuildScheduledEvent, err error) {
 	body, err := s.RequestWithBucketID("POST", EndpointGuildScheduledEvents(guildID), event, EndpointGuildScheduledEvents(guildID), options...)
 	if err != nil {
 		return
@@ -3226,7 +3226,7 @@ func (s *Session) GuildScheduledEventCreate(guildID string, event *GuildSchedule
 // GuildScheduledEventEdit updates a specific event for a guild and returns it.
 // guildID   : The ID of a Guild
 // eventID   : The ID of the event
-func (s *Session) GuildScheduledEventEdit(guildID, eventID string, event *GuildScheduledEventParams, options ...RequestOption) (st *GuildScheduledEvent, err error) {
+func (s *Session) GuildScheduledEventEdit(guildID, eventID Snowflake, event *GuildScheduledEventParams, options ...RequestOption) (st *GuildScheduledEvent, err error) {
 	body, err := s.RequestWithBucketID("PATCH", EndpointGuildScheduledEvent(guildID, eventID), event, EndpointGuildScheduledEvent(guildID, eventID), options...)
 	if err != nil {
 		return
@@ -3239,7 +3239,7 @@ func (s *Session) GuildScheduledEventEdit(guildID, eventID string, event *GuildS
 // GuildScheduledEventDelete deletes a specific GuildScheduledEvent in a guild
 // guildID   : The ID of a Guild
 // eventID   : The ID of the event
-func (s *Session) GuildScheduledEventDelete(guildID, eventID string, options ...RequestOption) (err error) {
+func (s *Session) GuildScheduledEventDelete(guildID, eventID Snowflake, options ...RequestOption) (err error) {
 	_, err = s.RequestWithBucketID("DELETE", EndpointGuildScheduledEvent(guildID, eventID), nil, EndpointGuildScheduledEvent(guildID, eventID), options...)
 	return
 }
@@ -3251,7 +3251,7 @@ func (s *Session) GuildScheduledEventDelete(guildID, eventID string, options ...
 // withMember : Whether to include the member object in the response
 // beforeID   : If is not empty all returned users entries will be before the given ID
 // afterID    : If is not empty all returned users entries will be after the given ID
-func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, withMember bool, beforeID, afterID string, options ...RequestOption) (st []*GuildScheduledEventUser, err error) {
+func (s *Session) GuildScheduledEventUsers(guildID, eventID Snowflake, limit int, withMember bool, beforeID, afterID string, options ...RequestOption) (st []*GuildScheduledEventUser, err error) {
 	uri := EndpointGuildScheduledEventUsers(guildID, eventID)
 
 	queryParams := url.Values{}
@@ -3283,7 +3283,7 @@ func (s *Session) GuildScheduledEventUsers(guildID, eventID string, limit int, w
 
 // GuildOnboarding returns onboarding configuration of a guild.
 // guildID   : The ID of the guild
-func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
+func (s *Session) GuildOnboarding(guildID Snowflake, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
 	endpoint := EndpointGuildOnboarding(guildID)
 
 	var body []byte
@@ -3299,7 +3299,7 @@ func (s *Session) GuildOnboarding(guildID string, options ...RequestOption) (onb
 // GuildOnboardingEdit edits onboarding configuration of a guild.
 // guildID   : The ID of the guild
 // o         : New GuildOnboarding data
-func (s *Session) GuildOnboardingEdit(guildID string, o *GuildOnboarding, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
+func (s *Session) GuildOnboardingEdit(guildID Snowflake, o *GuildOnboarding, options ...RequestOption) (onboarding *GuildOnboarding, err error) {
 	endpoint := EndpointGuildOnboarding(guildID)
 
 	var body []byte
@@ -3318,7 +3318,7 @@ func (s *Session) GuildOnboardingEdit(guildID string, o *GuildOnboarding, option
 
 // AutoModerationRules returns a list of auto moderation rules.
 // guildID : ID of the guild
-func (s *Session) AutoModerationRules(guildID string, options ...RequestOption) (st []*AutoModerationRule, err error) {
+func (s *Session) AutoModerationRules(guildID Snowflake, options ...RequestOption) (st []*AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRules(guildID)
 
 	var body []byte
@@ -3334,7 +3334,7 @@ func (s *Session) AutoModerationRules(guildID string, options ...RequestOption) 
 // AutoModerationRule returns an auto moderation rule.
 // guildID : ID of the guild
 // ruleID  : ID of the auto moderation rule
-func (s *Session) AutoModerationRule(guildID, ruleID string, options ...RequestOption) (st *AutoModerationRule, err error) {
+func (s *Session) AutoModerationRule(guildID, ruleID Snowflake, options ...RequestOption) (st *AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRule(guildID, ruleID)
 
 	var body []byte
@@ -3350,7 +3350,7 @@ func (s *Session) AutoModerationRule(guildID, ruleID string, options ...RequestO
 // AutoModerationRuleCreate creates an auto moderation rule with the given data and returns it.
 // guildID : ID of the guild
 // rule    : Rule data
-func (s *Session) AutoModerationRuleCreate(guildID string, rule *AutoModerationRule, options ...RequestOption) (st *AutoModerationRule, err error) {
+func (s *Session) AutoModerationRuleCreate(guildID Snowflake, rule *AutoModerationRule, options ...RequestOption) (st *AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRules(guildID)
 
 	var body []byte
@@ -3367,7 +3367,7 @@ func (s *Session) AutoModerationRuleCreate(guildID string, rule *AutoModerationR
 // guildID : ID of the guild
 // ruleID  : ID of the auto moderation rule
 // rule    : New rule data
-func (s *Session) AutoModerationRuleEdit(guildID, ruleID string, rule *AutoModerationRule, options ...RequestOption) (st *AutoModerationRule, err error) {
+func (s *Session) AutoModerationRuleEdit(guildID, ruleID Snowflake, rule *AutoModerationRule, options ...RequestOption) (st *AutoModerationRule, err error) {
 	endpoint := EndpointGuildAutoModerationRule(guildID, ruleID)
 
 	var body []byte
@@ -3383,7 +3383,7 @@ func (s *Session) AutoModerationRuleEdit(guildID, ruleID string, rule *AutoModer
 // AutoModerationRuleDelete deletes an auto moderation rule.
 // guildID : ID of the guild
 // ruleID  : ID of the auto moderation rule
-func (s *Session) AutoModerationRuleDelete(guildID, ruleID string, options ...RequestOption) (err error) {
+func (s *Session) AutoModerationRuleDelete(guildID, ruleID Snowflake, options ...RequestOption) (err error) {
 	endpoint := EndpointGuildAutoModerationRule(guildID, ruleID)
 	_, err = s.RequestWithBucketID("DELETE", endpoint, nil, endpoint, options...)
 	return
@@ -3391,7 +3391,7 @@ func (s *Session) AutoModerationRuleDelete(guildID, ruleID string, options ...Re
 
 // ApplicationRoleConnectionMetadata returns application role connection metadata.
 // appID : ID of the application
-func (s *Session) ApplicationRoleConnectionMetadata(appID string) (st []*ApplicationRoleConnectionMetadata, err error) {
+func (s *Session) ApplicationRoleConnectionMetadata(appID Snowflake) (st []*ApplicationRoleConnectionMetadata, err error) {
 	endpoint := EndpointApplicationRoleConnectionMetadata(appID)
 	var body []byte
 	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
@@ -3406,7 +3406,7 @@ func (s *Session) ApplicationRoleConnectionMetadata(appID string) (st []*Applica
 // ApplicationRoleConnectionMetadataUpdate updates and returns application role connection metadata.
 // appID    : ID of the application
 // metadata : New metadata
-func (s *Session) ApplicationRoleConnectionMetadataUpdate(appID string, metadata []*ApplicationRoleConnectionMetadata) (st []*ApplicationRoleConnectionMetadata, err error) {
+func (s *Session) ApplicationRoleConnectionMetadataUpdate(appID Snowflake, metadata []*ApplicationRoleConnectionMetadata) (st []*ApplicationRoleConnectionMetadata, err error) {
 	endpoint := EndpointApplicationRoleConnectionMetadata(appID)
 	var body []byte
 	body, err = s.RequestWithBucketID("PUT", endpoint, metadata, endpoint)
@@ -3420,7 +3420,7 @@ func (s *Session) ApplicationRoleConnectionMetadataUpdate(appID string, metadata
 
 // UserApplicationRoleConnection returns user role connection to the specified application.
 // appID : ID of the application
-func (s *Session) UserApplicationRoleConnection(appID string) (st *ApplicationRoleConnection, err error) {
+func (s *Session) UserApplicationRoleConnection(appID Snowflake) (st *ApplicationRoleConnection, err error) {
 	endpoint := EndpointUserApplicationRoleConnection(appID)
 	var body []byte
 	body, err = s.RequestWithBucketID("GET", endpoint, nil, endpoint)
@@ -3436,7 +3436,7 @@ func (s *Session) UserApplicationRoleConnection(appID string) (st *ApplicationRo
 // UserApplicationRoleConnectionUpdate updates and returns user role connection to the specified application.
 // appID      : ID of the application
 // connection : New ApplicationRoleConnection data
-func (s *Session) UserApplicationRoleConnectionUpdate(appID string, rconn *ApplicationRoleConnection) (st *ApplicationRoleConnection, err error) {
+func (s *Session) UserApplicationRoleConnectionUpdate(appID Snowflake, rconn *ApplicationRoleConnection) (st *ApplicationRoleConnection, err error) {
 	endpoint := EndpointUserApplicationRoleConnection(appID)
 	var body []byte
 	body, err = s.RequestWithBucketID("PUT", endpoint, rconn, endpoint)

--- a/state.go
+++ b/state.go
@@ -48,9 +48,9 @@ type State struct {
 	TrackVoice         bool
 	TrackPresences     bool
 
-	guildMap   map[string]*Guild
-	channelMap map[string]*Channel
-	memberMap  map[string]map[string]*Member
+	guildMap   map[Snowflake]*Guild
+	channelMap map[Snowflake]*Channel
+	memberMap  map[Snowflake]map[Snowflake]*Member
 }
 
 // NewState creates an empty state.
@@ -68,14 +68,14 @@ func NewState() *State {
 		TrackRoles:         true,
 		TrackVoice:         true,
 		TrackPresences:     true,
-		guildMap:           make(map[string]*Guild),
-		channelMap:         make(map[string]*Channel),
-		memberMap:          make(map[string]map[string]*Member),
+		guildMap:           make(map[Snowflake]*Guild),
+		channelMap:         make(map[Snowflake]*Channel),
+		memberMap:          make(map[Snowflake]map[Snowflake]*Member),
 	}
 }
 
 func (s *State) createMemberMap(guild *Guild) {
-	members := make(map[string]*Member)
+	members := make(map[Snowflake]*Member)
 	for _, m := range guild.Members {
 		members[m.User.ID] = m
 	}
@@ -107,7 +107,7 @@ func (s *State) GuildAdd(guild *Guild) error {
 		s.createMemberMap(guild)
 	} else if _, ok := s.memberMap[guild.ID]; !ok {
 		// Even if we have no new member slice, we still initialize the member map for this guild if it doesn't exist
-		s.memberMap[guild.ID] = make(map[string]*Member)
+		s.memberMap[guild.ID] = make(map[Snowflake]*Member)
 	}
 
 	if g, ok := s.guildMap[guild.ID]; ok {
@@ -175,9 +175,10 @@ func (s *State) GuildRemove(guild *Guild) error {
 
 // Guild gets a guild by ID.
 // Useful for querying if @me is in a guild:
-//     _, err := discordgo.Session.State.Guild(guildID)
-//     isInGuild := err == nil
-func (s *State) Guild(guildID string) (*Guild, error) {
+//
+//	_, err := discordgo.Session.State.Guild(guildID)
+//	isInGuild := err == nil
+func (s *State) Guild(guildID Snowflake) (*Guild, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -192,7 +193,7 @@ func (s *State) Guild(guildID string) (*Guild, error) {
 	return nil, ErrStateNotFound
 }
 
-func (s *State) presenceAdd(guildID string, presence *Presence) error {
+func (s *State) presenceAdd(guildID Snowflake, presence *Presence) error {
 	guild, ok := s.guildMap[guildID]
 	if !ok {
 		return ErrStateNotFound
@@ -247,7 +248,7 @@ func (s *State) presenceAdd(guildID string, presence *Presence) error {
 
 // PresenceAdd adds a presence to the current world state, or
 // updates it if it already exists.
-func (s *State) PresenceAdd(guildID string, presence *Presence) error {
+func (s *State) PresenceAdd(guildID Snowflake, presence *Presence) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -259,7 +260,7 @@ func (s *State) PresenceAdd(guildID string, presence *Presence) error {
 }
 
 // PresenceRemove removes a presence from the current world state.
-func (s *State) PresenceRemove(guildID string, presence *Presence) error {
+func (s *State) PresenceRemove(guildID Snowflake, presence *Presence) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -283,7 +284,7 @@ func (s *State) PresenceRemove(guildID string, presence *Presence) error {
 }
 
 // Presence gets a presence by ID from a guild.
-func (s *State) Presence(guildID, userID string) (*Presence, error) {
+func (s *State) Presence(guildID, userID Snowflake) (*Presence, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -379,7 +380,7 @@ func (s *State) MemberRemove(member *Member) error {
 }
 
 // Member gets a member by ID from a guild.
-func (s *State) Member(guildID, userID string) (*Member, error) {
+func (s *State) Member(guildID, userID Snowflake) (*Member, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -402,7 +403,7 @@ func (s *State) Member(guildID, userID string) (*Member, error) {
 
 // RoleAdd adds a role to the current world state, or
 // updates it if it already exists.
-func (s *State) RoleAdd(guildID string, role *Role) error {
+func (s *State) RoleAdd(guildID Snowflake, role *Role) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -427,7 +428,7 @@ func (s *State) RoleAdd(guildID string, role *Role) error {
 }
 
 // RoleRemove removes a role from current world state by ID.
-func (s *State) RoleRemove(guildID, roleID string) error {
+func (s *State) RoleRemove(guildID, roleID Snowflake) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -451,7 +452,7 @@ func (s *State) RoleRemove(guildID, roleID string) error {
 }
 
 // Role gets a role by ID from a guild.
-func (s *State) Role(guildID, roleID string) (*Role, error) {
+func (s *State) Role(guildID, roleID Snowflake) (*Role, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -671,7 +672,7 @@ func (s *State) ThreadMemberUpdate(mu *ThreadMemberUpdate) error {
 }
 
 // Channel gets a channel by ID, it will look in all guilds and private channels.
-func (s *State) Channel(channelID string) (*Channel, error) {
+func (s *State) Channel(channelID Snowflake) (*Channel, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -687,7 +688,7 @@ func (s *State) Channel(channelID string) (*Channel, error) {
 }
 
 // Emoji returns an emoji for a guild and emoji id.
-func (s *State) Emoji(guildID, emojiID string) (*Emoji, error) {
+func (s *State) Emoji(guildID, emojiID Snowflake) (*Emoji, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -710,7 +711,7 @@ func (s *State) Emoji(guildID, emojiID string) (*Emoji, error) {
 }
 
 // EmojiAdd adds an emoji to the current world state.
-func (s *State) EmojiAdd(guildID string, emoji *Emoji) error {
+func (s *State) EmojiAdd(guildID Snowflake, emoji *Emoji) error {
 	if s == nil {
 		return ErrNilState
 	}
@@ -735,7 +736,7 @@ func (s *State) EmojiAdd(guildID string, emoji *Emoji) error {
 }
 
 // EmojisAdd adds multiple emojis to the world state.
-func (s *State) EmojisAdd(guildID string, emojis []*Emoji) error {
+func (s *State) EmojisAdd(guildID Snowflake, emojis []*Emoji) error {
 	for _, e := range emojis {
 		if err := s.EmojiAdd(guildID, e); err != nil {
 			return err
@@ -811,7 +812,7 @@ func (s *State) MessageRemove(message *Message) error {
 }
 
 // messageRemoveByID removes a message by channelID and messageID from the world state.
-func (s *State) messageRemoveByID(channelID, messageID string) error {
+func (s *State) messageRemoveByID(channelID, messageID Snowflake) error {
 	c, err := s.Channel(channelID)
 	if err != nil {
 		return err
@@ -863,7 +864,7 @@ func (s *State) voiceStateUpdate(update *VoiceStateUpdate) error {
 }
 
 // VoiceState gets a VoiceState by guild and user ID.
-func (s *State) VoiceState(guildID, userID string) (*VoiceState, error) {
+func (s *State) VoiceState(guildID, userID Snowflake) (*VoiceState, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -883,7 +884,7 @@ func (s *State) VoiceState(guildID, userID string) (*VoiceState, error) {
 }
 
 // Message gets a message by channel and message ID.
-func (s *State) Message(channelID, messageID string) (*Message, error) {
+func (s *State) Message(channelID, messageID Snowflake) (*Message, error) {
 	if s == nil {
 		return nil, ErrNilState
 	}
@@ -1068,7 +1069,8 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	case *ThreadUpdate:
 		if s.TrackThreads {
-			old, err := s.Channel(t.ID)
+			var old *Channel
+			old, err = s.Channel(t.ID)
 			if err == nil {
 				oldCopy := *old
 				t.BeforeUpdate = &oldCopy
@@ -1169,7 +1171,7 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 // UserChannelPermissions returns the permission of a user in a channel.
 // userID    : The ID of the user to calculate permissions for.
 // channelID : The ID of the channel to calculate permission for.
-func (s *State) UserChannelPermissions(userID, channelID string) (apermissions int64, err error) {
+func (s *State) UserChannelPermissions(userID, channelID Snowflake) (apermissions int64, err error) {
 	if s == nil {
 		return 0, ErrNilState
 	}
@@ -1221,7 +1223,7 @@ func (s *State) MessagePermissions(message *Message) (apermissions int64, err er
 // 0 is returned in cases of error, which is the color of @everyone.
 // userID    : The ID of the user to calculate the color for.
 // channelID   : The ID of the channel to calculate the color for.
-func (s *State) UserColor(userID, channelID string) int {
+func (s *State) UserColor(userID, channelID Snowflake) int {
 	if s == nil {
 		return 0
 	}
@@ -1268,7 +1270,7 @@ func (s *State) MessageColor(message *Message) int {
 	return firstRoleColorColor(guild, message.Member.Roles)
 }
 
-func firstRoleColorColor(guild *Guild, memberRoles []string) int {
+func firstRoleColorColor(guild *Guild, memberRoles []Snowflake) int {
 	roles := Roles(guild.Roles)
 	sort.Sort(roles)
 

--- a/user.go
+++ b/user.go
@@ -1,6 +1,7 @@
 package discordgo
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -43,7 +44,7 @@ const (
 // A User stores all data for an individual Discord user.
 type User struct {
 	// The ID of the user.
-	ID string `json:"id"`
+	ID Snowflake `json:"id"`
 
 	// The email of the user. This is only present when
 	// the application possesses the email scope for the user.
@@ -116,7 +117,7 @@ func (u *User) String() string {
 
 // Mention return a string which mentions the user
 func (u *User) Mention() string {
-	return "<@" + u.ID + ">"
+	return fmt.Sprintf("<@%s>", u.ID)
 }
 
 // AvatarURL returns a URL to the user's avatar.
@@ -145,7 +146,7 @@ func (u *User) BannerURL(size string) string {
 // DefaultAvatarIndex returns the index of the user's default avatar.
 func (u *User) DefaultAvatarIndex() int {
 	if u.Discriminator == "0" {
-		id, _ := strconv.ParseUint(u.ID, 10, 64)
+		id, _ := strconv.ParseUint(string(u.ID), 10, 64)
 		return int((id >> 22) % 6)
 	}
 

--- a/voice.go
+++ b/voice.go
@@ -34,9 +34,9 @@ type VoiceConnection struct {
 	Debug        bool // If true, print extra logging -- DEPRECATED
 	LogLevel     int
 	Ready        bool // If true, voice is ready to send/receive audio
-	UserID       string
-	GuildID      string
-	ChannelID    string
+	UserID       Snowflake
+	GuildID      Snowflake
+	ChannelID    Snowflake
 	deaf         bool
 	mute         bool
 	speaking     bool
@@ -115,7 +115,7 @@ func (v *VoiceConnection) Speaking(b bool) (err error) {
 
 // ChangeChannel sends Discord a request to change channels within a Guild
 // !!! NOTE !!! This function may be removed in favour of just using ChannelVoiceJoin
-func (v *VoiceConnection) ChangeChannel(channelID string, mute, deaf bool) (err error) {
+func (v *VoiceConnection) ChangeChannel(channelID Snowflake, mute, deaf bool) (err error) {
 
 	v.log(LogInformational, "called")
 
@@ -316,10 +316,10 @@ func (v *VoiceConnection) open() (err error) {
 	}
 
 	type voiceHandshakeData struct {
-		ServerID  string `json:"server_id"`
-		UserID    string `json:"user_id"`
-		SessionID string `json:"session_id"`
-		Token     string `json:"token"`
+		ServerID  Snowflake `json:"server_id"`
+		UserID    Snowflake `json:"user_id"`
+		SessionID string    `json:"session_id"`
+		Token     string    `json:"token"`
 	}
 	type voiceHandshakeOp struct {
 		Op   int                `json:"op"` // Always 0
@@ -501,8 +501,6 @@ func (v *VoiceConnection) onEvent(message []byte) {
 	default:
 		v.log(LogDebug, "unknown voice operation, %d, %s", e.Operation, string(e.RawData))
 	}
-
-	return
 }
 
 type voiceHeartbeatOp struct {
@@ -920,7 +918,7 @@ func (v *VoiceConnection) reconnect() {
 			wait = 600
 		}
 
-		if v.session.DataReady == false || v.session.wsConn == nil {
+		if !v.session.DataReady || v.session.wsConn == nil {
 			v.log(LogInformational, "cannot reconnect to channel %s with unready session", v.ChannelID)
 			continue
 		}

--- a/webhook.go
+++ b/webhook.go
@@ -2,17 +2,17 @@ package discordgo
 
 // Webhook stores the data for a webhook.
 type Webhook struct {
-	ID        string      `json:"id"`
+	ID        Snowflake   `json:"id"`
 	Type      WebhookType `json:"type"`
-	GuildID   string      `json:"guild_id"`
-	ChannelID string      `json:"channel_id"`
+	GuildID   Snowflake   `json:"guild_id"`
+	ChannelID Snowflake   `json:"channel_id"`
 	User      *User       `json:"user"`
 	Name      string      `json:"name"`
 	Avatar    string      `json:"avatar"`
 	Token     string      `json:"token"`
 
 	// ApplicationID is the bot/OAuth2 application that created this webhook
-	ApplicationID string `json:"application_id,omitempty"`
+	ApplicationID Snowflake `json:"application_id,omitempty"`
 }
 
 // WebhookType is the type of Webhook (see WebhookType* consts) in the Webhook struct

--- a/wsapi.go
+++ b/wsapi.go
@@ -189,7 +189,7 @@ func (s *Session) Open() error {
 	// XXX: can this be moved to when opening a voice connection?
 	if s.VoiceConnections == nil {
 		s.log(LogInformational, "creating new VoiceConnections map")
-		s.VoiceConnections = make(map[string]*VoiceConnection)
+		s.VoiceConnections = make(map[Snowflake]*VoiceConnection)
 	}
 
 	// Create listening chan outside of listen, as it needs to happen inside the
@@ -669,10 +669,10 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 // ------------------------------------------------------------------------------------------------
 
 type voiceChannelJoinData struct {
-	GuildID   *string `json:"guild_id"`
-	ChannelID *string `json:"channel_id"`
-	SelfMute  bool    `json:"self_mute"`
-	SelfDeaf  bool    `json:"self_deaf"`
+	GuildID   *Snowflake `json:"guild_id"`
+	ChannelID *Snowflake `json:"channel_id"`
+	SelfMute  bool       `json:"self_mute"`
+	SelfDeaf  bool       `json:"self_deaf"`
 }
 
 type voiceChannelJoinOp struct {
@@ -682,16 +682,16 @@ type voiceChannelJoinOp struct {
 
 // ChannelVoiceJoin joins the session user to a voice channel.
 //
-//    gID     : Guild ID of the channel to join.
-//    cID     : Channel ID of the channel to join.
-//    mute    : If true, you will be set to muted upon joining.
-//    deaf    : If true, you will be set to deafened upon joining.
-func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *VoiceConnection, err error) {
+//	gID     : Guild ID of the channel to join.
+//	cID     : Channel ID of the channel to join.
+//	mute    : If true, you will be set to muted upon joining.
+//	deaf    : If true, you will be set to deafened upon joining.
+func (s *Session) ChannelVoiceJoin(gID, cID Snowflake, mute, deaf bool) (voice *VoiceConnection, err error) {
 
 	s.log(LogInformational, "called")
 
 	s.RLock()
-	voice, _ = s.VoiceConnections[gID]
+	voice = s.VoiceConnections[gID]
 	s.RUnlock()
 
 	if voice == nil {
@@ -729,15 +729,15 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 //
 // This should only be used when the VoiceServerUpdate will be intercepted and used elsewhere.
 //
-//    gID     : Guild ID of the channel to join.
-//    cID     : Channel ID of the channel to join, leave empty to disconnect.
-//    mute    : If true, you will be set to muted upon joining.
-//    deaf    : If true, you will be set to deafened upon joining.
-func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err error) {
+//	gID     : Guild ID of the channel to join.
+//	cID     : Channel ID of the channel to join, leave empty to disconnect.
+//	mute    : If true, you will be set to muted upon joining.
+//	deaf    : If true, you will be set to deafened upon joining.
+func (s *Session) ChannelVoiceJoinManual(gID, cID Snowflake, mute, deaf bool) (err error) {
 
 	s.log(LogInformational, "called")
 
-	var channelID *string
+	var channelID *Snowflake
 	if cID == "" {
 		channelID = nil
 	} else {
@@ -828,7 +828,7 @@ func (s *Session) identify() error {
 
 	// TODO: This is a temporary block of code to help
 	// maintain backwards compatibility
-	if s.Compress == false {
+	if !s.Compress {
 		s.Identify.Compress = false
 	}
 


### PR DESCRIPTION
Fixes #1394 

Change all fields which are of type `snowflake` in the Discord API to this new type.

The Snowflake type will unmarshal all string values (some special identifiers, such as `@me` are used), and any valid uint64.

NOTE: Examples are currently broken by this change, but will be fixed after discussion about the core change.