### PR TITLE
feat(Guild): Add GuildVanityURL method

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -109,6 +109,7 @@ var (
 	EndpointGuildTemplate            = func(tID string) string { return EndpointGuilds + "templates/" + tID }
 	EndpointGuildTemplates           = func(gID string) string { return EndpointGuilds + gID + "/templates" }
 	EndpointGuildTemplateSync        = func(gID, tID string) string { return EndpointGuilds + gID + "/templates/" + tID }
+	EndpointGuildVanityURL           = func(gID string) string { return EndpointGuilds + gID + "/vanity-url" }
 	EndpointGuildMemberAvatar        = func(gId, uID, aID string) string {
 		return EndpointCDNGuilds + gId + "/users/" + uID + "/avatars/" + aID + ".png"
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -1102,6 +1102,18 @@ func (s *Session) GuildInvites(guildID string, options ...RequestOption) (st []*
 	return
 }
 
+// GuildVanityURL return vanity url information of the guild
+// guildID: The ID of a Guild.
+func (s *Session) GuildVanityURL(guildID string, options ...RequestOption) (st GuildVanityURL, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointGuildVanityURL(guildID), nil, EndpointGuildVanityURL(guildID), options...)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
 // GuildRoles returns all roles for a given guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildRoles(guildID string, options ...RequestOption) (st []*Role, err error) {

--- a/structs.go
+++ b/structs.go
@@ -1261,6 +1261,14 @@ type GuildTemplateParams struct {
 	Description string `json:"description,omitempty"`
 }
 
+// GuildVanityURL stores the vanity URL code and its usage count.
+type GuildVanityURL struct {
+	// The vanity url code for the guild
+	Code string `json:"code"`
+	// The number of times the vanity url has been used
+	Uses int `json:"uses"`
+}
+
 // MessageNotifications is the notification level for a guild
 // https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
 type MessageNotifications int


### PR DESCRIPTION
As mentioned in https://github.com/bwmarrin/discordgo/issues/1681 this adds a method to fetch the GuildVanityURL information.