### PR TITLE
feat(permissions): add PinMessages and BypassSlowmode

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -2697,6 +2697,12 @@ const (
 
 	// Allows user-installed apps to send public responses. When disabled, users will still be allowed to use their apps but the responses will be ephemeral. This only applies to apps not also installed to the server.
 	PermissionUseExternalApps = 1 << 50
+
+	// Allows pinning and unpinning messages.
+	PermissionPinMessages = 1 << 51
+
+	// Allows bypassing the channel slowmode setting.
+	PermissionBypassSlowmode = 1 << 52
 )
 
 // Constants for the different bit offsets of voice permissions


### PR DESCRIPTION
## Summary

Adds two permission bits that the Discord API split out in late 2025 / early 2026:

- `PermissionPinMessages` (1 << 51) — pinning and unpinning messages, previously implied by `ManageMessages`.
- `PermissionBypassSlowmode` (1 << 52) — bypassing the channel slowmode setting.

Both constants mirror the numbering in the [official permissions docs](https://discord.com/developers/docs/topics/permissions).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`