### PR TITLE
feat: add GuildCurrentMemberEdit

### DIFF
--- a/restapi.go
+++ b/restapi.go
@@ -882,10 +882,10 @@ func (s *Session) GuildMemberDelete(guildID, userID string, options ...RequestOp
 	return s.GuildMemberDeleteWithReason(guildID, userID, "", options...)
 }
 
-// GuildMemberEditCurrent edits the current user in the context of the given guild.
+// GuildCurrentMemberEdit edits the current user in the context of the given guild.
 // guildID  : The ID of a Guild.
 // data     : Updated GuildCurrentMemberParams data.
-func (s *Session) GuildMemberEditCurrent(guildID string, data *GuildCurrentMemberParams, options ...RequestOption) (st *Member, err error) {
+func (s *Session) GuildCurrentMemberEdit(guildID string, data *GuildCurrentMemberParams, options ...RequestOption) (st *Member, err error) {
 	var body []byte
 	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, "@me"), data, EndpointGuildMember(guildID, ""), options...)
 	if err != nil {

--- a/restapi.go
+++ b/restapi.go
@@ -882,6 +882,20 @@ func (s *Session) GuildMemberDelete(guildID, userID string, options ...RequestOp
 	return s.GuildMemberDeleteWithReason(guildID, userID, "", options...)
 }
 
+// GuildMemberEditCurrent edits the current user in the context of the given guild.
+// guildID  : The ID of a Guild.
+// data     : Updated GuildCurrentMemberParams data.
+func (s *Session) GuildMemberEditCurrent(guildID string, data *GuildCurrentMemberParams, options ...RequestOption) (st *Member, err error) {
+	var body []byte
+	body, err = s.RequestWithBucketID("PATCH", EndpointGuildMember(guildID, "@me"), data, EndpointGuildMember(guildID, ""), options...)
+	if err != nil {
+		return nil, err
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
 // GuildMemberDeleteWithReason removes the given user from the given guild.
 // guildID   : The ID of a Guild.
 // userID    : The ID of a User

--- a/structs.go
+++ b/structs.go
@@ -2115,7 +2115,7 @@ const (
 // in the context of a specific guild (for server-level customization).
 // https://docs.discord.com/developers/resources/guild#modify-current-member
 type GuildCurrentMemberParams struct {
-	// Value to set user's nickname to.
+	// Value to set user's nickname.
 	Nick string `json:"nick,omitempty"`
 	// Data URI encoded banner image (e.g. "data:image/png;base64,<base64blob>")
 	Banner string `json:"banner,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -2111,6 +2111,20 @@ const (
 	AuditLogActionHomeSettingsUpdate = 191
 )
 
+// CurrentGuildMemberParams stores data needed to update the current member
+// in the context of a specific guild (for server-level customization).
+// https://docs.discord.com/developers/resources/guild#modify-current-member
+type GuildCurrentMemberParams struct {
+	// Value to set user's nickname to.
+	Nick string `json:"nick,omitempty"`
+	// Data URI encoded banner image (e.g. "data:image/png;base64,<base64blob>")
+	Banner string `json:"banner,omitempty"`
+	// Data URI encoded avatar image (e.g. "data:image/png;base64,<base64blob>")
+	Avatar string `json:"avatar,omitempty"`
+	// Value to set user's bio.
+	Bio string `json:"bio,omitempty"`
+}
+
 // GuildMemberParams stores data needed to update a member
 // https://discord.com/developers/docs/resources/guild#modify-guild-member
 type GuildMemberParams struct {


### PR DESCRIPTION
Discord added an "edit current build member" API (https://docs.discord.com/developers/resources/guild#modify-current-member) late last year, which allows per-server avatar/nick/etc customization.

According to the docs' implications and some testing, more image codecs are supported than just image/png, but I cited image/png as the example since Discord seems to silently drop image changes it doesn't like (the related user-edit API seems to do so with non-PNG avatars).