### PR TITLE
feat(components): label component

### DIFF
--- a/components.go
+++ b/components.go
@@ -25,6 +25,7 @@ const (
 	FileComponentType              ComponentType = 13
 	SeparatorComponent             ComponentType = 14
 	ContainerComponent             ComponentType = 17
+	LabelComponent                 ComponentType = 18
 )
 
 // MessageComponent is a base interface for all message components.
@@ -71,6 +72,8 @@ func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 		umc.MessageComponent = &Separator{}
 	case ContainerComponent:
 		umc.MessageComponent = &Container{}
+	case LabelComponent:
+		umc.MessageComponent = &Label{}
 	default:
 		return fmt.Errorf("unknown component type: %d", v.Type)
 	}
@@ -256,8 +259,12 @@ type SelectMenu struct {
 	// NOTE: Number of entries should be in the range defined by MinValues and MaxValues.
 	DefaultValues []SelectMenuDefaultValue `json:"default_values,omitempty"`
 
-	Options  []SelectMenuOption `json:"options,omitempty"`
-	Disabled bool               `json:"disabled"`
+	Options []SelectMenuOption `json:"options,omitempty"`
+	// The list of value(s) selected from the prefined options.
+	// NOTE: This will only exist if the InteractionType was a ModalSubmit
+	// otherwise you should (still) be using `MessageComponentData`
+	Values   []string `json:"values,omitempty"`
+	Disabled bool     `json:"disabled"`
 
 	// NOTE: Can only be used in SelectMenu with Channel menu type.
 	ChannelTypes []ChannelType `json:"channel_types,omitempty"`
@@ -601,4 +608,52 @@ type ResolvedUnfurledMediaItem struct {
 	Width       int    `json:"width"`
 	Height      int    `json:"height"`
 	ContentType string `json:"content_type"`
+}
+
+// Label is a top-level layout component.
+// Labels wrap modal components with text as a label and optional description.
+type Label struct {
+	// Unique identifier for the component; auto populated through increment if not provided.
+	ID          int              `json:"id,omitempty"`
+	Label       string           `json:"label"`
+	Description string           `json:"description,omitempty"`
+	Component   MessageComponent `json:"component"`
+}
+
+// Type is a method to get the type of a component.
+func (Label) Type() ComponentType {
+	return LabelComponent
+}
+
+// UnmarshalJSON is a method for unmarshaling Container from JSON
+func (l *Label) UnmarshalJSON(data []byte) error {
+	type label Label
+
+	var v struct {
+		label
+		RawComponent unmarshalableMessageComponent `json:"component"`
+	}
+
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+
+	*l = Label(v.label)
+	l.Component = v.RawComponent.MessageComponent
+
+	return nil
+}
+
+// MarshalJSON is a method for marshaling Container to a JSON object.
+func (l Label) MarshalJSON() ([]byte, error) {
+	type label Label
+
+	return Marshal(struct {
+		label
+		Type ComponentType `json:"type"`
+	}{
+		label: label(l),
+		Type:  l.Type(),
+	})
 }

--- a/components.go
+++ b/components.go
@@ -625,7 +625,7 @@ func (Label) Type() ComponentType {
 	return LabelComponent
 }
 
-// UnmarshalJSON is a method for unmarshaling Container from JSON
+// UnmarshalJSON is a method for unmarshaling Label from JSON
 func (l *Label) UnmarshalJSON(data []byte) error {
 	type label Label
 
@@ -645,7 +645,7 @@ func (l *Label) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON is a method for marshaling Container to a JSON object.
+// MarshalJSON is a method for marshaling Label to a JSON object.
 func (l Label) MarshalJSON() ([]byte, error) {
 	type label Label
 

--- a/examples/modals/main.go
+++ b/examples/modals/main.go
@@ -49,27 +49,45 @@ var (
 					CustomID: "modals_survey_" + i.Interaction.Member.User.ID,
 					Title:    "Modals survey",
 					Components: []discordgo.MessageComponent{
-						discordgo.ActionsRow{
-							Components: []discordgo.MessageComponent{
-								discordgo.TextInput{
-									CustomID:    "opinion",
-									Label:       "What is your opinion on them?",
-									Style:       discordgo.TextInputShort,
-									Placeholder: "Don't be shy, share your opinion with us",
-									Required:    true,
-									MaxLength:   300,
-									MinLength:   10,
-								},
+						discordgo.Label{
+							Label: "What is your opinion on them?",
+							Component: discordgo.TextInput{
+								CustomID:    "opinion",
+								Style:       discordgo.TextInputShort,
+								Placeholder: "Don't be shy, share your opinion with us",
+								Required:    true,
+								MaxLength:   300,
+								MinLength:   10,
 							},
 						},
-						discordgo.ActionsRow{
-							Components: []discordgo.MessageComponent{
-								discordgo.TextInput{
-									CustomID:  "suggestions",
-									Label:     "What would you suggest to improve them?",
-									Style:     discordgo.TextInputParagraph,
-									Required:  false,
-									MaxLength: 2000,
+						discordgo.Label{
+							Label: "What would you suggest to improve them?",
+							Component: discordgo.TextInput{
+								CustomID:  "suggestions",
+								Style:     discordgo.TextInputParagraph,
+								Required:  false,
+								MaxLength: 2000,
+							},
+						},
+						discordgo.Label{
+							Label:       "Which option best reflects your experience?",
+							Description: "Choose one that fits best",
+							Component: discordgo.SelectMenu{
+								MenuType: discordgo.StringSelectMenu,
+								CustomID: "select",
+								Options: []discordgo.SelectMenuOption{
+									{
+										Label: "Option 1: It was great",
+										Value: "1",
+									},
+									{
+										Label: "Option 2: It was okay",
+										Value: "2",
+									},
+									{
+										Label: "Option 3: Needs improvement",
+										Value: "3",
+									},
 								},
 							},
 						},
@@ -112,11 +130,13 @@ func main() {
 			}
 
 			userid := strings.Split(data.CustomID, "_")[2]
+
 			_, err = s.ChannelMessageSend(*ResultsChannel, fmt.Sprintf(
-				"Feedback received. From <@%s>\n\n**Opinion**:\n%s\n\n**Suggestions**:\n%s",
+				"Feedback received. From <@%s>\n\n**Opinion**:\n%s\n\n**Suggestions**:\n%s\n\n**Experience:**\n%s",
 				userid,
-				data.Components[0].(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput).Value,
-				data.Components[1].(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput).Value,
+				data.Components[0].(*discordgo.Label).Component.(*discordgo.TextInput).Value,
+				data.Components[1].(*discordgo.Label).Component.(*discordgo.TextInput).Value,
+				data.Components[2].(*discordgo.Label).Component.(*discordgo.SelectMenu).Values[0],
 			))
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
This is a duplicate of #1652 as the organization which the PR was made under was deleted.

Adds support for the new `Label` component that Discord introduced for modals
Updates the examples for modals to utilise `Label`s as `ActionRow`s inside modals is now deprecated behaviour.