### PR TITLE
fix(Thumbnail): correct typo in JSON tag for Spoiler field

### DIFF
--- a/components.go
+++ b/components.go
@@ -411,7 +411,7 @@ type Thumbnail struct {
 	ID          int               `json:"id,omitempty"`
 	Media       UnfurledMediaItem `json:"media"`
 	Description *string           `json:"description,omitempty"`
-	Spoiler     bool              `json:"spoiler,omitemoty"`
+	Spoiler     bool              `json:"spoiler,omitempty"`
 }
 
 // Type is a method to get the type of a component.


### PR DESCRIPTION
fixing a typo in struct tag for Spoiler field in Thumbnail struct in `components.go` "omitemoty" -> "omitempty"