### PR TITLE
Returning old state on update or delete events

### DIFF
--- a/events.go
+++ b/events.go
@@ -60,6 +60,7 @@ type ChannelUpdate struct {
 // ChannelDelete is the data for a ChannelDelete event.
 type ChannelDelete struct {
 	*Channel
+	BeforeDelete *Channel
 }
 
 // ChannelPinsUpdate stores data for a ChannelPinsUpdate event.
@@ -84,6 +85,7 @@ type ThreadUpdate struct {
 // ThreadDelete is the data for a ThreadDelete event.
 type ThreadDelete struct {
 	*Channel
+	BeforeDelete *Channel `json:"-"`
 }
 
 // ThreadListSync is the data for a ThreadListSync event.
@@ -158,6 +160,7 @@ type GuildMemberUpdate struct {
 // GuildMemberRemove is the data for a GuildMemberRemove event.
 type GuildMemberRemove struct {
 	*Member
+	BeforeDelete *Member `json:"-"`
 }
 
 // GuildRoleCreate is the data for a GuildRoleCreate event.
@@ -168,12 +171,14 @@ type GuildRoleCreate struct {
 // GuildRoleUpdate is the data for a GuildRoleUpdate event.
 type GuildRoleUpdate struct {
 	*GuildRole
+	BeforeUpdate *Role `json:"-"`
 }
 
 // A GuildRoleDelete is the data for a GuildRoleDelete event.
 type GuildRoleDelete struct {
-	RoleID  string `json:"role_id"`
-	GuildID string `json:"guild_id"`
+	RoleID       string `json:"role_id"`
+	GuildID      string `json:"guild_id"`
+	BeforeDelete *Role  `json:"-"`
 }
 
 // A GuildEmojisUpdate is the data for a guild emoji update event.

--- a/restapi.go
+++ b/restapi.go
@@ -1753,6 +1753,10 @@ func (s *Session) ChannelMessageSendComplex(channelID string, data *MessageSend,
 		}
 	}
 
+	if data.AllowedMentions == nil && s.AllowedMentions != nil {
+		data.AllowedMentions = s.AllowedMentions
+	}
+
 	for _, embed := range data.Embeds {
 		if embed.Type == "" {
 			embed.Type = "rich"

--- a/state.go
+++ b/state.go
@@ -1014,6 +1014,12 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 
 		// Removes member from the cache if tracking is enabled.
 		if s.TrackMembers {
+			old, err := s.Member(t.Member.GuildID, t.Member.User.ID)
+			if err == nil {
+				oldCopy := *old
+				t.BeforeDelete = &oldCopy
+			}
+
 			err = s.MemberRemove(t.Member)
 		}
 	case *GuildMembersChunk:
@@ -1035,10 +1041,22 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	case *GuildRoleUpdate:
 		if s.TrackRoles {
+			old, err := s.Role(t.GuildID, t.Role.ID)
+			if err == nil {
+				oldCopy := *old
+				t.BeforeUpdate = &oldCopy
+			}
+
 			err = s.RoleAdd(t.GuildID, t.Role)
 		}
 	case *GuildRoleDelete:
 		if s.TrackRoles {
+			old, err := s.Role(t.GuildID, t.RoleID)
+			if err == nil {
+				oldCopy := *old
+				t.BeforeDelete = &oldCopy
+			}
+
 			err = s.RoleRemove(t.GuildID, t.RoleID)
 		}
 	case *GuildEmojisUpdate:
@@ -1078,6 +1096,11 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	case *ChannelDelete:
 		if s.TrackChannels {
+			old, err := s.Channel(t.ID)
+			if err == nil {
+				oldCopy := *old
+				t.BeforeDelete = &oldCopy
+			}
 			err = s.ChannelRemove(t.Channel)
 		}
 	case *ThreadCreate:
@@ -1095,6 +1118,11 @@ func (s *State) OnInterface(se *Session, i interface{}) (err error) {
 		}
 	case *ThreadDelete:
 		if s.TrackThreads {
+			old, err := s.Channel(t.ID)
+			if err == nil {
+				oldCopy := *old
+				t.BeforeDelete = &oldCopy
+			}
 			err = s.ChannelRemove(t.Channel)
 		}
 	case *ThreadMemberUpdate:

--- a/structs.go
+++ b/structs.go
@@ -137,6 +137,9 @@ type Session struct {
 
 	// used to make sure gateway websocket writes do not happen concurrently
 	wsMutex sync.Mutex
+
+	// used to set the global default allowed mentions
+	AllowedMentions *MessageAllowedMentions
 }
 
 // ApplicationIntegrationType dictates where application can be installed and its available interaction contexts.


### PR DESCRIPTION
Hello,

Im opening this PR since I am making a logging bot for my server, audit logs are not enough for us.
Here I basically do more of the same, adding BeforeDelete and BeforeUpdate to channel, thread, guild member and guild roles

I might also do the same for emojis too later on.