### PR TITLE
Add message URL helpers

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -162,6 +162,11 @@ var (
 		return EndpointMessageReactions(cID, mID, eID) + "/" + uID
 	}
 
+	// EndpointMessageURL builds a canonical discord URL in the format https://discord.com/channels/:gID/:cID/:mID
+	EndpointMessageURL = func(gID, cID, mID string) string {
+		return EndpointDiscord + "channels/" + gID + "/" + cID + "/" + mID
+	}
+
 	EndpointPoll = func(cID, mID string) string {
 		return EndpointChannel(cID) + "/polls/" + mID
 	}

--- a/message.go
+++ b/message.go
@@ -595,3 +595,8 @@ type MessageInteractionMetadata struct {
 	// NOTE: present only on modal submit interactions.
 	TriggeringInteractionMetadata *MessageInteractionMetadata `json:"triggering_interaction_metadata,omitempty"`
 }
+
+// URL returns the canonical Discord message URL
+func (m *Message) URL() string {
+	return EndpointMessageURL(m.GuildID, m.ChannelID, m.ID)
+}

--- a/message_test.go
+++ b/message_test.go
@@ -50,3 +50,15 @@ func TestGettingEmojisFromMessage(t *testing.T) {
 	}
 
 }
+
+func TestMessage_URL(t *testing.T) {
+	m := &Message{
+		GuildID:   "foo",
+		ChannelID: "bar",
+		ID:        "baz",
+	}
+
+	if m.URL() != "https://discord.com/channels/foo/bar/baz" {
+		t.Error("Unexpected url: " + m.URL())
+	}
+}


### PR DESCRIPTION
This PR adds a helper func for generating canonical Discord message URLs