### PR TITLE
Support new '4022' voice close event code

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -354,10 +354,13 @@ func (v *VoiceConnection) wsListen(wsConn *websocket.Conn, close <-chan struct{}
 	for {
 		_, message, err := v.wsConn.ReadMessage()
 		if err != nil {
+			e, ok := err.(*websocket.CloseError)
+
 			// 4014 indicates a manual disconnection by someone in the guild;
+			// 4022 indicates a manual disconnection by someone in the guild and outside the voice channel;
 			// we shouldn't reconnect.
-			if websocket.IsCloseError(err, 4014) {
-				v.log(LogInformational, "received 4014 manual disconnection")
+			if ok && (e.Code == 4014 || e.Code == 4022) {
+				v.log(LogInformational, "received %d manual disconnection", e.Code)
 
 				// Abandon the voice WS connection
 				v.Lock()
@@ -366,7 +369,7 @@ func (v *VoiceConnection) wsListen(wsConn *websocket.Conn, close <-chan struct{}
 
 				// Wait for VOICE_SERVER_UPDATE.
 				// When the bot is moved by the user to another voice channel,
-				// VOICE_SERVER_UPDATE is received after the code 4014.
+				// VOICE_SERVER_UPDATE is received after the code.
 				for i := 0; i < 5; i++ { // TODO: temp, wait for VoiceServerUpdate.
 					<-time.After(1 * time.Second)
 
@@ -376,12 +379,12 @@ func (v *VoiceConnection) wsListen(wsConn *websocket.Conn, close <-chan struct{}
 					if !reconnected {
 						continue
 					}
-					v.log(LogInformational, "successfully reconnected after 4014 manual disconnection")
+					v.log(LogInformational, "successfully reconnected after %d manual disconnection", e.Code)
 					return
 				}
 
 				// When VOICE_SERVER_UPDATE is not received, disconnect as usual.
-				v.log(LogInformational, "disconnect due to 4014 manual disconnection")
+				v.log(LogInformational, "disconnect due to %d manual disconnection", e.Code)
 
 				v.session.Lock()
 				delete(v.session.VoiceConnections, v.GuildID)


### PR DESCRIPTION
Hi! Discord recently introduced a new voice close event code that hasn't been documented yet at https://discord.com/developers/docs/topics/opcodes-and-status-codes.
The new code (_4022_) is slightly more specific than the previous one (_4014_). It occurs when someone from the guild disconnects the bot **from outside the voice channel**.
I'm including the emails I exchanged with the Discord team, where they confirm it's not documented yet, as well as the error I was receiving before applying the change included in the code.

```
Your request is 56457380 has been updated. To add additional comments, repl=
y to this email.
----------------------------------------------

Vivi, May 21, 2025, 13:15 PDT

Hello!

Thank you for contacting Discord Developer Support. Yes! This is in fact in=
tended and valid but not currently documented. These codes are technically =
so our internal teams can distinguish events.

In your application, you can freely treat 4022 as a distinct event within i=
t's logic if you'd like.

Thank you,
Vivi

Blizzard - Blizzara - Blizzaga!

----------------------------------------------

Thezepols, May 19, 2025, 21:15 PDT

Hello! When I disconnect a bot from a voice channel while being outside the=
 channel, the event returns a close code 4022, which is not listed in the d=
ocumentation (https://discord.com/developers/docs/topics/opcodes-and-status=
-codes).

`2025/05/20 03:51:28 [DG0] voice.go:403:wsListen() voice endpoint us-south3=
722.discord.media:443 websocket closed unexpectantly, websocket: close 4022=
: Disconnected.`

According to the documentation, the expected close code in this case should=
 be 4014. Interestingly, when I perform the same action from inside the voi=
ce channel, the correct code 4014 is returned.

Could you clarify whether 4022 is a valid (but undocumented) code, or if th=
is is a bug?

Thanks in advance!

--------------------------------
This email is a service from Discord Support.
```
