### PR TITLE
fix(components): handle unknown component types without panic

### DIFF
--- a/components.go
+++ b/components.go
@@ -39,6 +39,33 @@ type unmarshalableMessageComponent struct {
 	MessageComponent
 }
 
+// unknownMessageComponent is a fallback for component types Discord ships
+// before the library has explicit support for them. It preserves the raw
+// JSON so callers can identify the type and re-marshal without data loss.
+type unknownMessageComponent struct {
+	ComponentType ComponentType
+	RawData       json.RawMessage
+}
+
+// Type is a method to get the type of a component.
+func (c unknownMessageComponent) Type() ComponentType {
+	return c.ComponentType
+}
+
+// MarshalJSON returns the original JSON bytes if available, otherwise a
+// minimal object containing only the component type.
+func (c unknownMessageComponent) MarshalJSON() ([]byte, error) {
+	if c.RawData != nil {
+		return c.RawData, nil
+	}
+
+	return json.Marshal(struct {
+		Type ComponentType `json:"type"`
+	}{
+		Type: c.Type(),
+	})
+}
+
 // UnmarshalJSON is a helper function to unmarshal MessageComponent object.
 func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 	var v struct {
@@ -78,7 +105,11 @@ func (umc *unmarshalableMessageComponent) UnmarshalJSON(src []byte) error {
 	case FileUploadComponent:
 		umc.MessageComponent = &FileUpload{}
 	default:
-		return fmt.Errorf("unknown component type: %d", v.Type)
+		umc.MessageComponent = &unknownMessageComponent{
+			ComponentType: v.Type,
+			RawData:       append(json.RawMessage(nil), src...),
+		}
+		return nil
 	}
 	return json.Unmarshal(src, umc.MessageComponent)
 }

--- a/components_test.go
+++ b/components_test.go
@@ -1,0 +1,45 @@
+package discordgo
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMessageCreateUnknownComponentType(t *testing.T) {
+	var m MessageCreate
+	err := json.Unmarshal([]byte(`{
+		"id":"message",
+		"channel_id":"channel",
+		"content":"content",
+		"components":[{"type":20,"id":1,"custom":"value"}]
+	}`), &m)
+	if err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	if m.Message == nil {
+		t.Fatal("Message is nil")
+	}
+	if len(m.Components) != 1 {
+		t.Fatalf("len(Components) = %d, want 1", len(m.Components))
+	}
+	if m.Components[0].Type() != ComponentType(20) {
+		t.Fatalf("component type = %d, want 20", m.Components[0].Type())
+	}
+
+	raw, err := m.Components[0].MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON returned error: %v", err)
+	}
+
+	var component struct {
+		Type   ComponentType `json:"type"`
+		ID     int           `json:"id"`
+		Custom string        `json:"custom"`
+	}
+	if err := json.Unmarshal(raw, &component); err != nil {
+		t.Fatalf("json.Unmarshal component returned error: %v", err)
+	}
+	if component.Type != ComponentType(20) || component.ID != 1 || component.Custom != "value" {
+		t.Fatalf("component = %#v, want type 20 with original fields", component)
+	}
+}


### PR DESCRIPTION
Closes #1683.

When Discord ships a new component type (recently type 20 for checkpoints), the `default` branch in `unmarshalableMessageComponent.UnmarshalJSON` returns an error. `Message.UnmarshalJSON` then exits before populating the Message, but `onEvent` in wsapi.go dispatches the event anyway (the existing comment there acknowledges that partially-populated structs get passed through on error). Handlers receive a Message with nil pointer fields and panic on first access.

The suggestion to just remove the `return err` doesn't fix it. The function falls through to `json.Unmarshal(src, umc.MessageComponent)` where the interface is still nil, which returns `json: Unmarshal(nil)`, and you end up in the same state.

This PR adds an `unknownMessageComponent` fallback. It implements `Type()` so handlers can identify and skip unknown components, and `MarshalJSON` that returns the original bytes so messages with unknown components round-trip without losing data (useful for transcript or forwarding bots).

Test covers unmarshalling a synthetic type 20 component, checking `Type()`, and round-tripping through `MarshalJSON` to confirm the original fields survive.