### PR TITLE
Fix typo in PollResults AnswerCounts json field

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -2369,7 +2369,7 @@ type PollAnswerCount struct {
 // PollResults contains voting results on a poll.
 type PollResults struct {
 	Finalized    bool               `json:"is_finalized"`
-	AnswerCounts []*PollAnswerCount `json:"answer_count"`
+	AnswerCounts []*PollAnswerCount `json:"answer_counts"`
 }
 
 // Poll contains all poll related data.


### PR DESCRIPTION
As documented in https://discord.com/developers/docs/resources/poll#poll-results-object-poll-results-object-structure, answer_count should be answer_counts