### PR TITLE
Guard voice AEAD access

### DIFF
--- a/voice_test.go
+++ b/voice_test.go
@@ -1,0 +1,27 @@
+package discordgo
+
+import (
+	"net"
+	"testing"
+)
+
+func TestOpusSenderNilAEAD(t *testing.T) {
+	udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("net.ListenUDP returned error: %v", err)
+	}
+	defer udpConn.Close()
+
+	opus := make(chan []byte, 1)
+	opus <- []byte{0x01, 0x02}
+	close(opus)
+
+	v := &VoiceConnection{LogLevel: -1}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("opusSender panicked with nil aead: %v", r)
+		}
+	}()
+
+	v.opusSender(udpConn, make(chan struct{}), opus, 48000, 960)
+}


### PR DESCRIPTION
Summary:
- Copy the voice AEAD cipher under RLock before sender and receiver use it.
- Skip opus packets until the cipher is available.
- Add a regression test for nil AEAD in the opus sender.

Why:
- The OP4 handler sets the AEAD cipher under the voice lock, while opus sender and receiver goroutines read it separately. The sender can panic if audio arrives before the cipher is ready.

Severity:
- High

Upstream:
- Relates to bwmarrin/discordgo#1692
- Reviewed upstream PR #1692 and reused the small lock-copy pattern.

Tests:
- go test -run TestOpusSenderNilAEAD .
- go test -race -run TestOpusSenderNilAEAD .
- go test ./...
- go test -race ./...
- git diff --check

Notes:
- Small localized fix in voice.go.
- No public API changes.