### PR TITLE
Add `MessageReferenceType`

### DIFF
--- a/message.go
+++ b/message.go
@@ -471,12 +471,23 @@ type MessageApplication struct {
 	Name        string `json:"name"`
 }
 
+// MessageReferenceType is a type of MessageReference
+type MessageReferenceType int
+
+// Known valid MessageReferenceType values
+// https://discord.com/developers/docs/resources/message#message-reference-types
+const (
+	MessageReferenceTypeDefault MessageReferenceType = 0
+	MessageReferenceTypeForward MessageReferenceType = 1
+)
+
 // MessageReference contains reference data sent with crossposted messages
 type MessageReference struct {
-	MessageID       string `json:"message_id"`
-	ChannelID       string `json:"channel_id,omitempty"`
-	GuildID         string `json:"guild_id,omitempty"`
-	FailIfNotExists *bool  `json:"fail_if_not_exists,omitempty"`
+	Type            *MessageReferenceType `json:"type,omitempty"`
+	MessageID       string                `json:"message_id"`
+	ChannelID       string                `json:"channel_id,omitempty"`
+	GuildID         string                `json:"guild_id,omitempty"`
+	FailIfNotExists *bool                 `json:"fail_if_not_exists,omitempty"`
 }
 
 func (m *Message) reference(failIfNotExists bool) *MessageReference {

--- a/message.go
+++ b/message.go
@@ -483,15 +483,16 @@ const (
 
 // MessageReference contains reference data sent with crossposted messages
 type MessageReference struct {
-	Type            *MessageReferenceType `json:"type,omitempty"`
-	MessageID       string                `json:"message_id"`
-	ChannelID       string                `json:"channel_id,omitempty"`
-	GuildID         string                `json:"guild_id,omitempty"`
-	FailIfNotExists *bool                 `json:"fail_if_not_exists,omitempty"`
+	Type            MessageReferenceType `json:"type,omitempty"`
+	MessageID       string               `json:"message_id"`
+	ChannelID       string               `json:"channel_id,omitempty"`
+	GuildID         string               `json:"guild_id,omitempty"`
+	FailIfNotExists *bool                `json:"fail_if_not_exists,omitempty"`
 }
 
-func (m *Message) reference(failIfNotExists bool) *MessageReference {
+func (m *Message) reference(refType MessageReferenceType, failIfNotExists bool) *MessageReference {
 	return &MessageReference{
+		Type:            refType,
 		GuildID:         m.GuildID,
 		ChannelID:       m.ChannelID,
 		MessageID:       m.ID,
@@ -501,13 +502,18 @@ func (m *Message) reference(failIfNotExists bool) *MessageReference {
 
 // Reference returns a MessageReference of the given message.
 func (m *Message) Reference() *MessageReference {
-	return m.reference(true)
+	return m.reference(MessageReferenceTypeDefault, true)
 }
 
 // SoftReference returns a MessageReference of the given message.
 // If the message doesn't exist it will instead be sent as a non-reply message.
 func (m *Message) SoftReference() *MessageReference {
-	return m.reference(false)
+	return m.reference(MessageReferenceTypeDefault, false)
+}
+
+// Forward returns a MessageReference for a forwarded message.
+func (m *Message) Forward() *MessageReference {
+	return m.reference(MessageReferenceTypeForward, true)
 }
 
 // ContentWithMentionsReplaced will replace all @<id> mentions with the

--- a/message_test.go
+++ b/message_test.go
@@ -50,3 +50,55 @@ func TestGettingEmojisFromMessage(t *testing.T) {
 	}
 
 }
+
+func TestMessage_Reference(t *testing.T) {
+	m := &Message{
+		ID:        "811736565172011001",
+		GuildID:   "811736565172011002",
+		ChannelID: "811736565172011003",
+	}
+
+	ref := m.Reference()
+
+	if ref.Type != 0 {
+		t.Error("Default reference type should be 0")
+	}
+
+	if ref.MessageID != m.ID {
+		t.Error("Message ID should be the same")
+	}
+
+	if ref.GuildID != m.GuildID {
+		t.Error("Guild ID should be the same")
+	}
+
+	if ref.ChannelID != m.ChannelID {
+		t.Error("Channel ID should be the same")
+	}
+}
+
+func TestMessage_Forward(t *testing.T) {
+	m := &Message{
+		ID:        "811736565172011001",
+		GuildID:   "811736565172011002",
+		ChannelID: "811736565172011003",
+	}
+
+	ref := m.Forward()
+
+	if ref.Type != MessageReferenceTypeForward {
+		t.Error("Reference type should be 1 (forward)")
+	}
+
+	if ref.MessageID != m.ID {
+		t.Error("Message ID should be the same")
+	}
+
+	if ref.GuildID != m.GuildID {
+		t.Error("Guild ID should be the same")
+	}
+
+	if ref.ChannelID != m.ChannelID {
+		t.Error("Channel ID should be the same")
+	}
+}

--- a/message_test.go
+++ b/message_test.go
@@ -102,3 +102,10 @@ func TestMessage_Forward(t *testing.T) {
 		t.Error("Channel ID should be the same")
 	}
 }
+
+func TestMessageReference_DefaultTypeIsDefault(t *testing.T) {
+	r := MessageReference{}
+	if r.Type != MessageReferenceTypeDefault {
+		t.Error("Default message type should be MessageReferenceTypeDefault")
+	}
+}


### PR DESCRIPTION
This PR adds the `MessageReferenceType` type to `MessageReference`s as per https://github.com/bwmarrin/discordgo/issues/1594

It also adds a `Forward` convenience method on messages to create a forward reference for messages