### PR TITLE
feat(User): Add Spammer flag found in User PublicFlags

### DIFF
--- a/user.go
+++ b/user.go
@@ -25,6 +25,7 @@ const (
 	UserFlagVerifiedBotDeveloper      UserFlags = 1 << 17
 	UserFlagDiscordCertifiedModerator UserFlags = 1 << 18
 	UserFlagBotHTTPInteractions       UserFlags = 1 << 19
+	UserFlagSpammer                   UserFlags = 1 << 20
 	UserFlagActiveBotDeveloper        UserFlags = 1 << 22
 )
 


### PR DESCRIPTION
This adds a UserFlagSpammer found in User PublicFlags. I've tested this against one guild and it matches output from discord.py's UserFlags https://github.com/Rapptz/discord.py/blob/ff638d393d0f5a83639ccc087bec9bf588b59a22/discord/enums.py#L516