### PR TITLE
fix issues with go vet printf analyzer during tests using go1.24

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -298,7 +298,7 @@ func (s *Session) RequestWithLockedBucket(method, urlStr, contentType string, b 
 		}
 	case http.StatusUnauthorized:
 		if strings.Index(s.Token, "Bot ") != 0 {
-			s.log(LogInformational, ErrUnauthorized.Error())
+			s.log(LogInformational, "%s", ErrUnauthorized.Error())
 			err = ErrUnauthorized
 		}
 		fallthrough

--- a/restapi_test.go
+++ b/restapi_test.go
@@ -95,7 +95,7 @@ func TestUserChannelCreate(t *testing.T) {
 
 	_, err := dg.UserChannelCreate(envAdmin)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	// TODO make sure the channel was added
@@ -108,7 +108,7 @@ func TestUserGuilds(t *testing.T) {
 
 	_, err := dg.UserGuilds(10, "", "", false)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 }
 


### PR DESCRIPTION
As explained in the linked issue, go1.24 changed the printf analyzer for go vet which can cause go test to fail. This PR makes go vet happy without changing any functionality while making as few changes as possible.

Resolves #1630 