### PR TITLE
Handle unknown message component types

### DIFF
--- a/components.go
+++ b/components.go
@@ -39,6 +39,27 @@ type unmarshalableMessageComponent struct {
 	MessageComponent
 }
 
+type unknownMessageComponent struct {
+	ComponentType ComponentType
+	RawData       json.RawMessage
+}
+
+func (c unknownMessageComponent) Type() ComponentType {
+	return c.ComponentType
+}
+
+func (c unknownMessageComponent) MarshalJSON() ([]byte, error) {
+	if c.RawData != nil {
+		return c.RawData, nil
+	}
+
+	return Marshal(struct {
+		Type ComponentType `json:"type"`
+	}{
+		Type: c.Type(),
+	})
+}
+
 // UnmarshalJSON is a helper function to unmarshal MessageComponent object.
 func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 	var v struct {
@@ -78,7 +99,11 @@ func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 	case FileUploadComponent:
 		umc.MessageComponent = &FileUpload{}
 	default:
-		return fmt.Errorf("unknown component type: %d", v.Type)
+		umc.MessageComponent = unknownMessageComponent{
+			ComponentType: v.Type,
+			RawData:       append(json.RawMessage(nil), src...),
+		}
+		return nil
 	}
 	return json.Unmarshal(src, umc.MessageComponent)
 }

--- a/message_test.go
+++ b/message_test.go
@@ -1,6 +1,7 @@
 package discordgo
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -107,5 +108,44 @@ func TestMessageReference_DefaultTypeIsDefault(t *testing.T) {
 	r := MessageReference{}
 	if r.Type != MessageReferenceTypeDefault {
 		t.Error("Default message type should be MessageReferenceTypeDefault")
+	}
+}
+
+func TestMessageCreateUnknownComponentType(t *testing.T) {
+	var m MessageCreate
+	err := json.Unmarshal([]byte(`{
+		"id":"message",
+		"channel_id":"channel",
+		"content":"content",
+		"components":[{"type":20,"id":1,"custom":"value"}]
+	}`), &m)
+	if err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	if m.Message == nil {
+		t.Fatal("Message is nil")
+	}
+	if len(m.Components) != 1 {
+		t.Fatalf("len(Components) = %d, want 1", len(m.Components))
+	}
+	if m.Components[0].Type() != ComponentType(20) {
+		t.Fatalf("component type = %d, want 20", m.Components[0].Type())
+	}
+
+	raw, err := m.Components[0].MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON returned error: %v", err)
+	}
+
+	var component struct {
+		Type   ComponentType `json:"type"`
+		ID     int           `json:"id"`
+		Custom string        `json:"custom"`
+	}
+	if err := json.Unmarshal(raw, &component); err != nil {
+		t.Fatalf("json.Unmarshal component returned error: %v", err)
+	}
+	if component.Type != ComponentType(20) || component.ID != 1 || component.Custom != "value" {
+		t.Fatalf("component = %#v, want type 20 with original fields", component)
 	}
 }


### PR DESCRIPTION
Summary:
- Preserve unknown message components as opaque components during unmarshal.
- Keep the original component payload available through MarshalJSON.
- Add a regression test for component type 20 in MESSAGE_CREATE data.

Why:
- Discord can send component types before discordgo has concrete structs for them. Returning an unmarshal error can leave message event data unusable and lead handlers to panic.

Severity:
- High

Upstream:
- Fixes bwmarrin/discordgo#1683
- Reviewed upstream PR #1696. It adds some known component types, but it does not fix the unknown-type fallback.

Tests:
- go test -run TestMessageCreateUnknownComponentType .
- go test -race -run TestMessageCreateUnknownComponentType .
- go test ./...
- git diff --check

Notes:
- Small compatibility fallback only.
- No new dependencies.