### PR TITLE
Typo fix

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1918,8 +1918,8 @@ const (
 	AuditLogChangeKeyPrivacylevel AuditLogChangeKey = "privacy_level"
 	// AuditLogChangeKeyPruneDeleteDays is sent when number of days after which inactive and role-unassigned members are kicked changed (int) - guild
 	AuditLogChangeKeyPruneDeleteDays AuditLogChangeKey = "prune_delete_days"
-	// AuditLogChangeKeyPulibUpdatesChannelID is sent when id of the public updates channel changed (snowflake) - guild
-	AuditLogChangeKeyPulibUpdatesChannelID AuditLogChangeKey = "public_updates_channel_id"
+	// AuditLogChangeKeyPublicUpdatesChannelID is sent when id of the public updates channel changed (snowflake) - guild
+	AuditLogChangeKeyPublicUpdatesChannelID AuditLogChangeKey = "public_updates_channel_id"
 	// AuditLogChangeKeyRateLimitPerUser is sent when amount of seconds a user has to wait before sending another message changed (int) - channel
 	AuditLogChangeKeyRateLimitPerUser AuditLogChangeKey = "rate_limit_per_user"
 	// AuditLogChangeKeyRegion is sent when region changed (string) - guild


### PR DESCRIPTION
Hey,

Coding my first _Go_ Discord bot and came across this:

```go
// structs.go, lines 1921 & 1922

// AuditLogChangeKeyPulibUpdatesChannelID is sent when id of the public updates channel changed (snowflake) - guild
AuditLogChangeKeyPulibUpdatesChannelID AuditLogChangeKey = "public_updates_channel_id"
```

Changed `Pulib` to `Public`

That's pretty much it