### PR TITLE
Fix voice UDP discovery timeout

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -575,6 +575,8 @@ type voiceUDPOp struct {
 	Data voiceUDPD `json:"d"`
 }
 
+var voiceUDPReadTimeout = 5 * time.Second
+
 // udpOpen opens a UDP connection to the voice server and completes the
 // initial required handshake.  This connection is left open in the session
 // and can be used to send or receive audio.  This should only be called
@@ -632,7 +634,16 @@ func (v *VoiceConnection) udpOpen() (err error) {
 	// of the response.  This should be our public IP and PORT as Discord
 	// saw us.
 	rb := make([]byte, 74)
+	err = v.udpConn.SetReadDeadline(time.Now().Add(voiceUDPReadTimeout))
+	if err != nil {
+		v.log(LogWarning, "udp read deadline error, %s, %s", addr.String(), err)
+		return
+	}
+
 	rlen, _, err := v.udpConn.ReadFromUDP(rb)
+	if deadlineErr := v.udpConn.SetReadDeadline(time.Time{}); deadlineErr != nil && err == nil {
+		err = deadlineErr
+	}
 	if err != nil {
 		v.log(LogWarning, "udp read error, %s, %s", addr.String(), err)
 		return

--- a/voice_test.go
+++ b/voice_test.go
@@ -1,0 +1,62 @@
+package discordgo
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestUDPOpenReadTimeout(t *testing.T) {
+	oldTimeout := voiceUDPReadTimeout
+	voiceUDPReadTimeout = 25 * time.Millisecond
+	defer func() {
+		voiceUDPReadTimeout = oldTimeout
+	}()
+
+	server, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("error listening on udp: %v", err)
+	}
+	defer server.Close()
+
+	addr := server.LocalAddr().(*net.UDPAddr)
+	v := &VoiceConnection{
+		wsConn:   &websocket.Conn{},
+		close:    make(chan struct{}),
+		endpoint: "127.0.0.1",
+		op2: voiceOP2{
+			IP:   "127.0.0.1",
+			Port: addr.Port,
+			SSRC: 1,
+		},
+	}
+	defer func() {
+		if v.udpConn != nil {
+			v.udpConn.Close()
+		}
+	}()
+
+	start := time.Now()
+	err = v.udpOpen()
+	if err == nil {
+		t.Fatal("expected udpOpen to time out waiting for discovery response")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("udpOpen took too long to return: %s", elapsed)
+	}
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		v.RLock()
+		v.RUnlock()
+		close(lockAcquired)
+	}()
+
+	select {
+	case <-lockAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("udpOpen returned without releasing the voice lock")
+	}
+}


### PR DESCRIPTION
Summary:
- Add a bounded read deadline to the UDP discovery read in voice connection setup.
- Add a regression test for a voice UDP endpoint that receives discovery but never replies.

Why:
- udpOpen holds the voice connection lock while waiting for the UDP discovery response.
- If the response never arrives, ChannelVoiceJoin can block while waiting on that same lock.

Severity:
- High

Upstream:
- Fixes bwmarrin/discordgo#1627
- Relates to bwmarrin/discordgo#1643
- No upstream PR found for this exact fix

Tests:
- go test -run TestUDPOpenReadTimeout .
- go test -race -run TestUDPOpenReadTimeout .
- go test ./...
- go test -race ./...
- git diff --check

Notes:
- The default discovery wait is 5 seconds. This keeps the existing join timeout useful without changing public API.