### PR TITLE
feat(User): implement PrimaryGuild attribute

### DIFF
--- a/user.go
+++ b/user.go
@@ -40,6 +40,21 @@ const (
 	UserPremiumTypeNitroBasic   UserPremiumType = 3
 )
 
+type UserPrimaryGuild struct {
+	// The ID of the user's primary guild.
+	IdentityGuildID string `json:"identity_guild_id"`
+
+	// Whether the user is displaying the primary guild's server tag.
+	IdentityEnabled bool `json:"identity_enabled"`
+
+	// The server tag of the user's primary guild. Limited to 4 characters
+	Tag string `json:"tag"`
+
+	// The server tag badge hash
+	// https://discord.com/developers/docs/reference#image-formatting
+	Badge string `json:"badge"`
+}
+
 // A User stores all data for an individual Discord user.
 type User struct {
 	// The ID of the user.
@@ -100,6 +115,9 @@ type User struct {
 	// The flags on a user's account.
 	// Only available when the request is authorized via a Bearer token.
 	Flags int `json:"flags"`
+
+	// The user's primary guild.
+	PrimaryGuild UserPrimaryGuild `json:"primary_guild"`
 }
 
 // String returns a unique identifier of the form username#discriminator


### PR DESCRIPTION
This PR adds support for guild tags introduced on [July 2nd, 2025](https://discord.com/developers/docs/change-log#gradient-roles-and-guild-tags).

This will close #1642, and in combination with #1634 will ensure that discordgo is up-to-date with that API update.

_I stumbled across this project, and I''m hoping to contribute some more, to make sure discordgo is capable of doing everything the API can do atm. Cheers!_