### PR TITLE
feat: add guild member banners

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -115,6 +115,12 @@ var (
 	EndpointGuildMemberAvatarAnimated = func(gId, uID, aID string) string {
 		return EndpointCDNGuilds + gId + "/users/" + uID + "/avatars/" + aID + ".gif"
 	}
+	EndpointGuildMemberBanner = func(gId, uID, hash string) string {
+		return EndpointCDNGuilds + gId + "/users/" + uID + "/banners/" + hash + ".png"
+	}
+	EndpointGuildMemberBannerAnimated = func(gId, uID, hash string) string {
+		return EndpointCDNGuilds + gId + "/users/" + uID + "/banners/" + hash + ".gif"
+	}
 
 	EndpointRoleIcon = func(rID, hash string) string {
 		return EndpointCDNRoleIcons + rID + "/" + hash + ".png"

--- a/structs.go
+++ b/structs.go
@@ -1566,6 +1566,9 @@ type Member struct {
 	// The hash of the avatar for the guild member, if any.
 	Avatar string `json:"avatar"`
 
+	// The hash of the banner for the guild member, if any.
+	Banner string `json:"banner"`
+
 	// The underlying user on which the member is based.
 	User *User `json:"user"`
 
@@ -1608,6 +1611,22 @@ func (m *Member) AvatarURL(size string) string {
 	return avatarURL(m.Avatar, "", EndpointGuildMemberAvatar(m.GuildID, m.User.ID, m.Avatar),
 		EndpointGuildMemberAvatarAnimated(m.GuildID, m.User.ID, m.Avatar), size)
 
+}
+
+// BannerURL returns the URL of the member's banner image.
+//
+//	size:    The size of the desired banner image as a power of two
+//	         Image size can be any power of two between 16 and 4096.
+func (m *Member) BannerURL(size string) string {
+	if m.Banner == "" {
+		return m.User.BannerURL(size)
+	}
+	return bannerURL(
+		m.Banner,
+		EndpointGuildMemberBanner(m.GuildID, m.User.ID, m.Banner),
+		EndpointGuildMemberBannerAnimated(m.GuildID, m.User.ID, m.Banner),
+		size,
+	)
 }
 
 // DisplayName returns the member's guild nickname if they have one,


### PR DESCRIPTION
As of july 16th 2024, member banners were added to the API. 
Ref: https://discord.com/developers/docs/change-log#guild-member-banners

This PR adds the banner field, BannerURL method, and endpoints.
