### PR TITLE
Add VerifyUnmarshalInteraction() for performance & convenience

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -660,3 +660,48 @@ func VerifyInteraction(r *http.Request, key ed25519.PublicKey) bool {
 
 	return ed25519.Verify(key, msg.Bytes(), sig)
 }
+
+// VerifyUnmarshalInteraction() combines VerifyInteraction() and UnmarshalJSON()
+// to avoid extra data copies
+func VerifyUnmarshalInteraction(r *http.Request, key ed25519.PublicKey, i *Interaction) error {
+	var msg bytes.Buffer
+
+	signature := r.Header.Get("X-Signature-Ed25519")
+	if signature == "" {
+		return fmt.Errorf("Missing X-Signature-Ed25519 header")
+	}
+
+	sig, err := hex.DecodeString(signature)
+	if err != nil {
+		return fmt.Errorf("Failed to decode Ed25519 signature")
+	}
+
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("Incorrect Ed25519 signature size expected %v got %v",
+			ed25519.SignatureSize, len(sig))
+	}
+
+	timestamp := r.Header.Get("X-Signature-Timestamp")
+	if timestamp == "" {
+		return fmt.Errorf("Missing X-Signature-Timestamp header")
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("Failed to read request body: %w", err)
+	}
+
+	msg.WriteString(timestamp)
+	msg.Write(body)
+
+	if !ed25519.Verify(key, msg.Bytes(), sig) {
+		return fmt.Errorf("Ed25519 signature verification failed")
+	}
+
+	err = i.UnmarshalJSON(body)
+	if err != nil {
+		return fmt.Errorf("Failed to unmarshal interaction: %w", err)
+	}
+
+	return nil
+}

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -66,3 +66,115 @@ func TestVerifyInteraction(t *testing.T) {
 		}
 	})
 }
+
+// TestVerifyUnmarshalInteraction tests the combined Verify and Unmarshal for interactions.
+func TestVerifyUnmarshalInteraction(t *testing.T) {
+	pubkey, privkey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("error generating signing keypair: %s", err)
+	}
+	timestamp := "1608597133"
+	// prepare a minimal valid interaction JSON (ApplicationCommand)
+	payload := `{
+       "id": "123",
+       "application_id": "appid",
+       "type": 2,
+       "data": {"id":"cmdid","name":"test","type":1}
+    }`
+
+	t.Run("success", func(t *testing.T) {
+		body := payload
+		req := httptest.NewRequest("POST", "http://example.com/", strings.NewReader(body))
+		req.Header.Set("X-Signature-Timestamp", timestamp)
+
+		var msg bytes.Buffer
+		msg.WriteString(timestamp)
+		msg.WriteString(body)
+
+		sig := ed25519.Sign(privkey, msg.Bytes())
+		req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(sig))
+		var inter Interaction
+		if err := VerifyUnmarshalInteraction(req, pubkey, &inter); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if inter.ID != "123" || inter.Type != InteractionApplicationCommand {
+			t.Errorf("unexpected interaction data: %+v", inter)
+		}
+	})
+
+	t.Run("missing signature header", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+		req.Header.Set("X-Signature-Timestamp", timestamp)
+		var inter Interaction
+		err := VerifyUnmarshalInteraction(req, pubkey, &inter)
+		if err == nil || !strings.Contains(err.Error(), "Missing X-Signature-Ed25519 header") {
+			t.Errorf("expected missing signature error, got %v", err)
+		}
+	})
+
+	t.Run("invalid signature hex", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+		req.Header.Set("X-Signature-Timestamp", timestamp)
+		req.Header.Set("X-Signature-Ed25519", "zzzz")
+		var inter Interaction
+		err := VerifyUnmarshalInteraction(req, pubkey, &inter)
+		if err == nil || !strings.Contains(err.Error(), "Failed to decode Ed25519 signature") {
+			t.Errorf("expected decode error, got %v", err)
+		}
+	})
+
+	t.Run("invalid signature size", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+		req.Header.Set("X-Signature-Timestamp", timestamp)
+		// too short sig
+		short := make([]byte, ed25519.SignatureSize/2)
+		req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(short))
+		var inter Interaction
+		err := VerifyUnmarshalInteraction(req, pubkey, &inter)
+		if err == nil || !strings.Contains(err.Error(), "Incorrect Ed25519 signature size") {
+			t.Errorf("expected signature size error, got %v", err)
+		}
+	})
+
+	t.Run("missing timestamp header", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+		sig := ed25519.Sign(privkey, []byte(timestamp+payload))
+		req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(sig))
+		var inter Interaction
+		err := VerifyUnmarshalInteraction(req, pubkey, &inter)
+		if err == nil || !strings.Contains(err.Error(), "Missing X-Signature-Timestamp header") {
+			t.Errorf("expected missing timestamp error, got %v", err)
+		}
+	})
+
+	t.Run("verification failure", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(payload))
+		req.Header.Set("X-Signature-Timestamp", timestamp)
+		// sign wrong message
+		sig := ed25519.Sign(privkey, []byte(timestamp+"wrong"))
+		req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(sig))
+		var inter Interaction
+		err := VerifyUnmarshalInteraction(req, pubkey, &inter)
+		if err == nil || !strings.Contains(err.Error(), "Ed25519 signature verification failed") {
+			t.Errorf("expected verification failure, got %v", err)
+		}
+	})
+
+	t.Run("invalid json body", func(t *testing.T) {
+		body := "not-json"
+		req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+		req.Header.Set("X-Signature-Timestamp", timestamp)
+
+		var msg bytes.Buffer
+		msg.WriteString(timestamp)
+		msg.WriteString(body)
+		sig := ed25519.Sign(privkey, msg.Bytes())
+
+		req.Header.Set("X-Signature-Ed25519", hex.EncodeToString(sig))
+		var inter Interaction
+		err := VerifyUnmarshalInteraction(req, pubkey, &inter)
+		if err == nil || !strings.Contains(err.Error(), "Failed to unmarshal interaction") {
+			t.Errorf("expected unmarshal error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This commit adds VerifyUnmarshalInteraction() which combines VerifyInteraction() and Interaction.UnmarshalJSON(). This eliminates the extra data copying that VerifyInteraction() does to put the http body back into the http request for the caller. Additionally, this reduces code for callers following the common
verify()/read()/unmarshall() pattern into a single function call.