### PR TITLE
feat(user): Add helper function to get effective display name

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1635,7 +1635,7 @@ func (m *Member) DisplayName() string {
 	if m.Nick != "" {
 		return m.Nick
 	}
-	return m.User.GlobalName
+	return m.User.DisplayName()
 }
 
 // ClientStatus stores the online, offline, idle, or dnd status of each device of a Guild member.

--- a/structs_test.go
+++ b/structs_test.go
@@ -20,8 +20,9 @@ func TestMember_DisplayName(t *testing.T) {
 			Nick: "",
 			User: user,
 		}
-		if dn := m.DisplayName(); dn != user.GlobalName {
-			t.Errorf("Member.DisplayName() = %v, want %v", dn, user.GlobalName)
+		want := user.DisplayName()
+		if dn := m.DisplayName(); dn != want {
+			t.Errorf("Member.DisplayName() = %v, want %v", dn, want)
 		}
 	})
 	t.Run("server nickname set", func(t *testing.T) {

--- a/user.go
+++ b/user.go
@@ -152,3 +152,11 @@ func (u *User) DefaultAvatarIndex() int {
 	id, _ := strconv.Atoi(u.Discriminator)
 	return id % 5
 }
+
+// DisplayName returns the user's global name if they have one, otherwise it returns their username.
+func (u *User) DisplayName() string {
+	if u.GlobalName != "" {
+		return u.GlobalName
+	}
+	return u.Username
+}

--- a/user_test.go
+++ b/user_test.go
@@ -35,3 +35,24 @@ func TestUser_String(t *testing.T) {
 		})
 	}
 }
+
+func TestUser_DisplayName(t *testing.T) {
+	t.Run("no global name set", func(t *testing.T) {
+		u := &User{
+			GlobalName: "",
+			Username:   "username",
+		}
+		if dn := u.DisplayName(); dn != u.Username {
+			t.Errorf("User.DisplayName() = %v, want %v", dn, u.Username)
+		}
+	})
+	t.Run("global name set", func(t *testing.T) {
+		u := &User{
+			GlobalName: "global",
+			Username:   "username",
+		}
+		if dn := u.DisplayName(); dn != u.GlobalName {
+			t.Errorf("User.DisplayName() = %v, want %v", dn, u.GlobalName)
+		}
+	})
+}


### PR DESCRIPTION
User.GlobalName can be empty.
https://discord.com/developers/docs/resources/user#user-object-user-structure

So we need helper function to select the effective name.

This change is already mentioned at https://github.com/bwmarrin/discordgo/pull/1426#issuecomment-1687974189