### PR TITLE
Update golang.org/x/crypto to v0.22.0 and Minimum Go Version to 1.18 to Address Security Vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Check diff between gofmt and code
         run: diff <(gofmt -d .) <(echo -n)
-  
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.13, 1.14, 1.15, 1.16, 1.17, 1.18]
+        go-version: [1.18, 1.19, 1.20, 1.21, 1.22]
     steps:
       - name: Install Go
         uses: actions/setup-go@v3
@@ -30,7 +30,7 @@ jobs:
       - name: Code
         uses: actions/checkout@v3
       - run: go test -v -race ./...
-  
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -50,11 +50,10 @@ jobs:
           only-new-issues: true
           skip-pkg-cache: true
           skip-build-cache: true
-      
+
       - name: GolangCI-Lint
         if: github.event.name != 'pull_request' # See https://github.com/golangci/golangci-lint-action/issues/362
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
 
           $(go env GOPATH)/bin/golangci-lint run
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,12 +7,12 @@ linters:
 
 linters-settings:
   staticcheck:
-    go: "1.13"
+    go: "1.18"
 
     checks: ["all"]
 
   unused:
-    go: "1.13"
+    go: "1.18"
 
 issues:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: go
 go:
-    - 1.13.x
-    - 1.14.x
-    - 1.15.x
-    - 1.16.x
-    - 1.17.x
     - 1.18.x
+    - 1.19.x
+    - 1.20.x
+    - 1.21.x
+    - 1.22.x
 env:
     - GO111MODULE=on
 install:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/bwmarrin/discordgo
 
-go 1.13
+go 1.18
 
 require (
 	github.com/gorilla/websocket v1.4.2
-	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
+	golang.org/x/crypto v0.22.0
 )
+
+require golang.org/x/sys v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
-golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
+golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
This pull request updates the golang.org/x/crypto package to version 0.22.0 and raises the minimum Go version to 1.18. These changes address several high and moderate severity security vulnerabilities, specifically CVE-2021-43565, CVE-2022-27191, CVE-2023-48795, and CVE-2022-29526, which were present in the previously used version of the crypto package. 

This update ensures that the DiscordGo library remains secure and up-to-date with the latest security patches and features. 

The Go version in CI workflows has also been updated to support versions from 1.18 through 1.22, in line with the community's commitment to maintaining compatibility with current Go releases.

To properly address all vulnerabilities listed, the minimum version of go should be >= 1.18.2.

CVE's covered:
- CVE-2021-43565
   - Severity: `HIGH`
   - Package: golang.org/x/crypto from 0.0.0-20210421170649-83a5a9bb288b
   - Advisory: https://github.com/advisories/GHSA-gwc9-m7rh-j2ww
- CVE-2022-27191
   - Severity: `HIGH`
   - Package: golang.org/x/crypto from 0.0.0-20210421170649-83a5a9bb288b
   - Advisory: https://github.com/advisories/GHSA-8c26-wmh5-6g9v
- CVE-2023-48795 
   - Severity: `Moderate` 
   - Package:  golang.org/x/crypto from 0.0.0-20210421170649-83a5a9bb288b 
   - Advisory: https://github.com/advisories/GHSA-45x7-px36-x8w8
- CVE-2022-29526
   - Severity: `Moderate` 
   - Package:  go < 1.18.2 via golang.org/x/sys/unix
   - Advisory: https://github.com/advisories/GHSA-p782-xgp4-8hr8

Validation Steps Taken:
- `go mod tidy`
- `diff <(gofmt -d .) <(echo -n)`
- `go vet -x ./...`
- `golint -set_exit_status ./...`
- `go test -v -race ./...`

Resolves PR: https://github.com/bwmarrin/discordgo/pull/1341 