### PR TITLE
Fix nil websocket writes during reconnect

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -602,9 +602,16 @@ func (s *Session) onEvent(messageType int, message []byte) (*Event, error) {
 	// Must respond with a heartbeat packet within 5 seconds
 	if e.Operation == 1 {
 		s.log(LogInformational, "sending heartbeat in response to Op1")
+
+		s.RLock()
+		if s.wsConn == nil {
+			s.RUnlock()
+			return e, ErrWSNotFound
+		}
 		s.wsMutex.Lock()
 		err = s.wsConn.WriteJSON(heartbeatOp{1, atomic.LoadInt64(s.sequence)})
 		s.wsMutex.Unlock()
+		s.RUnlock()
 		if err != nil {
 			s.log(LogError, "error sending heartbeat in response to Op1")
 			return e, err
@@ -778,6 +785,11 @@ func (s *Session) ChannelVoiceJoinManual(gID, cID string, mute, deaf bool) (err 
 
 	// Send the request to Discord that we want to join the voice channel
 	data := voiceChannelJoinOp{4, voiceChannelJoinData{&gID, channelID, mute, deaf}}
+	s.RLock()
+	defer s.RUnlock()
+	if s.wsConn == nil {
+		return ErrWSNotFound
+	}
 	s.wsMutex.Lock()
 	err = s.wsConn.WriteJSON(data)
 	s.wsMutex.Unlock()

--- a/wsapi_test.go
+++ b/wsapi_test.go
@@ -1,0 +1,27 @@
+package discordgo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestOnEventOp1NilWsConn(t *testing.T) {
+	seq := int64(0)
+	s := &Session{sequence: &seq}
+
+	_, err := s.onEvent(websocket.TextMessage, []byte(`{"op":1,"s":0,"t":"","d":null}`))
+	if !errors.Is(err, ErrWSNotFound) {
+		t.Fatalf("onEvent() error = %v, want %v", err, ErrWSNotFound)
+	}
+}
+
+func TestChannelVoiceJoinManualNilWsConn(t *testing.T) {
+	s := &Session{}
+
+	err := s.ChannelVoiceJoinManual("guild", "channel", false, false)
+	if !errors.Is(err, ErrWSNotFound) {
+		t.Fatalf("ChannelVoiceJoinManual() error = %v, want %v", err, ErrWSNotFound)
+	}
+}


### PR DESCRIPTION
Summary:
- Guard Op1 heartbeat replies and manual voice joins when the gateway websocket has been cleared.
- Return ErrWSNotFound instead of writing through a nil websocket connection.
- Add regression tests for both nil websocket paths.

Why:
- CloseWithCode can set wsConn to nil while another goroutine is preparing a gateway write. That panic can kill a multi-session bot host.

Severity:
- Critical

Upstream:
- Fixes bwmarrin/discordgo#1702
- Reviewed upstream PR #1715 and reused the existing lock pattern.
- Reviewed upstream PR #1719 and did not use it because wsMutex alone does not synchronize with CloseWithCode.

Tests:
- go test -run 'TestOnEventOp1NilWsConn|TestChannelVoiceJoinManualNilWsConn' .
- go test -race -run 'TestOnEventOp1NilWsConn|TestChannelVoiceJoinManualNilWsConn' .
- go test ./...
- go test -race ./...
- git diff --check

Notes:
- Small localized fix in wsapi.go.
- No public API changes.