### PR TITLE
fix(message)!: omit empty Components and Embeds

### DIFF
--- a/message.go
+++ b/message.go
@@ -233,7 +233,7 @@ type MessageSend struct {
 	Content         string                  `json:"content,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds"`
 	TTS             bool                    `json:"tts"`
-	Components      []MessageComponent      `json:"components"`
+	Components      []*MessageComponent     `json:"components"`
 	Files           []*File                 `json:"-"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Reference       *MessageReference       `json:"message_reference,omitempty"`
@@ -251,8 +251,8 @@ type MessageSend struct {
 // is also where you should get the instance from.
 type MessageEdit struct {
 	Content         *string                 `json:"content,omitempty"`
-	Components      []MessageComponent      `json:"components"`
-	Embeds          []*MessageEmbed         `json:"embeds"`
+	Components      []*MessageComponent     `json:"components,omitempty"`
+	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Flags           MessageFlags            `json:"flags,omitempty"`
 	// Files to append to the message

--- a/message.go
+++ b/message.go
@@ -251,7 +251,7 @@ type MessageSend struct {
 // is also where you should get the instance from.
 type MessageEdit struct {
 	Content         *string                 `json:"content,omitempty"`
-	Components      []*MessageComponent     `json:"components,omitempty"`
+	Components      *[]MessageComponent     `json:"components,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Flags           MessageFlags            `json:"flags,omitempty"`

--- a/message.go
+++ b/message.go
@@ -233,7 +233,7 @@ type MessageSend struct {
 	Content         string                  `json:"content,omitempty"`
 	Embeds          []*MessageEmbed         `json:"embeds"`
 	TTS             bool                    `json:"tts"`
-	Components      []*MessageComponent     `json:"components"`
+	Components      []MessageComponent      `json:"components"`
 	Files           []*File                 `json:"-"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Reference       *MessageReference       `json:"message_reference,omitempty"`
@@ -252,7 +252,7 @@ type MessageSend struct {
 type MessageEdit struct {
 	Content         *string                 `json:"content,omitempty"`
 	Components      *[]MessageComponent     `json:"components,omitempty"`
-	Embeds          *[]*MessageEmbed         `json:"embeds,omitempty"`
+	Embeds          *[]*MessageEmbed        `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Flags           MessageFlags            `json:"flags,omitempty"`
 	// Files to append to the message
@@ -286,14 +286,14 @@ func (m *MessageEdit) SetContent(str string) *MessageEdit {
 // SetEmbed is a convenience function for setting the embed,
 // so you can chain commands.
 func (m *MessageEdit) SetEmbed(embed *MessageEmbed) *MessageEdit {
-	m.Embeds = []*MessageEmbed{embed}
+	m.Embeds = &[]*MessageEmbed{embed}
 	return m
 }
 
 // SetEmbeds is a convenience function for setting the embeds,
 // so you can chain commands.
 func (m *MessageEdit) SetEmbeds(embeds []*MessageEmbed) *MessageEdit {
-	m.Embeds = embeds
+	m.Embeds = &embeds
 	return m
 }
 

--- a/message.go
+++ b/message.go
@@ -252,7 +252,7 @@ type MessageSend struct {
 type MessageEdit struct {
 	Content         *string                 `json:"content,omitempty"`
 	Components      *[]MessageComponent     `json:"components,omitempty"`
-	Embeds          []*MessageEmbed         `json:"embeds,omitempty"`
+	Embeds          *[]*MessageEmbed         `json:"embeds,omitempty"`
 	AllowedMentions *MessageAllowedMentions `json:"allowed_mentions,omitempty"`
 	Flags           MessageFlags            `json:"flags,omitempty"`
 	// Files to append to the message

--- a/restapi.go
+++ b/restapi.go
@@ -1803,13 +1803,13 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit, options ...RequestOp
 			return
 		}
 	}
-
-	for _, embed := range *m.Embeds {
-		if embed.Type == "" {
-			embed.Type = "rich"
+	if m.Embeds != nil {
+		for _, embed := range *m.Embeds {
+			if embed.Type == "" {
+				embed.Type = "rich"
+			}
 		}
 	}
-
 	endpoint := EndpointChannelMessage(m.Channel, m.ID)
 
 	var response []byte

--- a/restapi.go
+++ b/restapi.go
@@ -1803,6 +1803,7 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit, options ...RequestOp
 			return
 		}
 	}
+
 	if m.Embeds != nil {
 		for _, embed := range *m.Embeds {
 			if embed.Type == "" {
@@ -1810,6 +1811,7 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit, options ...RequestOp
 			}
 		}
 	}
+
 	endpoint := EndpointChannelMessage(m.Channel, m.ID)
 
 	var response []byte

--- a/restapi.go
+++ b/restapi.go
@@ -1797,14 +1797,14 @@ func (s *Session) ChannelMessageEditComplex(m *MessageEdit, options ...RequestOp
 	// TODO: Remove this when compatibility is not required.
 	if m.Embed != nil {
 		if m.Embeds == nil {
-			m.Embeds = []*MessageEmbed{m.Embed}
+			m.Embeds = &[]*MessageEmbed{m.Embed}
 		} else {
 			err = fmt.Errorf("cannot specify both Embed and Embeds")
 			return
 		}
 	}
 
-	for _, embed := range m.Embeds {
+	for _, embed := range *m.Embeds {
 		if embed.Type == "" {
 			embed.Type = "rich"
 		}


### PR DESCRIPTION
A while ago there was a small discussion on this topic in discord [down from this message](https://discord.com/channels/118456055842734083/155361364909621248/1172388479964028959)
Implemented as was described(at least I think that's what was meant about converting slices to slices of pointers), here's a recording of it working
![DiscordPTB_2024-01-12_22-32-58](https://github.com/bwmarrin/discordgo/assets/45398541/8a522d3e-f421-4720-8c5a-8f883c3f4c43)
Snippet with example of code that's used for suppression.
```go
func MessageUpdate(s *discordgo.Session, m *discordgo.MessageUpdate) {
	if len(m.Embeds) > 0 {
		messageEdit := discordgo.NewMessageEdit(m.ChannelID, m.ID)
		messageEdit.Flags = discordgo.MessageFlagsSuppressEmbeds
		s.ChannelMessageEditComplex(messageEdit)
		s.ChannelMessageSend(m.ChannelID, "Suppressed embed")
	}
}
```