### PR TITLE
fix: add wsConn nil check in onEvent and ChannelVoiceJoinManual

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -602,9 +602,17 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 	// Must respond with a heartbeat packet within 5 seconds
 	if e.Operation == 1 {
 		s.log(LogInformational, "sending heartbeat in response to Op1")
+
+		s.RLock()
+		if s.wsConn == nil {
+			s.RUnlock()
+			return e, ErrWSNotFound
+		}
 		s.wsMutex.Lock()
 		err = s.wsConn.WriteJSON(heartbeatOp{1, atomic.LoadInt64(s.sequence)})
 		s.wsMutex.Unlock()
+		s.RUnlock()
+
 		if err != nil {
 			s.log(LogError, "error sending heartbeat in response to Op1")
 			return e, err
@@ -778,6 +786,11 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 
 	// Send the request to Discord that we want to join the voice channel
 	data := voiceChannelJoinOp{4, voiceChannelJoinData{&gID, channelID, mute, deaf}}
+	s.RLock()
+	defer s.RUnlock()
+	if s.wsConn == nil {
+		return ErrWSNotFound
+	}
 	s.wsMutex.Lock()
 	err = s.wsConn.WriteJSON(data)
 	s.wsMutex.Unlock()


### PR DESCRIPTION
`onEvent()` and `ChannelVoiceJoinManual()` access `s.wsConn` under `s.wsMutex` without checking for nil first. When `CloseWithCode()` sets `s.wsConn = nil` concurrently (which uses `s.Lock()`, a different mutex), this causes a nil pointer dereference panic that crashes the whole process.

The rest of the codebase already handles this — `UpdateStatusComplex()`, `GatewayWriteStruct()`, and `requestGuildMembers()` all guard `s.wsConn` with `s.RLock()` + nil check before touching the connection. This PR applies the same pattern to the two places that were missing it.

**onEvent (Op1 heartbeat response):**
- Take `s.RLock()` before accessing `s.wsConn`
- Return `ErrWSNotFound` if nil
- Release after `WriteJSON` completes

**ChannelVoiceJoinManual:**
- Take `s.RLock()` (deferred) before accessing `s.wsConn`
- Return `ErrWSNotFound` if nil

Lock ordering stays the same as everywhere else: `s.RLock()` then `s.wsMutex.Lock()`.

Fixes #1702