### PR TITLE
fix(EmojiRegex): A-z range 

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -612,7 +612,7 @@ type Emoji struct {
 
 // EmojiRegex is the regex used to find and identify emojis in messages
 var (
-	EmojiRegex = regexp.MustCompile(`<(a|):[A-z0-9_~]+:[0-9]{18,20}>`)
+	EmojiRegex = regexp.MustCompile(`<(a|):[A-Za-z0-9_~]+:[0-9]{18,20}>`)
 )
 
 // MessageFormat returns a correctly formatted Emoji for use in Message content and embeds


### PR DESCRIPTION
EmojiRegex uses range [A-z], which includes more characters than [A-Z] and [a-z]. Couldn't tell if this was always guaranteed to be run case insensitive, so made it [A-Za-z]