### PR TITLE
Add ThreadArchiveDuration enum

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -2632,7 +2632,7 @@ func (s *Session) MessageThreadStartComplex(channelID, messageID string, data *T
 // messageID       : Message to start thread from
 // name            : Name of the thread
 // archiveDuration : Auto archive duration (in minutes)
-func (s *Session) MessageThreadStart(channelID, messageID string, name string, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
+func (s *Session) MessageThreadStart(channelID, messageID string, name string, archiveDuration ThreadArchiveDuration, options ...RequestOption) (ch *Channel, err error) {
 	return s.MessageThreadStartComplex(channelID, messageID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
@@ -2658,7 +2658,7 @@ func (s *Session) ThreadStartComplex(channelID string, data *ThreadStart, option
 // channelID       : Channel to create thread in
 // name            : Name of the thread
 // archiveDuration : Auto archive duration (in minutes)
-func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDuration int, options ...RequestOption) (ch *Channel, err error) {
+func (s *Session) ThreadStart(channelID, name string, typ ChannelType, archiveDuration ThreadArchiveDuration, options ...RequestOption) (ch *Channel, err error) {
 	return s.ThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		Type:                typ,
@@ -2729,7 +2729,7 @@ func (s *Session) ForumThreadStartComplex(channelID string, threadData *ThreadSt
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // content         : Content of the starting message.
-func (s *Session) ForumThreadStart(channelID, name string, archiveDuration int, content string, options ...RequestOption) (th *Channel, err error) {
+func (s *Session) ForumThreadStart(channelID, name string, archiveDuration ThreadArchiveDuration, content string, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
@@ -2741,7 +2741,7 @@ func (s *Session) ForumThreadStart(channelID, name string, archiveDuration int, 
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // embed           : Embed data of the starting message.
-func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration int, embed *MessageEmbed, options ...RequestOption) (th *Channel, err error) {
+func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration ThreadArchiveDuration, embed *MessageEmbed, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,
@@ -2753,7 +2753,7 @@ func (s *Session) ForumThreadStartEmbed(channelID, name string, archiveDuration 
 // name            : Name of the thread.
 // archiveDuration : Auto archive duration.
 // embeds          : Embeds data of the starting message.
-func (s *Session) ForumThreadStartEmbeds(channelID, name string, archiveDuration int, embeds []*MessageEmbed, options ...RequestOption) (th *Channel, err error) {
+func (s *Session) ForumThreadStartEmbeds(channelID, name string, archiveDuration ThreadArchiveDuration, embeds []*MessageEmbed, options ...RequestOption) (th *Channel, err error) {
 	return s.ForumThreadStartComplex(channelID, &ThreadStart{
 		Name:                name,
 		AutoArchiveDuration: archiveDuration,

--- a/structs.go
+++ b/structs.go
@@ -483,10 +483,10 @@ type ChannelEdit struct {
 
 	// NOTE: threads only
 
-	Archived            *bool `json:"archived,omitempty"`
-	AutoArchiveDuration int   `json:"auto_archive_duration,omitempty"`
-	Locked              *bool `json:"locked,omitempty"`
-	Invitable           *bool `json:"invitable,omitempty"`
+	Archived            *bool                   `json:"archived,omitempty"`
+	AutoArchiveDuration ThreadArchiveDuration   `json:"auto_archive_duration,omitempty"`
+	Locked              *bool                   `json:"locked,omitempty"`
+	Invitable           *bool                   `json:"invitable,omitempty"`
 
 	// NOTE: forum channels only
 
@@ -523,13 +523,26 @@ type PermissionOverwrite struct {
 	Allow int64                   `json:"allow,string"`
 }
 
+// Threads will archive automatically after a period of inactivity.
+// That period can be set to a select few values.
+// ThreadArchiveDuration represents those values.
+type ThreadArchiveDuration int
+
+// The following are the possible durations.
+const (
+	ThreadArchiveDurationOneHour   =    60 // minutes
+	ThreadArchiveDurationOneDay    =  1440 // minutes
+	ThreadArchiveDurationThreeDays =  4320 // minutes
+	ThreadArchiveDurationOneWeek   = 10080 // minutes
+)
+
 // ThreadStart stores all parameters you can use with MessageThreadStartComplex or ThreadStartComplex
 type ThreadStart struct {
-	Name                string      `json:"name"`
-	AutoArchiveDuration int         `json:"auto_archive_duration,omitempty"`
-	Type                ChannelType `json:"type,omitempty"`
-	Invitable           bool        `json:"invitable"`
-	RateLimitPerUser    int         `json:"rate_limit_per_user,omitempty"`
+	Name                string                `json:"name"`
+	AutoArchiveDuration ThreadArchiveDuration `json:"auto_archive_duration,omitempty"`
+	Type                ChannelType           `json:"type,omitempty"`
+	Invitable           bool                  `json:"invitable"`
+	RateLimitPerUser    int                   `json:"rate_limit_per_user,omitempty"`
 
 	// NOTE: forum threads only
 	AppliedTags []string `json:"applied_tags,omitempty"`
@@ -540,7 +553,7 @@ type ThreadMetadata struct {
 	// Whether the thread is archived
 	Archived bool `json:"archived"`
 	// Duration in minutes to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080
-	AutoArchiveDuration int `json:"auto_archive_duration"`
+	AutoArchiveDuration ThreadArchiveDuration `json:"auto_archive_duration"`
 	// Timestamp when the thread's archive status was last changed, used for calculating recent activity
 	ArchiveTimestamp time.Time `json:"archive_timestamp"`
 	// Whether the thread is locked; when a thread is locked, only users with MANAGE_THREADS can unarchive it


### PR DESCRIPTION
This PR adds a `ThreadArchiveDuration` enum, on the model of [Discord.NET](https://docs.discordnet.dev/api/Discord.ThreadArchiveDuration.html). This makes the range of valid values for a thread's auto archive duration more explicit and can be used in place of unitless magic numbers when making calls to `ThreadStart`, etc.

These values could be validated in `MessageThreadStartComplex`, `ThreadStartComplex`, and `ForumThreadStartComplex` before an API call is made. However, such validation is not (yet) included in this PR.