### PR TITLE
chore: typo in comment under Session struct

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -72,7 +72,7 @@ type Session struct {
 	// Exposed but should not be modified by User.
 
 	// Whether the Data Websocket is ready
-	DataReady bool // NOTE: Maye be deprecated soon
+	DataReady bool // NOTE: Maybe deprecated soon
 
 	// Max number of REST API retries
 	MaxRestRetries int


### PR DESCRIPTION
Fixed a typo in one of the comments, under the type Session code block, in the documentation. Should be "Maybe", instead of "Maye be".