### PR TITLE
fix(Guild): Remove blocked GuildCreate method

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -235,8 +235,6 @@ var (
 		return EndpointWebhookMessage(aID, iToken, mID)
 	}
 
-	EndpointGuildCreate = EndpointAPI + "guilds"
-
 	EndpointInvite = func(iID string) string { return EndpointAPI + "invites/" + iID }
 
 	EndpointEmoji         = func(eID string) string { return EndpointCDN + "emojis/" + eID + ".png" }

--- a/restapi.go
+++ b/restapi.go
@@ -617,23 +617,6 @@ func (s *Session) GuildPreview(guildID string, options ...RequestOption) (st *Gu
 	return
 }
 
-// GuildCreate creates a new Guild
-// name      : A name for the Guild (2-100 characters)
-func (s *Session) GuildCreate(name string, options ...RequestOption) (st *Guild, err error) {
-
-	data := struct {
-		Name string `json:"name"`
-	}{name}
-
-	body, err := s.RequestWithBucketID("POST", EndpointGuildCreate, data, EndpointGuildCreate, options...)
-	if err != nil {
-		return
-	}
-
-	err = unmarshal(body, &st)
-	return
-}
-
 // GuildEdit edits a new Guild
 // guildID   : The ID of a Guild
 // g 		 : A GuildParams struct with the values Name, Region and VerificationLevel defined.


### PR DESCRIPTION
As per the changelog entry on [April 15th 2025](https://discord.com/developers/docs/change-log#deprecating-guild-creation-by-apps), Creating guilds (without a template), will be deprecated and has since [July 15th or July 28th 2025](https://discord.com/developers/docs/change-log#guild-create-deprecation), been blocked by bots.

This PR removes that method from discordgo, as it can't be called anyways.
<img width="568" height="40" alt="image" src="https://github.com/user-attachments/assets/2e121a35-86e8-437c-a98a-b6737c0e7d37" />
