### PR TITLE
Updating documentation to reflect the deprecation of Session.UserAvatar

### DIFF
--- a/user.go
+++ b/user.go
@@ -52,8 +52,8 @@ type User struct {
 	// The user's username.
 	Username string `json:"username"`
 
-	// The hash of the user's avatar. Use Session.UserAvatar
-	// to retrieve the avatar itself.
+	// The hash of the user's avatar. Use Session.UserAvatarDecode
+	// to retrieve the avatar itself (Session.UserAvatar is deprecated).
 	Avatar string `json:"avatar"`
 
 	// The user's chosen language option.


### PR DESCRIPTION
I found that the description for the 'Avatar' field in user.go tells you to use Session.UserAvatar to grab the actual avatar, but the corresponding doc for Session.UserAvatar notes that it's deprecated, so I thought I would make that change in user.go as well to make sure people aren't calling a deprecated function. 