### PR TITLE
feat(restapi)!: use new channel pins endpoints

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -140,8 +140,8 @@ var (
 	EndpointChannelMessage                      = func(cID, mID string) string { return EndpointChannels + cID + "/messages/" + mID }
 	EndpointChannelMessageThread                = func(cID, mID string) string { return EndpointChannelMessage(cID, mID) + "/threads" }
 	EndpointChannelMessagesBulkDelete           = func(cID string) string { return EndpointChannel(cID) + "/messages/bulk-delete" }
-	EndpointChannelMessagesPins                 = func(cID string) string { return EndpointChannel(cID) + "/pins" }
-	EndpointChannelMessagePin                   = func(cID, mID string) string { return EndpointChannel(cID) + "/pins/" + mID }
+	EndpointChannelMessagesPins                 = func(cID string) string { return EndpointChannel(cID) + "/messages/pins" }
+	EndpointChannelMessagePin                   = func(cID, mID string) string { return EndpointChannel(cID) + "/messages/pins/" + mID }
 	EndpointChannelMessageCrosspost             = func(cID, mID string) string { return EndpointChannel(cID) + "/messages/" + mID + "/crosspost" }
 	EndpointChannelFollow                       = func(cID string) string { return EndpointChannel(cID) + "/followers" }
 	EndpointThreadMembers                       = func(tID string) string { return EndpointChannel(tID) + "/thread-members" }

--- a/restapi.go
+++ b/restapi.go
@@ -1980,15 +1980,31 @@ func (s *Session) ChannelMessageUnpin(channelID, messageID string, options ...Re
 // ChannelMessagesPinned returns an array of Message structures for pinned messages
 // within a given channel
 // channelID : The ID of a Channel.
-func (s *Session) ChannelMessagesPinned(channelID string, options ...RequestOption) (st []*Message, err error) {
+// before : If specified returns only pinned messages before the timestamp
+// limit  : Optional maximum amount of pinned messages to return.
+func (s *Session) ChannelMessagesPinned(channelID string, before *time.Time, limit int, options ...RequestOption) (pinnedMessages *ChannelMessagePinsList, err error) {
+	uri := EndpointChannelMessagesPins(channelID)
 
-	body, err := s.RequestWithBucketID("GET", EndpointChannelMessagesPins(channelID), nil, EndpointChannelMessagesPins(channelID), options...)
+	v := url.Values{}
 
+	if before != nil {
+		v.Set("before", before.Format(time.RFC3339))
+	}
+
+	if limit > 0 {
+		v.Set("limit", strconv.Itoa(limit))
+	}
+
+	if len(v) > 0 {
+		uri += "?" + v.Encode()
+	}
+
+	body, err := s.RequestWithBucketID("GET", uri, nil, uri, options...)
 	if err != nil {
 		return
 	}
 
-	err = unmarshal(body, &st)
+	err = unmarshal(body, &pinnedMessages)
 	return
 }
 

--- a/structs.go
+++ b/structs.go
@@ -2621,6 +2621,24 @@ type EntitlementFilterOptions struct {
 	ExcludeEnded bool
 }
 
+// MessagePin contains information about a pinned message, and the message itself
+type MessagePin struct {
+	// The time the message was pinned
+	PinnedAt time.Time `json:"pinned_at"`
+
+	// The message object which was pinned
+	Message *Message `json:"message"`
+}
+
+// ChannelMessagePinsList contains a list of pinned messages in a channel
+type ChannelMessagePinsList struct {
+	// The list of pinned messages
+	Items []*MessagePin `json:"items"`
+
+	// Whether there are more items available to fetch
+	HasMore bool `json:"has_more"`
+}
+
 // Constants for the different bit offsets of text channel permissions
 const (
 	// Deprecated: PermissionReadMessages has been replaced with PermissionViewChannel for text and voice channels


### PR DESCRIPTION
  This PR updates discordgo to support the [June, 25th 2025](https://discord.com/developers/docs/change-log#paginated-pin-endpoints) Discord API update, revolving around adding pagination to getting pinned messages in a channel, and new endpoints (but same functionality) for pin, and unpin. Avoiding using deprecated routes going forward.

BREAKING CHANGE: `ChannelMessagesPinned` now has new pagination arguments

^^ Do let me know if you prefer a new method that takes in the new arguments, to avoid breaking the old method, or if this is fine with you! :D