### PR TITLE
Stop reconnecting on terminal voice closes

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -358,34 +358,40 @@ func (v *VoiceConnection) wsListen(wsConn *websocket.Conn, close <-chan struct{}
 	for {
 		_, message, err := v.wsConn.ReadMessage()
 		if err != nil {
+			closeErr, isCloseErr := err.(*websocket.CloseError)
+
 			// 4014 indicates a manual disconnection by someone in the guild;
+			// 4021 indicates that the voice connection was dropped due to rate limiting;
+			// 4022 indicates that the call was terminated.
 			// we shouldn't reconnect.
-			if websocket.IsCloseError(err, 4014) {
-				v.log(LogInformational, "received 4014 manual disconnection")
+			if isCloseErr && (closeErr.Code == 4014 || closeErr.Code == 4021 || closeErr.Code == 4022) {
+				v.log(LogInformational, "received %d manual disconnection", closeErr.Code)
 
 				// Abandon the voice WS connection
 				v.Lock()
 				v.wsConn = nil
 				v.Unlock()
 
-				// Wait for VOICE_SERVER_UPDATE.
-				// When the bot is moved by the user to another voice channel,
-				// VOICE_SERVER_UPDATE is received after the code 4014.
-				for i := 0; i < 5; i++ { // TODO: temp, wait for VoiceServerUpdate.
-					<-time.After(1 * time.Second)
+				if closeErr.Code == 4014 {
+					// Wait for VOICE_SERVER_UPDATE.
+					// When the bot is moved by the user to another voice channel,
+					// VOICE_SERVER_UPDATE is received after the code 4014.
+					for i := 0; i < 5; i++ { // TODO: temp, wait for VoiceServerUpdate.
+						<-time.After(1 * time.Second)
 
-					v.RLock()
-					reconnected := v.wsConn != nil
-					v.RUnlock()
-					if !reconnected {
-						continue
+						v.RLock()
+						reconnected := v.wsConn != nil
+						v.RUnlock()
+						if !reconnected {
+							continue
+						}
+						v.log(LogInformational, "successfully reconnected after 4014 manual disconnection")
+						return
 					}
-					v.log(LogInformational, "successfully reconnected after 4014 manual disconnection")
-					return
 				}
 
 				// When VOICE_SERVER_UPDATE is not received, disconnect as usual.
-				v.log(LogInformational, "disconnect due to 4014 manual disconnection")
+				v.log(LogInformational, "disconnect due to %d manual disconnection", closeErr.Code)
 
 				v.session.Lock()
 				delete(v.session.VoiceConnections, v.GuildID)

--- a/voice_test.go
+++ b/voice_test.go
@@ -1,0 +1,57 @@
+package discordgo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestVoiceClose4022DoesNotReconnect(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade returned error: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		err = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(4022, ""))
+		if err != nil {
+			t.Errorf("WriteMessage returned error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Dial returned error: %v", err)
+	}
+	defer conn.Close()
+
+	s := &Session{VoiceConnections: make(map[string]*VoiceConnection)}
+	v := &VoiceConnection{
+		GuildID:  "guild",
+		LogLevel: -1,
+		close:    make(chan struct{}),
+		session:  s,
+		wsConn:   conn,
+	}
+	s.VoiceConnections[v.GuildID] = v
+
+	v.wsListen(conn, v.close)
+
+	if v.wsConn != nil {
+		t.Fatal("wsConn is not nil")
+	}
+	if _, ok := s.VoiceConnections[v.GuildID]; ok {
+		t.Fatal("voice connection was not removed")
+	}
+	if v.reconnecting {
+		t.Fatal("voice connection started reconnecting")
+	}
+}


### PR DESCRIPTION
Summary:
- Treat voice close codes 4021 and 4022 as terminal disconnects.
- Keep the existing 4014 voice move wait path.
- Add a local websocket regression test for 4022.

Why:
- Discord marks 4021 and 4022 as non-reconnectable voice closes. Reconnecting after those closes can put bots into a voice reconnect loop.

Severity:
- High

Upstream:
- Fixes bwmarrin/discordgo#1655
- Reviewed upstream PR #1629 and kept the fix localized.
- Checked Discord voice close-code docs for 4014, 4021, and 4022 behavior.

Tests:
- go test -run TestVoiceClose4022DoesNotReconnect .
- go test -race -run TestVoiceClose4022DoesNotReconnect .
- go test ./...
- go test -race ./...
- git diff --check

Notes:
- Small localized fix in voice.go.
- No public API changes.