### PR TITLE
feat(Session.UserUpdate)!: add banner support

### DIFF
--- a/examples/avatar/main.go
+++ b/examples/avatar/main.go
@@ -82,7 +82,7 @@ func main() {
 	// Now lets format our base64 image into the proper format Discord wants
 	// and then call UserUpdate to set it as our user's Avatar.
 	avatar := fmt.Sprintf("data:%s;base64,%s", contentType, base64img)
-	_, err = dg.UserUpdate("", avatar)
+	_, err = dg.UserUpdate("", avatar, "")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -358,7 +358,7 @@ func (s *Session) UserAvatarDecode(u *User, options ...RequestOption) (img image
 }
 
 // UserUpdate updates current user settings.
-func (s *Session) UserUpdate(username, avatar string, options ...RequestOption) (st *User, err error) {
+func (s *Session) UserUpdate(username, avatar, banner string, options ...RequestOption) (st *User, err error) {
 
 	// NOTE: Avatar must be either the hash/id of existing Avatar or
 	// data:image/png;base64,BASE64_STRING_OF_NEW_AVATAR_PNG
@@ -368,7 +368,8 @@ func (s *Session) UserUpdate(username, avatar string, options ...RequestOption) 
 	data := struct {
 		Username string `json:"username,omitempty"`
 		Avatar   string `json:"avatar,omitempty"`
-	}{username, avatar}
+		Banner   string `json:"banner,omitempty"`
+	}{username, avatar, banner}
 
 	body, err := s.RequestWithBucketID("PATCH", EndpointUser("@me"), data, EndpointUsers, options...)
 	if err != nil {


### PR DESCRIPTION
Add support for editing bot's banner using `UserUpdate`.

🚧 This PR is built upon an [yet to be documented](<https://github.com/discord/discord-api-docs/pull/6710>) feature 🚧

