### PR TITLE
feat(wsapi): Add GuildScheduledEvents

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -925,6 +925,9 @@ type Guild struct {
 
 	// Stage instances in the guild
 	StageInstances []*StageInstance `json:"stage_instances"`
+
+	// Scheduled events in the guild
+	GuildScheduledEvents []*GuildScheduledEvent `json:"guild_scheduled_events"`
 }
 
 // A GuildPreview holds data related to a specific public Discord Guild, even if the user is not in the guild.


### PR DESCRIPTION
Documented under [Guild Create Extra Fields](https://docs.discord.com/developers/events/gateway-events#guild-create)

I would put it under `GUILD_CREATE`, but this project seems to have a standard of putting the extra fields in the original Guild object.

This field is present in `GUILD_CREATE` always, regardless of intents.