### PR TITLE
feat(locales): add Spanish LATAM

### DIFF
--- a/locales.go
+++ b/locales.go
@@ -39,6 +39,7 @@ const (
 	Romanian     Locale = "ro"
 	Russian      Locale = "ru"
 	SpanishES    Locale = "es-ES"
+	SpanishLATAM Locale = "es-419"
 	Swedish      Locale = "sv-SE"
 	Thai         Locale = "th"
 	Turkish      Locale = "tr"
@@ -74,6 +75,7 @@ var Locales = map[Locale]string{
 	Romanian:     "Romanian",
 	Russian:      "Russian",
 	SpanishES:    "Spanish (Spain)",
+	SpanishLATAM: "Spanish (LATAM)",
 	Swedish:      "Swedish",
 	Thai:         "Thai",
 	Turkish:      "Turkish",


### PR DESCRIPTION
Add "Spanish LATAM" to supported locales.
https://github.com/discord/discord-api-docs/pull/6577
