### PR TITLE
feat(restapi): add GuildVanityURL

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -95,6 +95,7 @@ var (
 	EndpointGuildIconAnimated        = func(gID, hash string) string { return EndpointCDNIcons + gID + "/" + hash + ".gif" }
 	EndpointGuildSplash              = func(gID, hash string) string { return EndpointCDNSplashes + gID + "/" + hash + ".png" }
 	EndpointGuildWebhooks            = func(gID string) string { return EndpointGuilds + gID + "/webhooks" }
+	EndpointGuildVanityURL           = func(gID string) string { return EndpointGuilds + gID + "/vanity-url" }
 	EndpointGuildAuditLogs           = func(gID string) string { return EndpointGuilds + gID + "/audit-logs" }
 	EndpointGuildEmojis              = func(gID string) string { return EndpointGuilds + gID + "/emojis" }
 	EndpointGuildEmoji               = func(gID, eID string) string { return EndpointGuilds + gID + "/emojis/" + eID }

--- a/restapi.go
+++ b/restapi.go
@@ -1431,6 +1431,22 @@ func (s *Session) GuildAuditLog(guildID, userID, beforeID string, actionType, li
 	return
 }
 
+// GuildVanityURL returns the vanity URL partial invite for a Guild, including
+// the code and the number of times it has been used. Requires the
+// MANAGE_GUILD permission on the guild.
+// guildID : The ID of a Guild.
+func (s *Session) GuildVanityURL(guildID string, options ...RequestOption) (vanity *GuildVanityURL, err error) {
+	endpoint := EndpointGuildVanityURL(guildID)
+
+	body, err := s.RequestWithBucketID("GET", endpoint, nil, endpoint, options...)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &vanity)
+	return
+}
+
 // GuildEmojis returns all emoji
 // guildID : The ID of a Guild.
 func (s *Session) GuildEmojis(guildID string, options ...RequestOption) (emoji []*Emoji, err error) {

--- a/structs.go
+++ b/structs.go
@@ -963,6 +963,19 @@ type GuildPreview struct {
 	Description string `json:"description"`
 }
 
+// GuildVanityURL is the partial invite object returned from the Get Guild
+// Vanity URL endpoint, containing the vanity code and its redemption count.
+// https://discord.com/developers/docs/resources/guild#get-guild-vanity-url
+type GuildVanityURL struct {
+	// Code is the vanity URL code, or an empty string if the guild does
+	// not have a vanity URL set.
+	Code string `json:"code"`
+
+	// Uses is the number of times the vanity URL has been used to join
+	// the guild.
+	Uses int `json:"uses"`
+}
+
 // IconURL returns a URL to the guild's icon.
 //
 //	size:    The size of the desired icon image as a power of two


### PR DESCRIPTION
Closes #1681.

The existing `Guild.VanityURLCode` field only carries the code itself. Discord's [Get Guild Vanity URL](https://discord.com/developers/docs/resources/guild#get-guild-vanity-url) endpoint returns a partial invite with `{ code, uses }`, and there was no library method for it. That meant reading the vanity's redemption count required dropping to a raw `s.Request` call with hand-written unmarshalling.

### What's new

- `GuildVanityURL` struct (`Code string`, `Uses int`).
- `EndpointGuildVanityURL`.
- `Session.GuildVanityURL(guildID, options...)` returning `*GuildVanityURL`.

Requires `MANAGE_GUILD` on the guild, same as the underlying endpoint. `Code` is an empty string when the guild has no vanity URL set (Discord sends `null`, JSON unmarshal into `string` yields `""`).

### Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 -short ./...` all clean.