### PR TITLE
chore(shutdown): Improved shutdown by waiting for ws closing

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -137,6 +137,9 @@ type Session struct {
 
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
+
+	// used to wait for discord to close the websocket connection when bot gets stopped
+	closeWg sync.WaitGroup
 }
 
 // ApplicationIntegrationType dictates where application can be installed and its available interaction contexts.

--- a/wsapi.go
+++ b/wsapi.go
@@ -720,10 +720,10 @@ type voiceChannelJoinOp struct {
 
 // ChannelVoiceJoin joins the session user to a voice channel.
 //
-//	gID     : Guild ID of the channel to join.
-//	cID     : Channel ID of the channel to join.
-//	mute    : If true, you will be set to muted upon joining.
-//	deaf    : If true, you will be set to deafened upon joining.
+//    gID     : Guild ID of the channel to join.
+//    cID     : Channel ID of the channel to join.
+//    mute    : If true, you will be set to muted upon joining.
+//    deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *VoiceConnection, err error) {
 
 	s.log(LogInformational, "called")
@@ -767,10 +767,10 @@ func (s *Session) ChannelVoiceJoin(gID, cID string, mute, deaf bool) (voice *Voi
 //
 // This should only be used when the VoiceServerUpdate will be intercepted and used elsewhere.
 //
-//	gID     : Guild ID of the channel to join.
-//	cID     : Channel ID of the channel to join, leave empty to disconnect.
-//	mute    : If true, you will be set to muted upon joining.
-//	deaf    : If true, you will be set to deafened upon joining.
+//    gID     : Guild ID of the channel to join.
+//    cID     : Channel ID of the channel to join, leave empty to disconnect.
+//    mute    : If true, you will be set to muted upon joining.
+//    deaf    : If true, you will be set to deafened upon joining.
 func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err error) {
 
 	s.log(LogInformational, "called")


### PR DESCRIPTION
I was wondering why my Discord Bot always needed exactly 1 second to shutdown. Now it's faster