### PR TITLE
feat(UserGuilds): support with_counts parameter

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -424,10 +424,11 @@ func (s *Session) UserGuildMember(guildID string, options ...RequestOption) (st 
 }
 
 // UserGuilds returns an array of UserGuild structures for all guilds.
-// limit     : The number guilds that can be returned. (max 100)
-// beforeID  : If provided all guilds returned will be before given ID.
-// afterID   : If provided all guilds returned will be after given ID.
-func (s *Session) UserGuilds(limit int, beforeID, afterID string, options ...RequestOption) (st []*UserGuild, err error) {
+// limit       : The number guilds that can be returned. (max 200)
+// beforeID    : If provided all guilds returned will be before given ID.
+// afterID     : If provided all guilds returned will be after given ID.
+// withCounts  : Whether to include approximate member and presence counts or not
+func (s *Session) UserGuilds(limit int, beforeID, afterID string, withCounts bool, options ...RequestOption) (st []*UserGuild, err error) {
 
 	v := url.Values{}
 
@@ -439,6 +440,9 @@ func (s *Session) UserGuilds(limit int, beforeID, afterID string, options ...Req
 	}
 	if beforeID != "" {
 		v.Set("before", beforeID)
+	}
+	if withCounts {
+		v.Set("with_counts", "true")
 	}
 
 	uri := EndpointUserGuilds("@me")

--- a/restapi.go
+++ b/restapi.go
@@ -427,7 +427,7 @@ func (s *Session) UserGuildMember(guildID string, options ...RequestOption) (st 
 // limit       : The number guilds that can be returned. (max 200)
 // beforeID    : If provided all guilds returned will be before given ID.
 // afterID     : If provided all guilds returned will be after given ID.
-// withCounts  : Whether to include approximate member and presence counts or not
+// withCounts  : Whether to include approximate member and presence counts or not.
 func (s *Session) UserGuilds(limit int, beforeID, afterID string, withCounts bool, options ...RequestOption) (st []*UserGuild, err error) {
 
 	v := url.Values{}

--- a/restapi_test.go
+++ b/restapi_test.go
@@ -106,7 +106,7 @@ func TestUserGuilds(t *testing.T) {
 		t.Skip("Cannot TestUserGuilds, dg not set.")
 	}
 
-	_, err := dg.UserGuilds(10, "", "")
+	_, err := dg.UserGuilds(10, "", "", false)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/structs.go
+++ b/structs.go
@@ -1274,7 +1274,13 @@ type UserGuild struct {
 	Owner                    bool           `json:"owner"`
 	Permissions              int64          `json:"permissions,string"`
 	Features                 []GuildFeature `json:"features"`
+
+	// Approximate number of members in this guild
+	// NOTE: this field is only filled when withCounts is true
 	ApproximateMemberCount   int            `json:"approximate_member_count"`
+
+	// Approximate number of members in this guild
+	// NOTE: this field is only filled when withCounts is true
 	ApproximatePresenceCount int            `json:"approximate_presence_count"`
 }
 

--- a/structs.go
+++ b/structs.go
@@ -1268,20 +1268,20 @@ func (g *Guild) BannerURL(size string) string {
 
 // A UserGuild holds a brief version of a Guild
 type UserGuild struct {
-	ID                       string         `json:"id"`
-	Name                     string         `json:"name"`
-	Icon                     string         `json:"icon"`
-	Owner                    bool           `json:"owner"`
-	Permissions              int64          `json:"permissions,string"`
-	Features                 []GuildFeature `json:"features"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Icon        string         `json:"icon"`
+	Owner       bool           `json:"owner"`
+	Permissions int64          `json:"permissions,string"`
+	Features    []GuildFeature `json:"features"`
 
 	// Approximate number of members in this guild
 	// NOTE: this field is only filled when withCounts is true
-	ApproximateMemberCount   int            `json:"approximate_member_count"`
+	ApproximateMemberCount int `json:"approximate_member_count"`
 
 	// Approximate number of members in this guild
 	// NOTE: this field is only filled when withCounts is true
-	ApproximatePresenceCount int            `json:"approximate_presence_count"`
+	ApproximatePresenceCount int `json:"approximate_presence_count"`
 }
 
 // GuildFeature indicates the presence of a feature in a guild

--- a/structs.go
+++ b/structs.go
@@ -1275,12 +1275,12 @@ type UserGuild struct {
 	Permissions int64          `json:"permissions,string"`
 	Features    []GuildFeature `json:"features"`
 
-	// Approximate number of members in this guild
-	// NOTE: this field is only filled when withCounts is true
+	// Approximate number of members in this guild.
+	// NOTE: this field is only filled when withCounts is true.
 	ApproximateMemberCount int `json:"approximate_member_count"`
 
-	// Approximate number of members in this guild
-	// NOTE: this field is only filled when withCounts is true
+	// Approximate number of members in this guild.
+	// NOTE: this field is only filled when withCounts is true.
 	ApproximatePresenceCount int `json:"approximate_presence_count"`
 }
 

--- a/structs.go
+++ b/structs.go
@@ -1279,7 +1279,7 @@ type UserGuild struct {
 	// NOTE: this field is only filled when withCounts is true.
 	ApproximateMemberCount int `json:"approximate_member_count"`
 
-	// Approximate number of members in this guild.
+	// Approximate number of non-offline members in this guild.
 	// NOTE: this field is only filled when withCounts is true.
 	ApproximatePresenceCount int `json:"approximate_presence_count"`
 }

--- a/structs.go
+++ b/structs.go
@@ -1268,12 +1268,14 @@ func (g *Guild) BannerURL(size string) string {
 
 // A UserGuild holds a brief version of a Guild
 type UserGuild struct {
-	ID          string         `json:"id"`
-	Name        string         `json:"name"`
-	Icon        string         `json:"icon"`
-	Owner       bool           `json:"owner"`
-	Permissions int64          `json:"permissions,string"`
-	Features    []GuildFeature `json:"features"`
+	ID                       string         `json:"id"`
+	Name                     string         `json:"name"`
+	Icon                     string         `json:"icon"`
+	Owner                    bool           `json:"owner"`
+	Permissions              int64          `json:"permissions,string"`
+	Features                 []GuildFeature `json:"features"`
+	ApproximateMemberCount   int            `json:"approximate_member_count"`
+	ApproximatePresenceCount int            `json:"approximate_presence_count"`
 }
 
 // GuildFeature indicates the presence of a feature in a guild


### PR DESCRIPTION
This PR adds support for the `with_count` query parameter on the `UserGuilds()` function. 

Additionally, the `limit` of returned guilds has been increased from 100 to 200.

Reference: https://discord.com/developers/docs/resources/user#get-current-user-guilds