### PR TITLE
feat: Function to get the user ID as a uint64

### DIFF
--- a/user.go
+++ b/user.go
@@ -102,6 +102,8 @@ type User struct {
 	Flags int `json:"flags"`
 }
 
+// Parses the `ID` field to a uint64 and returns it.
+// This function is not cached
 func (u *User) IdLong() uint64 {
 	// We can ignore the error because discord
 	// identifiers are always valid as uint64


### PR DESCRIPTION
Added the function `IdLong()` on the User struct, allowing to get the user's ID as a uint64.