### PR TITLE
fix(GuildMembers): populate GuildID for consistency with GuildMember

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -808,6 +808,10 @@ func (s *Session) GuildMembers(guildID string, after string, limit int, options 
 	}
 
 	err = unmarshal(body, &st)
+	// The returned objects don't have the GuildID attribute so we will set it here.
+	for _, member := range st {
+		member.GuildID = guildID
+	}
 	return
 }
 


### PR DESCRIPTION
This is pretty self-explanatory; as described in https://github.com/bwmarrin/discordgo/issues/1675, the current behavior has some drawbacks/unexpected behavior for callers relying on GuildMembers.