### PR TITLE
feat(message)!: use partial sticker objects

### DIFF
--- a/message.go
+++ b/message.go
@@ -149,7 +149,7 @@ type Message struct {
 	Thread *Channel `json:"thread,omitempty"`
 
 	// An array of Sticker objects, if any were sent.
-	StickerItems []*Sticker `json:"sticker_items"`
+	StickerItems []*StickerItem `json:"sticker_items"`
 }
 
 // UnmarshalJSON is a helper function to unmarshal the Message.

--- a/structs.go
+++ b/structs.go
@@ -656,6 +656,13 @@ type Sticker struct {
 	SortValue   int           `json:"sort_value"`
 }
 
+// StickerItem represents the smallest amount of data required to render a sticker. A partial sticker object.
+type StickerItem struct {
+	ID         string        `json:"id"`
+	Name       string        `json:"name"`
+	FormatType StickerFormat `json:"format_type"`
+}
+
 // StickerPack represents a pack of standard stickers.
 type StickerPack struct {
 	ID             string     `json:"id"`


### PR DESCRIPTION
https://discord.com/developers/docs/resources/channel#message-object
https://discord.com/developers/docs/resources/sticker#sticker-item-object

There exists a property called `stickers` that contain the full sticker information but that is deprecated and not part of the struct here.