### PR TITLE
Add channel types `ChannelTypeGuildDirectory` and `ChannelTypeGuildMedia`

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -288,7 +288,9 @@ const (
 	ChannelTypeGuildPublicThread  ChannelType = 11
 	ChannelTypeGuildPrivateThread ChannelType = 12
 	ChannelTypeGuildStageVoice    ChannelType = 13
+	ChannelTypeGuildDirectory     ChannelType = 14
 	ChannelTypeGuildForum         ChannelType = 15
+	ChannelTypeGuildMedia         ChannelType = 16
 )
 
 // ChannelFlags represent flags of a channel/thread.


### PR DESCRIPTION
Support the channel types 14 (GUILD_DIRECTORY) and 16 (GUILD_MEDIA)

Reference: https://discord.com/developers/docs/resources/channel#channel-object-channel-types