### PR TITLE
feat(message): add MessageFlagsHasSnapshot

### DIFF
--- a/message.go
+++ b/message.go
@@ -230,6 +230,8 @@ const (
 	MessageFlagsSuppressNotifications MessageFlags = 1 << 12
 	// MessageFlagsIsVoiceMessage this message is a voice message.
 	MessageFlagsIsVoiceMessage MessageFlags = 1 << 13
+	// MessageFlagsHasSnapshot this message has a snapshot (forwarded message).
+	MessageFlagsHasSnapshot MessageFlags = 1 << 14
 	// MessageFlagsIsComponentsV2 this message uses the new components system. Disables the ability of sending `content` & `embeds`
 	MessageFlagsIsComponentsV2 MessageFlags = 1 << 15
 )


### PR DESCRIPTION
## Summary

Adds `MessageFlagsHasSnapshot` (1 << 14). Discord sets this flag on forwarded messages that carry a snapshot of the referenced message. Matches the [message flags](https://discord.com/developers/docs/resources/message#message-object-message-flags) list in the docs.

Closes #1678

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`