### PR TITLE
Implemented MESSAGE_REACTION_REMOVE_EMOJI event type

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -49,6 +49,7 @@ const (
 	messagePollVoteRemoveEventType               = "MESSAGE_POLL_VOTE_REMOVE"
 	messageReactionAddEventType                  = "MESSAGE_REACTION_ADD"
 	messageReactionRemoveEventType               = "MESSAGE_REACTION_REMOVE"
+	messageReactionRemoveEmojiEventType          = "MESSAGE_REACTION_REMOVE_EMOJI"
 	messageReactionRemoveAllEventType            = "MESSAGE_REACTION_REMOVE_ALL"
 	messageUpdateEventType                       = "MESSAGE_UPDATE"
 	presenceUpdateEventType                      = "PRESENCE_UPDATE"
@@ -897,6 +898,26 @@ func (eh messageReactionRemoveEventHandler) Handle(s *Session, i interface{}) {
 	}
 }
 
+// messageReactionRemoveEmojiEventHandler is an event handler for MessageReactionRemoveAll events.
+type messageReactionRemoveEmojiEventHandler func(*Session, *MessageReactionRemoveEmoji)
+
+// Type returns the event type for MessageReactionRemoveEmoji events.
+func (eh messageReactionRemoveEmojiEventHandler) Type() string {
+	return messageReactionRemoveEmojiEventType
+}
+
+// New returns a new instance of MessageReactionRemoveEmoji.
+func (eh messageReactionRemoveEmojiEventHandler) New() interface{} {
+	return &MessageReactionRemoveEmoji{}
+}
+
+// Handle is the handler for MessageReactionRemoveEmoji events.
+func (eh messageReactionRemoveEmojiEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*MessageReactionRemoveEmoji); ok {
+		eh(s, t)
+	}
+}
+
 // messageReactionRemoveAllEventHandler is an event handler for MessageReactionRemoveAll events.
 type messageReactionRemoveAllEventHandler func(*Session, *MessageReactionRemoveAll)
 
@@ -1400,6 +1421,8 @@ func handlerForInterface(handler interface{}) EventHandler {
 		return messageReactionAddEventHandler(v)
 	case func(*Session, *MessageReactionRemove):
 		return messageReactionRemoveEventHandler(v)
+	case func(*Session, *MessageReactionRemoveEmoji):
+		return messageReactionRemoveEmojiEventHandler(v)
 	case func(*Session, *MessageReactionRemoveAll):
 		return messageReactionRemoveAllEventHandler(v)
 	case func(*Session, *MessageUpdate):
@@ -1487,6 +1510,7 @@ func init() {
 	registerInterfaceProvider(messagePollVoteRemoveEventHandler(nil))
 	registerInterfaceProvider(messageReactionAddEventHandler(nil))
 	registerInterfaceProvider(messageReactionRemoveEventHandler(nil))
+	registerInterfaceProvider(messageReactionRemoveEmojiEventHandler(nil))
 	registerInterfaceProvider(messageReactionRemoveAllEventHandler(nil))
 	registerInterfaceProvider(messageUpdateEventHandler(nil))
 	registerInterfaceProvider(presenceUpdateEventHandler(nil))

--- a/events.go
+++ b/events.go
@@ -274,15 +274,38 @@ func (m *MessageDelete) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &m.Message)
 }
 
+type MessageReactionType int
+
+const (
+	MessageReactionTypeNormal MessageReactionType = 0
+	MessageReactionTypeBurst  MessageReactionType = 1
+)
+
 // MessageReactionAdd is the data for a MessageReactionAdd event.
 type MessageReactionAdd struct {
 	*MessageReaction
-	Member *Member `json:"member,omitempty"`
+	UserID          string              `json:"user_id"`
+	Member          *Member             `json:"member,omitempty"`
+	Emoji           Emoji               `json:"emoji"`
+	MessageAuthorID string              `json:"message_author_id,omitempty"`
+	Burst           bool                `json:"burst"`
+	BurstColors     []string            `json:"burst_colors,omitempty"`
+	Type            MessageReactionType `json:"type"`
 }
 
 // MessageReactionRemove is the data for a MessageReactionRemove event.
 type MessageReactionRemove struct {
 	*MessageReaction
+	UserID string              `json:"user_id"`
+	Emoji  Emoji               `json:"emoji"`
+	Burst  bool                `json:"burst"`
+	Type   MessageReactionType `json:"type"`
+}
+
+// MessageReactionRemoveEmoji is the data for a MessageReactionRemoveEmoji event.
+type MessageReactionRemoveEmoji struct {
+	*MessageReaction
+	Emoji Emoji `json:"emoji"`
 }
 
 // MessageReactionRemoveAll is the data for a MessageReactionRemoveAll event.

--- a/structs.go
+++ b/structs.go
@@ -2153,11 +2153,9 @@ type APIErrorMessage struct {
 	Message string `json:"message"`
 }
 
-// MessageReaction stores the data for a message reaction.
+// MessageReaction stores partial data for a message reaction.
 type MessageReaction struct {
-	UserID    string `json:"user_id"`
 	MessageID string `json:"message_id"`
-	Emoji     Emoji  `json:"emoji"`
 	ChannelID string `json:"channel_id"`
 	GuildID   string `json:"guild_id,omitempty"`
 }


### PR DESCRIPTION
This PR also refactors the `MessageReaction*` structs to more closely resemble those in [Discord's own documentation](https://discord.com/developers/docs/topics/gateway-events#message-reaction-add). This could potentially be a breaking change for some people.

This will close #1542.
In my limited testing, I couldn't find any issues. Let me know if anything else is needed.