### PR TITLE
Add additional fields to VoiceRegion struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -256,9 +256,13 @@ type IntegrationAccount struct {
 }
 
 // A VoiceRegion stores data for a specific voice region server.
+// https://discord.com/developers/docs/resources/voice#voice-region-object
 type VoiceRegion struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Optimal    bool   `json:"optimal"`
+	Deprecated bool   `json:"deprecated"`
+	Custom     bool   `json:"custom"`
 }
 
 // InviteTargetType indicates the type of target of an invite


### PR DESCRIPTION
Updates the `VoiceRegion` struct to export all VoiceRegion fields.
https://discord.com/developers/docs/resources/voice#voice-region-object