### PR TITLE
feat: Added GuildVanityURL endpoint

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -110,6 +110,7 @@ var (
 	EndpointGuildTemplate            = func(tID string) string { return EndpointGuilds + "templates/" + tID }
 	EndpointGuildTemplates           = func(gID string) string { return EndpointGuilds + gID + "/templates" }
 	EndpointGuildTemplateSync        = func(gID, tID string) string { return EndpointGuilds + gID + "/templates/" + tID }
+	EndpointGuildVanityURL           = func(gID string) string { return EndpointGuilds + gID + "/vanity-url" }
 	EndpointGuildMemberAvatar        = func(gId, uID, aID string) string {
 		return EndpointCDNGuilds + gId + "/users/" + uID + "/avatars/" + aID + ".png"
 	}

--- a/restapi.go
+++ b/restapi.go
@@ -1102,6 +1102,18 @@ func (s *Session) GuildInvites(guildID string, options ...RequestOption) (st []*
 	return
 }
 
+// GuildVanityURL returns an Invite structure with only the vanity URL code and the number of uses for the given guild set
+// guildID   : The ID of a Guild.
+func (s *Session) GuildVanityURL(guildID string, options ...RequestOption) (st *Invite, err error) {
+	body, err := s.RequestWithBucketID("GET", EndpointGuildVanityURL(guildID), nil, EndpointGuildVanityURL(guildID), options...)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
 // GuildRoles returns all roles for a given guild.
 // guildID   : The ID of a Guild.
 func (s *Session) GuildRoles(guildID string, options ...RequestOption) (st []*Role, err error) {


### PR DESCRIPTION
As mentioned in #1681 and #1682 this changes add the GuildVanityURL method for the restapi reusing a Invite struct as return parameter.

discord api docs: https://docs.discord.com/developers/resources/guild#get-guild-vanity-url