### PR TITLE
feat(Interaction): helper function for getting the user

### DIFF
--- a/interactions.go
+++ b/interactions.go
@@ -268,6 +268,23 @@ type rawInteraction struct {
 	Data json.RawMessage `json:"data"`
 }
 
+type ErrUserNotFound struct{}
+
+func (e *ErrUserNotFound) Error() string {
+	return "User not found"
+}
+
+// Gets the user from the interaction
+func (i *interaction) GetUser() (*User, error) {
+	if i.Member != nil {
+		return i.Member.User, nil
+	}
+	if i.User != nil {
+		return i.User, nil
+	}
+	return nil, &ErrUserNotFound{}
+}
+
 // UnmarshalJSON is a method for unmarshalling JSON object to Interaction.
 func (i *Interaction) UnmarshalJSON(raw []byte) error {
 	var tmp rawInteraction


### PR DESCRIPTION
Adding a `GetUser` function to the `Interaction` struct to make retrieving the user of the interaction easier. 
According to the Discord spec it appears that there will always be a `User` in either `Interaction.Member.User` or `Interaction.User` this comes from the fact that the `Member.User` is only possibly unpopulated during a `MESSAGE_CREATE`  or `MESSAGE_UPDATE` event. 

Current methods to access interactions given from Guilds or DMs require you to check both `Member` and `User` and this function attempts to alleviate that by providing a shortcut. A custom `ErrUserNotFound` error has been provided in the error case that the user was not found possibly due to unmarshalling not returning a user. 

This is one of my first PRs, suggestions and critic welcome.