### PR TITLE
Add message reaction remove emoji event

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -53,6 +53,7 @@ const (
 	messageReactionAddEventType                  = "MESSAGE_REACTION_ADD"
 	messageReactionRemoveEventType               = "MESSAGE_REACTION_REMOVE"
 	messageReactionRemoveAllEventType            = "MESSAGE_REACTION_REMOVE_ALL"
+	messageReactionRemoveEmojiEventType          = "MESSAGE_REACTION_REMOVE_EMOJI"
 	messageUpdateEventType                       = "MESSAGE_UPDATE"
 	presenceUpdateEventType                      = "PRESENCE_UPDATE"
 	presencesReplaceEventType                    = "PRESENCES_REPLACE"
@@ -980,6 +981,26 @@ func (eh messageReactionRemoveAllEventHandler) Handle(s *Session, i interface{})
 	}
 }
 
+// messageReactionRemoveEmojiEventHandler is an event handler for MessageReactionRemoveEmoji events.
+type messageReactionRemoveEmojiEventHandler func(*Session, *MessageReactionRemoveEmoji)
+
+// Type returns the event type for MessageReactionRemoveEmoji events.
+func (eh messageReactionRemoveEmojiEventHandler) Type() string {
+	return messageReactionRemoveEmojiEventType
+}
+
+// New returns a new instance of MessageReactionRemoveEmoji.
+func (eh messageReactionRemoveEmojiEventHandler) New() interface{} {
+	return &MessageReactionRemoveEmoji{}
+}
+
+// Handle is the handler for MessageReactionRemoveEmoji events.
+func (eh messageReactionRemoveEmojiEventHandler) Handle(s *Session, i interface{}) {
+	if t, ok := i.(*MessageReactionRemoveEmoji); ok {
+		eh(s, t)
+	}
+}
+
 // messageUpdateEventHandler is an event handler for MessageUpdate events.
 type messageUpdateEventHandler func(*Session, *MessageUpdate)
 
@@ -1471,6 +1492,8 @@ func handlerForInterface(handler interface{}) EventHandler {
 		return messageReactionRemoveEventHandler(v)
 	case func(*Session, *MessageReactionRemoveAll):
 		return messageReactionRemoveAllEventHandler(v)
+	case func(*Session, *MessageReactionRemoveEmoji):
+		return messageReactionRemoveEmojiEventHandler(v)
 	case func(*Session, *MessageUpdate):
 		return messageUpdateEventHandler(v)
 	case func(*Session, *PresenceUpdate):
@@ -1560,6 +1583,7 @@ func init() {
 	registerInterfaceProvider(messageReactionAddEventHandler(nil))
 	registerInterfaceProvider(messageReactionRemoveEventHandler(nil))
 	registerInterfaceProvider(messageReactionRemoveAllEventHandler(nil))
+	registerInterfaceProvider(messageReactionRemoveEmojiEventHandler(nil))
 	registerInterfaceProvider(messageUpdateEventHandler(nil))
 	registerInterfaceProvider(presenceUpdateEventHandler(nil))
 	registerInterfaceProvider(presencesReplaceEventHandler(nil))

--- a/events.go
+++ b/events.go
@@ -309,6 +309,11 @@ type MessageReactionRemoveAll struct {
 	*MessageReaction
 }
 
+// MessageReactionRemoveEmoji is the data for a MessageReactionRemoveEmoji event.
+type MessageReactionRemoveEmoji struct {
+	*MessageReaction
+}
+
 // PresencesReplace is the data for a PresencesReplace event.
 type PresencesReplace []*Presence
 


### PR DESCRIPTION
Add support for gateway event MESSAGE_REACTION_REMOVE_EMOJI see [](https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-emoji)

<img width="920" alt="image" src="https://github.com/user-attachments/assets/75f1a49c-a23c-4680-8854-ab93adfebaa2">
